### PR TITLE
Fix compilation error on Piz Daint

### DIFF
--- a/src/runtime.h
+++ b/src/runtime.h
@@ -12,7 +12,7 @@
 #include <chrono>
 #include <omp.h>
 #include <unistd.h>
-#include <cinttypes.h>
+#include <cinttypes>
 #include <cstring>
 #include <cstdarg>
 #include "config.h"


### PR DESCRIPTION
This fixed the following error I had while compiling with GCC on Piz Daint:

```
CC -O3 -DNDEBUG -std=c++11 -Wall -Wconversion -fopenmp -D__SCALAPACK -D__ELPA -D__GPU -I/opt/intel/compilers_and_libraries_2017.1.132/linux/mkl/include/fftw/ -I/users/mborelli/SIRIUS_builds/20170922/SIRIUS/src -I/users/mborelli/SIRIUS_builds/20170922/SIRIUS/src/SDDK -I/opt/nvidia/cudatoolkit8.0/8.0.54_2.2.8_ga620558-2.1/include -I/users/mborelli/SIRIUS_builds/20170922/SIRIUS/libs/spglib-1.9.9/src -I/users/mborelli/SIRIUS_builds/20170922/SIRIUS/libs/gsl-2.3 -I/users/mborelli/SIRIUS_builds/20170922/SIRIUS/libs/libxc-3.0.0/src -I/users/mborelli/SIRIUS_builds/20170922/SIRIUS/libs/libxc-3.0.0 -c -o ./force.o force.cpp
In file included from sirius_internal.h:41:0,
                 from utils.h:32,
                 from simulation_parameters.h:29,
                 from simulation_context_base.h:29,
                 from simulation_context.h:28,
                 from periodic_function.h:28,
                 from k_point.h:28,
                 from force.h:28,
                 from force.cpp:25:
runtime.h:15:23: fatal error: cinttypes.h: No such file or directory
compilation terminated.
```

But It may need to be tested for other compilers.