### PR TITLE
Intel compiler complains if inttypes.h from C std library is used.

### DIFF
--- a/src/runtime.h
+++ b/src/runtime.h
@@ -12,7 +12,7 @@
 #include <chrono>
 #include <omp.h>
 #include <unistd.h>
-#include <inttypes.h>
+#include <cinttypes.h>
 #include <cstring>
 #include <cstdarg>
 #include "config.h"


### PR DESCRIPTION
This change solves the compiler error:

    SIRIUS/src/runtime.h(214): error: expected a ")"
      printf("hash(%s): %" PRIx64 "\n", label__.c_str(), hash__);

Effects for other compilers should be checked.