### PR TITLE
Added ifdef __GPU to allow compilation of CPU only version.

### DIFF
--- a/apps/tests/test_wf_ortho_3.cpp
+++ b/apps/tests/test_wf_ortho_3.cpp
@@ -34,13 +34,14 @@ void test_wf_ortho(BLACS_grid const& blacs_grid__,
 
     dmatrix<double_complex> ovlp(2 * num_bands__, 2 * num_bands__, blacs_grid__, bs__, bs__);
 
+#ifdef __GPU
     if (pu == GPU) {
         phi.pw_coeffs().allocate_on_device();
         tmp.pw_coeffs().allocate_on_device();
         phi.pw_coeffs().copy_to_device(0, 2 * num_bands__);
         ovlp.allocate(memory_t::device);
     }
-    
+#endif
     
     orthogonalize<double_complex>(0, num_bands__, phi, ovlp, tmp);
     orthogonalize<double_complex>(num_bands__, num_bands__, phi, ovlp, tmp);


### PR DESCRIPTION
Otherwise compilation fails with

    test_wf_ortho_3.cpp(38): error: class "sddk::matrix_storage<sddk::double_complex, sddk::matrix_storage_t::slab>" has no member "allocate_on_device"
          phi.pw_coeffs().allocate_on_device();
                          ^

    test_wf_ortho_3.cpp(39): error: class "sddk::matrix_storage<sddk::double_complex, sddk::matrix_storage_t::slab>" has no member "allocate_on_device"
          tmp.pw_coeffs().allocate_on_device();
                          ^

    test_wf_ortho_3.cpp(40): error: class "sddk::matrix_storage<sddk::double_complex, sddk::matrix_storage_t::slab>" has no member "copy_to_device"
          phi.pw_coeffs().copy_to_device(0, 2 * num_bands__);
