### PR TITLE
better G-vector partition implementation

### DIFF
--- a/src/Band/diag_full_potential.hpp
+++ b/src/Band/diag_full_potential.hpp
@@ -94,7 +94,7 @@ inline void Band::diag_fv_exact(K_point* kp, Hamiltonian& hamiltonian__) const
     
     /* renormalize wave-functions */
     if (ctx_.valence_relativity() == relativity_t::iora) {
-        Wave_functions ofv(kp->gkvec(), unit_cell_.num_atoms(),
+        Wave_functions ofv(kp->gkvec_partition(), unit_cell_.num_atoms(),
                            [this](int ia){return unit_cell_.atom(ia).mt_lo_basis_size();}, ctx_.num_fv_states(), 1);
         #ifdef __GPU
         if (ctx_.processing_unit() == GPU) {
@@ -212,10 +212,10 @@ inline void Band::get_singular_components(K_point* kp__, Hamiltonian& H__) const
 
     int num_phi = itso.subspace_size_ * ncomp;
 
-    Wave_functions  phi(kp__->gkvec(), num_phi);
-    Wave_functions ophi(kp__->gkvec(), num_phi);
-    Wave_functions opsi(kp__->gkvec(), ncomp);
-    Wave_functions  res(kp__->gkvec(), ncomp);
+    Wave_functions  phi(kp__->gkvec_partition(), num_phi);
+    Wave_functions ophi(kp__->gkvec_partition(), num_phi);
+    Wave_functions opsi(kp__->gkvec_partition(), ncomp);
+    Wave_functions  res(kp__->gkvec_partition(), ncomp);
 
     int bs = ctx_.cyclic_block_size();
 
@@ -422,21 +422,21 @@ inline void Band::diag_fv_davidson(K_point* kp, Hamiltonian& H__) const
     }
 
     /* allocate wave-functions */
-    Wave_functions  phi(kp->gkvec(), unit_cell_.num_atoms(),
+    Wave_functions  phi(kp->gkvec_partition(), unit_cell_.num_atoms(),
                         [this](int ia){return unit_cell_.atom(ia).mt_lo_basis_size();}, num_phi);
-    Wave_functions hphi(kp->gkvec(), unit_cell_.num_atoms(),
+    Wave_functions hphi(kp->gkvec_partition(), unit_cell_.num_atoms(),
                         [this](int ia){return unit_cell_.atom(ia).mt_lo_basis_size();}, num_phi);
-    Wave_functions ophi(kp->gkvec(), unit_cell_.num_atoms(),
+    Wave_functions ophi(kp->gkvec_partition(), unit_cell_.num_atoms(),
                         [this](int ia){return unit_cell_.atom(ia).mt_lo_basis_size();}, num_phi);
-    Wave_functions hpsi(kp->gkvec(), unit_cell_.num_atoms(),
+    Wave_functions hpsi(kp->gkvec_partition(), unit_cell_.num_atoms(),
                         [this](int ia){return unit_cell_.atom(ia).mt_lo_basis_size();}, num_bands);
-    Wave_functions opsi(kp->gkvec(), unit_cell_.num_atoms(),
+    Wave_functions opsi(kp->gkvec_partition(), unit_cell_.num_atoms(),
                         [this](int ia){return unit_cell_.atom(ia).mt_lo_basis_size();}, num_bands);
 
     /* residuals */
     /* res is also used as a temporary array in orthogonalize() and the first time nlo + ncomp + num_bands
      * states will be orthogonalized */
-    Wave_functions res(kp->gkvec(), unit_cell_.num_atoms(),
+    Wave_functions res(kp->gkvec_partition(), unit_cell_.num_atoms(),
                        [this](int ia){return unit_cell_.atom(ia).mt_lo_basis_size();}, nlo + ncomp + num_bands);
 
     //auto mem_type = (gen_evp_solver_->type() == ev_magma) ? memory_t::host_pinned : memory_t::host;
@@ -621,7 +621,7 @@ inline void Band::diag_sv(K_point* kp,
     /* product of the second-variational Hamiltonian and a first-variational wave-function */
     std::vector<Wave_functions> hpsi;
     for (int i = 0; i < ctx_.num_mag_comp(); i++) {
-        hpsi.push_back(std::move(Wave_functions(kp->gkvec(),
+        hpsi.push_back(std::move(Wave_functions(kp->gkvec_partition(),
                                                 unit_cell_.num_atoms(),
                                                 [this](int ia)
                                                 {

--- a/src/Band/diag_pseudo_potential.hpp
+++ b/src/Band/diag_pseudo_potential.hpp
@@ -126,27 +126,27 @@ inline int Band::diag_pseudo_potential_davidson(K_point*       kp__,
     /* allocate wave-functions */
 
     /* auxiliary wave-functions */
-    Wave_functions phi(mem_buf_ptr, kp__->gkvec(), num_phi, num_sc);
+    Wave_functions phi(mem_buf_ptr, kp__->gkvec_partition(), num_phi, num_sc);
     mem_buf_ptr += kp__->num_gkvec_loc() * num_phi * num_sc;
 
     /* Hamiltonian, applied to auxiliary wave-functions */
-    Wave_functions hphi(mem_buf_ptr, kp__->gkvec(), num_phi, num_sc);
+    Wave_functions hphi(mem_buf_ptr, kp__->gkvec_partition(), num_phi, num_sc);
     mem_buf_ptr += kp__->num_gkvec_loc() * num_phi * num_sc;
 
     /* S operator, applied to auxiliary wave-functions */
-    Wave_functions sphi(mem_buf_ptr, kp__->gkvec(), num_phi, num_sc);
+    Wave_functions sphi(mem_buf_ptr, kp__->gkvec_partition(), num_phi, num_sc);
     mem_buf_ptr += kp__->num_gkvec_loc() * num_phi * num_sc;
 
     /* Hamiltonain, applied to new Psi wave-functions */
-    Wave_functions hpsi(mem_buf_ptr, kp__->gkvec(), num_bands, num_sc);
+    Wave_functions hpsi(mem_buf_ptr, kp__->gkvec_partition(), num_bands, num_sc);
     mem_buf_ptr += kp__->num_gkvec_loc() * num_bands * num_sc;
 
     /* S operator, applied to new Psi wave-functions */
-    Wave_functions spsi(mem_buf_ptr, kp__->gkvec(), num_bands, num_sc);
+    Wave_functions spsi(mem_buf_ptr, kp__->gkvec_partition(), num_bands, num_sc);
     mem_buf_ptr += kp__->num_gkvec_loc() * num_bands * num_sc;
 
     /* residuals */
-    Wave_functions res(mem_buf_ptr, kp__->gkvec(), num_bands, num_sc);
+    Wave_functions res(mem_buf_ptr, kp__->gkvec_partition(), num_bands, num_sc);
     t1.stop();
 
     sddk::timer t2("sirius::Band::diag_pseudo_potential_davidson|alloc");

--- a/src/Band/initialize_subspace.hpp
+++ b/src/Band/initialize_subspace.hpp
@@ -22,7 +22,7 @@ inline void Band::initialize_subspace(K_point_set& kset__, Hamiltonian& H__) con
         }
     }
 
-    H__.local_op().prepare(ctx_.gvec_coarse(), ctx_.num_mag_dims(), H__.potential());
+    H__.local_op().prepare(ctx_.gvec_coarse_partition(), ctx_.num_mag_dims(), H__.potential());
 
     for (int ikloc = 0; ikloc < kset__.spl_num_kpoints().local_size(); ikloc++) {
         int ik  = kset__.spl_num_kpoints(ikloc);
@@ -64,7 +64,7 @@ Band::initialize_subspace(K_point* kp__, Hamiltonian &H__, int num_ao__) const
     int num_phi_tot = (ctx_.num_mag_dims() == 3) ? num_phi * 2 : num_phi;
 
     /* initial basis functions */
-    Wave_functions phi(kp__->gkvec(), num_phi_tot, num_sc);
+    Wave_functions phi(kp__->gkvec_partition(), num_phi_tot, num_sc);
     for (int ispn = 0; ispn < num_sc; ispn++) {
         phi.pw_coeffs(ispn).prime().zero();
     }
@@ -142,14 +142,14 @@ Band::initialize_subspace(K_point* kp__, Hamiltonian &H__, int num_ao__) const
     /* short notation for number of target wave-functions */
     int num_bands = (ctx_.num_mag_dims() == 3) ? ctx_.num_bands() : ctx_.num_fv_states();
 
-    ctx_.fft_coarse().prepare(kp__->gkvec().partition());
-    H__.local_op().prepare(kp__->gkvec());
+    ctx_.fft_coarse().prepare(kp__->gkvec_partition());
+    H__.local_op().prepare(kp__->gkvec_partition());
 
     /* allocate wave-functions */
-    Wave_functions hphi(kp__->gkvec(), num_phi_tot, num_sc);
-    Wave_functions ophi(kp__->gkvec(), num_phi_tot, num_sc);
+    Wave_functions hphi(kp__->gkvec_partition(), num_phi_tot, num_sc);
+    Wave_functions ophi(kp__->gkvec_partition(), num_phi_tot, num_sc);
     /* temporary wave-functions required as a storage during orthogonalization */
-    Wave_functions wf_tmp(kp__->gkvec(), num_phi_tot, num_sc);
+    Wave_functions wf_tmp(kp__->gkvec_partition(), num_phi_tot, num_sc);
 
     int bs        = ctx_.cyclic_block_size();
     auto mem_type = (ctx_.std_evp_solver_type() == ev_solver_t::magma) ? memory_t::host_pinned : memory_t::host;

--- a/src/Band/solve.hpp
+++ b/src/Band/solve.hpp
@@ -121,9 +121,9 @@ inline void Band::solve_for_kset(K_point_set& kset__, Hamiltonian& Hamiltonian__
     }
 
     if (ctx_.full_potential()) {
-        Hamiltonian__.local_op().prepare(ctx_.gvec_coarse(), ctx_.num_mag_dims(), Hamiltonian__.potential(), ctx_.step_function());
+        Hamiltonian__.local_op().prepare(ctx_.gvec_coarse_partition(), ctx_.num_mag_dims(), Hamiltonian__.potential(), ctx_.step_function());
     } else {
-        Hamiltonian__.local_op().prepare(ctx_.gvec_coarse(), ctx_.num_mag_dims(), Hamiltonian__.potential());
+        Hamiltonian__.local_op().prepare(ctx_.gvec_coarse_partition(), ctx_.num_mag_dims(), Hamiltonian__.potential());
     }
 
     if (ctx_.comm().rank() == 0 && ctx_.control().print_memory_usage_) {

--- a/src/Density/add_k_point_contribution_rg.hpp
+++ b/src/Density/add_k_point_contribution_rg.hpp
@@ -18,7 +18,7 @@ inline void Density::add_k_point_contribution_rg(K_point* kp__)
         density_rg.zero<memory_t::device>();
     }
 
-    fft.prepare(kp__->gkvec().partition());
+    fft.prepare(kp__->gkvec_partition());
 
     /* non-magnetic or collinear case */
     if (ctx_.num_mag_dims() != 3) {

--- a/src/Geometry/stress.h
+++ b/src/Geometry/stress.h
@@ -767,7 +767,7 @@ class Stress {
 
         if (potential_.is_gradient_correction()) {
 
-            Smooth_periodic_function<double> rhovc(ctx_.fft(), ctx_.gvec());
+            Smooth_periodic_function<double> rhovc(ctx_.fft(), ctx_.gvec_partition());
             rhovc.zero();
             rhovc.add(density_.rho());
             rhovc.add(density_.rho_pseudo_core());

--- a/src/Hamiltonian/apply.hpp
+++ b/src/Hamiltonian/apply.hpp
@@ -215,7 +215,7 @@ inline void Hamiltonian::apply_fv_o(K_point* kp__,
     }
 
     /* interstitial part */
-    local_op_->apply_o(kp__->gkvec().partition(), N__, n__, phi__, ophi__);
+    local_op_->apply_o(kp__->gkvec_partition(), N__, n__, phi__, ophi__);
 
     matrix<double_complex> alm(kp__->num_gkvec_loc(), unit_cell_.max_mt_aw_basis_size());
     matrix<double_complex> oalm(kp__->num_gkvec_loc(), unit_cell_.max_mt_aw_basis_size());
@@ -403,9 +403,9 @@ inline void Hamiltonian::apply_fv_h_o(K_point* kp__,
     /* interstitial part */
     if (N__ == 0) {
         /* don't apply to the pure local orbital basis functions */
-        local_op_->apply_h_o(kp__->gkvec().partition(), nlo__, n__ - nlo__, phi__, hphi__, ophi__);
+        local_op_->apply_h_o(kp__->gkvec_partition(), nlo__, n__ - nlo__, phi__, hphi__, ophi__);
     } else {
-        local_op_->apply_h_o(kp__->gkvec().partition(), N__, n__, phi__, hphi__, ophi__);
+        local_op_->apply_h_o(kp__->gkvec_partition(), N__, n__, phi__, hphi__, ophi__);
     }
 
     //if (ctx_.control().print_checksum_) {

--- a/src/Hamiltonian/get_h_o_diag.hpp
+++ b/src/Hamiltonian/get_h_o_diag.hpp
@@ -100,7 +100,7 @@ Hamiltonian::get_o_diag(K_point* kp__,
 
 template <typename T>
 inline mdarray<double, 2>
-Hamiltonian::get_h_diag(K_point*        kp__) const
+Hamiltonian::get_h_diag(K_point* kp__) const
 {
     PROFILE("sirius::Band::get_h_diag");
 

--- a/src/Hubbard/hubbard_generate_atomic_orbitals.hpp
+++ b/src/Hubbard/hubbard_generate_atomic_orbitals.hpp
@@ -42,7 +42,7 @@ void generate_atomic_orbitals(K_point& kp, Q_operator<double_complex>& q_op)
     }
 
     // temporary wave functions
-    Wave_functions sphi(kp.gkvec(), this->number_of_hubbard_orbitals(), ctx_.num_spins());
+    Wave_functions sphi(kp.gkvec_partition(), this->number_of_hubbard_orbitals(), ctx_.num_spins());
 
     #pragma omp parallel for schedule(static)
     for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {

--- a/src/K_point/generate_gklo_basis.hpp
+++ b/src/K_point/generate_gklo_basis.hpp
@@ -20,7 +20,7 @@ inline void K_point::generate_gklo_basis()
     
     igk_loc_.resize(num_gkvec_loc());
     for (int i = 0; i < num_gkvec_loc(); i++) {
-        igk_loc_[i] = gkvec_.gvec_offset(comm_.rank()) + i;
+        igk_loc_[i] = gkvec().offset() + i;
     }
 
     if (ctx_.full_potential()) {

--- a/src/K_point/initialize.hpp
+++ b/src/K_point/initialize.hpp
@@ -57,17 +57,17 @@ inline void K_point::initialize()
     if (ctx_.esm_type() == electronic_structure_method_t::full_potential_lapwlo) {
         if (ctx_.iterative_solver_input().type_ == "exact") {
             alm_coeffs_row_ = std::unique_ptr<Matching_coefficients>(
-                new Matching_coefficients(unit_cell_, ctx_.lmax_apw(), num_gkvec_row(), igk_row_, gkvec_));
+                new Matching_coefficients(unit_cell_, ctx_.lmax_apw(), num_gkvec_row(), igk_row_, gkvec()));
             alm_coeffs_col_ = std::unique_ptr<Matching_coefficients>(
-                new Matching_coefficients(unit_cell_, ctx_.lmax_apw(), num_gkvec_col(), igk_col_, gkvec_));
+                new Matching_coefficients(unit_cell_, ctx_.lmax_apw(), num_gkvec_col(), igk_col_, gkvec()));
         }
         alm_coeffs_loc_ = std::unique_ptr<Matching_coefficients>(
-            new Matching_coefficients(unit_cell_, ctx_.lmax_apw(), num_gkvec_loc(), igk_loc_, gkvec_));
+            new Matching_coefficients(unit_cell_, ctx_.lmax_apw(), num_gkvec_loc(), igk_loc_, gkvec()));
     }
 
     if (!ctx_.full_potential()) {
         /* compute |beta> projectors for atom types */
-        beta_projectors_ = std::unique_ptr<Beta_projectors>(new Beta_projectors(ctx_, gkvec_));
+        beta_projectors_ = std::unique_ptr<Beta_projectors>(new Beta_projectors(ctx_, gkvec()));
 
         //if (false) {
         //    p_mtrx_ = mdarray<double_complex, 3>(unit_cell_.max_mt_basis_size(), unit_cell_.max_mt_basis_size(), unit_cell_.num_atom_types());
@@ -117,8 +117,8 @@ inline void K_point::initialize()
         if (use_second_variation) {
             /* allocate fv eien vectors */
             fv_eigen_vectors_slab_ = std::unique_ptr<Wave_functions>(
-                new Wave_functions(gkvec(), unit_cell_.num_atoms(),
-                    [this](int ia){return unit_cell_.atom(ia).mt_lo_basis_size();}, ctx_.num_fv_states(), 1));
+                new Wave_functions(gkvec_partition(), unit_cell_.num_atoms(),
+                    [this](int ia){return unit_cell_.atom(ia).mt_lo_basis_size();}, ctx_.num_fv_states()));
 
             fv_eigen_vectors_slab_->pw_coeffs(0).prime().zero();
             fv_eigen_vectors_slab_->mt_coeffs(0).prime().zero();
@@ -146,7 +146,7 @@ inline void K_point::initialize()
                     ncomp = ctx_.num_fv_states() / 2;
                 }
 
-                singular_components_ = std::unique_ptr<Wave_functions>(new Wave_functions(gkvec(), ncomp, 1));
+                singular_components_ = std::unique_ptr<Wave_functions>(new Wave_functions(gkvec_partition(), ncomp));
                 singular_components_->pw_coeffs(0).prime().zero();
                 /* starting guess for wave-functions */
                 for (int i = 0; i < ncomp; i++) {
@@ -172,16 +172,15 @@ inline void K_point::initialize()
                 }
             }
 
-            fv_states_ = std::unique_ptr<Wave_functions>(new Wave_functions(gkvec(),
+            fv_states_ = std::unique_ptr<Wave_functions>(new Wave_functions(gkvec_partition(),
                                                                             unit_cell_.num_atoms(),
                                                                             [this](int ia)
                                                                             {
                                                                                 return unit_cell_.atom(ia).mt_basis_size();
                                                                             },
-                                                                            ctx_.num_fv_states(),
-                                                                            1));
+                                                                            ctx_.num_fv_states()));
             
-            spinor_wave_functions_ = std::unique_ptr<Wave_functions>(new Wave_functions(gkvec(),
+            spinor_wave_functions_ = std::unique_ptr<Wave_functions>(new Wave_functions(gkvec_partition(),
                                                                                         unit_cell_.num_atoms(),
                                                                                         [this](int ia)
                                                                                         {
@@ -195,7 +194,7 @@ inline void K_point::initialize()
     } else {
         assert(ctx_.num_fv_states() < num_gkvec());
 
-        spinor_wave_functions_ = std::unique_ptr<Wave_functions>(new Wave_functions(gkvec(), nst, ctx_.num_spins()));
+        spinor_wave_functions_ = std::unique_ptr<Wave_functions>(new Wave_functions(gkvec_partition(), nst, ctx_.num_spins()));
     }
     if (ctx_.processing_unit() == GPU && keep_wf_on_gpu) {
         /* allocate GPU memory */

--- a/src/Potential/generate_pw_coefs.hpp
+++ b/src/Potential/generate_pw_coefs.hpp
@@ -4,8 +4,8 @@ inline void Potential::generate_pw_coefs()
 
     double sq_alpha_half = 0.5 * std::pow(speed_of_light, -2);
 
-    int gv_count  = ctx_.gvec().partition().gvec_count_fft();
-    int gv_offset = ctx_.gvec().partition().gvec_offset_fft();
+    int gv_count  = ctx_.gvec_partition().gvec_count_fft();
+    int gv_offset = ctx_.gvec_partition().gvec_offset_fft();
 
     switch (ctx_.valence_relativity()) {
         case relativity_t::iora: {

--- a/src/Potential/xc.hpp
+++ b/src/Potential/xc.hpp
@@ -442,7 +442,7 @@ inline void Potential::xc_rg_nonmagnetic(Density const& density__)
     /* we can use this comm for parallelization */
     //auto& comm = ctx_.gvec().comm_ortho_fft();
 
-    Smooth_periodic_function<double> rho(ctx_.fft(), ctx_.gvec());
+    Smooth_periodic_function<double> rho(ctx_.fft(), ctx_.gvec_partition());
 
     /* split real-space points between available ranks */
     //splindex<block> spl_np(num_points, comm.size(), comm.rank());
@@ -614,8 +614,8 @@ inline void Potential::xc_rg_magnetic(Density const& density__)
 
     int num_points = ctx_.fft().local_size();
     
-    Smooth_periodic_function<double> rho_up(ctx_.fft(), ctx_.gvec());
-    Smooth_periodic_function<double> rho_dn(ctx_.fft(), ctx_.gvec());
+    Smooth_periodic_function<double> rho_up(ctx_.fft(), ctx_.gvec_partition());
+    Smooth_periodic_function<double> rho_dn(ctx_.fft(), ctx_.gvec_partition());
 
     /* compute "up" and "dn" components and also check for negative values of density */
     double rhomin{0};
@@ -806,9 +806,9 @@ inline void Potential::xc_rg_magnetic(Density const& density__)
 
     if (is_gga) {
         /* gather vsigma */
-        Smooth_periodic_function<double> vsigma_uu(ctx_.fft(), ctx_.gvec());
-        Smooth_periodic_function<double> vsigma_ud(ctx_.fft(), ctx_.gvec());
-        Smooth_periodic_function<double> vsigma_dd(ctx_.fft(), ctx_.gvec());
+        Smooth_periodic_function<double> vsigma_uu(ctx_.fft(), ctx_.gvec_partition());
+        Smooth_periodic_function<double> vsigma_ud(ctx_.fft(), ctx_.gvec_partition());
+        Smooth_periodic_function<double> vsigma_dd(ctx_.fft(), ctx_.gvec_partition());
         for (int ir = 0; ir < num_points; ir++) {
             vsigma_uu.f_rg(ir) = vsigma_uu_tmp[ir];
             vsigma_ud.f_rg(ir) = vsigma_ud_tmp[ir];

--- a/src/SDDK/gvec.hpp
+++ b/src/SDDK/gvec.hpp
@@ -27,11 +27,12 @@
 
 #include <numeric>
 #include <map>
+#include <iostream>
 #include "fft3d_grid.hpp"
 #include "geometry3d.hpp"
 
-// TODO: generate fine G-vectors in such a way that local set of fine vectors fully contain the local set of coarse G-vectors
-//       this will considerbly simplify the remapping of G-vectors from fine to corase mesh or vice versa
+// TODO: generate fine G-vectors in such a way that local set of fine vectors fully contain the local set of coarse
+// G-vectors this will considerbly simplify the remapping of G-vectors from fine to corase mesh or vice versa
 
 using namespace geometry3d;
 
@@ -60,13 +61,11 @@ struct z_column_descriptor
     }
 };
 
-/// Store list of G-vectors for FFTs and G+k basis functions.
+/// A set of G-vectors for FFTs and G+k basis functions.
 /** Current implemntation supports up to 2^12 (4096) z-dimension of the FFT grid and 2^20 (1048576) number of
  *  z-columns. */
 class Gvec
 {
-    //friend class Gvec_partition;
-
   private:
     /// k-vector of G+k.
     vector3d<double> vk_;
@@ -80,26 +79,14 @@ class Gvec
     /// Total communicator which is used to distribute G or G+k vectors.
     Communicator const& comm_;
 
-    /// Communicator of FFT driver.
-    //Communicator const* comm_fft_{nullptr};
-
-    /// Communicator which is orthogonal to FFT communicator.
-    //Communicator const* comm_ortho_fft_{nullptr};
-
     /// Indicates that G-vectors are reduced by inversion symmetry.
     bool reduce_gvec_;
-
-    ///// Rank of current process.
-    //int rank_;
-
-    ///// Number of ranks for fine-grained distribution.
-    //int num_ranks_;
 
     /// Total number of G-vectors.
     int num_gvec_;
 
     /// Mapping between G-vector index [0:num_gvec_) and a full index.
-    /** Full index is used to store x,y,z coordinates in a packed form in a single integer number. 
+    /** Full index is used to store x,y,z coordinates in a packed form in a single integer number.
      *  The index is equal to ((i << 12) + j) where i is the global index of z_column and j is the
      *  index of G-vector z-coordinate in the column i. This is a global array: each MPI rank stores exactly the
      *  same copy of the gvec_full_index_.
@@ -126,8 +113,12 @@ class Gvec
     /// Fine-grained distribution of z-columns.
     block_data_descriptor zcol_distr_;
 
-    /// Default G-vector partitioning.
-    //std::unique_ptr<Gvec_partition> gvec_partition_;
+    /// Set of G-vectors on which the current G-vector distribution can be based.
+    /** This can be used to establish a local mapping between coarse and fine G-vector sets
+     *  without MPI communication. */
+    Gvec const* gvec_base_{nullptr};
+
+    mdarray<int, 1> gvec_base_mapping_;
 
     /* copy constructor is forbidden */
     Gvec(Gvec const& src__) = delete;
@@ -150,71 +141,108 @@ class Gvec
         int z = z_columns_[i].z[j];
         return vector3d<int>(x, y, z);
     }
-
+    
+    /// Find z-columns of G-vectors inside a sphere with Gmax radius.
+    /** This function also computes the total number of G-vectors. */
     inline void find_z_columns(double Gmax__, FFT3D_grid const& fft_box__)
     {
         mdarray<int, 2> non_zero_columns(fft_box__.limits(0), fft_box__.limits(1));
         non_zero_columns.zero();
 
         num_gvec_ = 0;
+
+        auto add_new_column = [&](int i, int j)
+        {
+            std::vector<int> zcol;
+
+            /* in general case take z in [0, Nz) */
+            int zmax = fft_box__.size(2) - 1;
+            /* in case of G-vector reduction take z in [0, Nz/2] for {x=0,y=0} stick */
+            if (reduce_gvec_ && !i && !j) {
+                zmax = fft_box__.limits(2).second;
+            }
+            /* loop over z-coordinates of FFT grid */
+            for (int iz = 0; iz <= zmax; iz++) {
+                /* get z-coordinate of G-vector */
+                int k = fft_box__.gvec_by_coord(iz, 2);
+                /* take G+k */
+                auto vgk = lattice_vectors_ * (vector3d<double>(i, j, k) + vk_);
+                /* add z-coordinate of G-vector to the list */
+                if (vgk.length() <= Gmax__) {
+                    zcol.push_back(k);
+                }
+            }
+
+            /* add column to the list */
+            if (zcol.size() && !non_zero_columns(i, j)) {
+                z_columns_.push_back(z_column_descriptor(i, j, zcol));
+                num_gvec_ += static_cast<int>(zcol.size());
+
+                non_zero_columns(i, j) = 1;
+                if (reduce_gvec_) {
+                    non_zero_columns(-i, -j) = 1;
+                }
+            }
+        };
+
+        /* copy column order from previous G-vector set */
+        if (gvec_base_) {
+            for (int icol = 0; icol < gvec_base_->num_zcol(); icol++) {
+                int i = gvec_base_->zcol(icol).x;
+                int j = gvec_base_->zcol(icol).y;
+                add_new_column(i, j);
+            }
+        }
+
         for (int i = fft_box__.limits(0).first; i <= fft_box__.limits(0).second; i++) {
             for (int j = fft_box__.limits(1).first; j <= fft_box__.limits(1).second; j++) {
-                std::vector<int> zcol;
+                add_new_column(i, j);
+            }
+        }
 
-                /* in general case take z in [0, Nz) */
-                int zmax = fft_box__.size(2) - 1;
-                /* in case of G-vector reduction take z in [0, Nz/2] for {x=0,y=0} stick */
-                if (reduce_gvec_ && !i && !j) {
-                    zmax = fft_box__.limits(2).second;
-                }
-                /* loop over z-coordinates of FFT grid */
-                for (int iz = 0; iz <= zmax; iz++) {
-                    /* get z-coordinate of G-vector */
-                    int k = fft_box__.gvec_by_coord(iz, 2);
-                    /* take G+k */
-                    auto vgk = lattice_vectors_ * (vector3d<double>(i, j, k) + vk_);
-                    /* add z-coordinate of G-vector to the list */
-                    if (vgk.length() <= Gmax__) {
-                        zcol.push_back(k);
-                    }
-                }
-                
-                /* add column to the list */
-                if (zcol.size() && !non_zero_columns(i, j)) {
-                    z_columns_.push_back(z_column_descriptor(i, j, zcol));
-                    num_gvec_ += static_cast<int>(zcol.size());
-
-                    non_zero_columns(i, j) = 1;
-                    if (reduce_gvec_) {
-                        non_zero_columns(-i, -j) = 1;
-                    }
+        if (!gvec_base_) {
+            /* put column with {x, y} = {0, 0} to the beginning */
+            for (size_t i = 0; i < z_columns_.size(); i++) {
+                if (z_columns_[i].x == 0 && z_columns_[i].y == 0) {
+                    std::swap(z_columns_[i], z_columns_[0]);
+                    break;
                 }
             }
         }
 
-        /* put column with {x, y} = {0, 0} to the beginning */
-        for (size_t i = 0; i < z_columns_.size(); i++) {
-            if (z_columns_[i].x == 0 && z_columns_[i].y == 0) {
-                std::swap(z_columns_[i], z_columns_[0]);
-                break;
-            }
-        }
+        /* sort z-columns starting from the second or skip num_zcol of base distribution */
+        int n = (gvec_base_) ? gvec_base_->num_zcol() : 1;
+        std::sort(z_columns_.begin() + n, z_columns_.end(),
+                  [](z_column_descriptor const& a, z_column_descriptor const& b) { return a.z.size() > b.z.size(); });
     }
 
+    /// Distribute z-columns between MPI ranks.
     inline void distribute_z_columns()
     {
-        /* sort z-columns starting from the second */
-        std::sort(z_columns_.begin() + 1, z_columns_.end(),
-                  [](z_column_descriptor const& a, z_column_descriptor const& b) { return a.z.size() > b.z.size(); });
-
-        /* distribute z-columns between N ranks */
         gvec_distr_ = block_data_descriptor(comm().size());
         zcol_distr_ = block_data_descriptor(comm().size());
         /* local number of z-columns for each rank */
         std::vector<std::vector<z_column_descriptor>> zcols_local(comm().size());
+        
+        /* use already existing distribution of base G-vector set */
+        if (gvec_base_) {
+            for (int rank = 0; rank < comm().size(); rank++) {
+                for (int i = 0; i < gvec_base_->zcol_count(rank); i++) {
+                    int icol = gvec_base_->zcol_offset(rank) + i;
+                    /* assign column to the found rank */
+                    zcols_local[rank].push_back(z_columns_[icol]);
+                    /* count local number of z-columns */
+                    zcol_distr_.counts[rank] += 1;
+                    /* count local number of G-vectors */
+                    gvec_distr_.counts[rank] += static_cast<int>(z_columns_[icol].z.size());
+                }
+            }
+        }
+
+        int n = (gvec_base_) ? gvec_base_->num_zcol() : 0;
 
         std::vector<int> ranks;
-        for (size_t i = 0; i < z_columns_.size(); i++) {
+        for (int i = n; i < static_cast<int>(z_columns_.size()); i++) {
             /* initialize the list of ranks to 0,1,2,... */
             if (ranks.empty()) {
                 ranks.resize(comm().size());
@@ -227,6 +255,7 @@ class Gvec
 
             /* assign column to the found rank */
             zcols_local[*rank_with_min_gvec].push_back(z_columns_[i]);
+            /* count local number of z-columns */
             zcol_distr_.counts[*rank_with_min_gvec] += 1;
             /* count local number of G-vectors */
             gvec_distr_.counts[*rank_with_min_gvec] += static_cast<int>(z_columns_[i].z.size());
@@ -241,6 +270,15 @@ class Gvec
         for (int rank = 0; rank < comm().size(); rank++) {
             z_columns_.insert(z_columns_.end(), zcols_local[rank].begin(), zcols_local[rank].end());
         }
+
+        /* sanity check */
+        int ng{0};
+        for (int rank = 0; rank < comm().size(); rank++) {
+            ng += gvec_distr_.counts[rank];
+        }
+        if (ng != num_gvec_) {
+            TERMINATE("wrong number of G-vectors");
+        }
     }
 
     /// Find a list of G-vector shells.
@@ -252,7 +290,7 @@ class Gvec
         /* list of pairs (length, index of G-vector) */
         std::vector<std::pair<size_t, int>> tmp(num_gvec_);
         #pragma omp parallel for schedule(static)
-        for (int ig = 0; ig < num_gvec_; ig++) {
+        for (int ig = 0; ig < num_gvec(); ig++) {
             /* take G+k */
             auto gk = gkvec_cart(ig);
             /* make some reasonable roundoff */
@@ -284,7 +322,8 @@ class Gvec
         gvec_shell_len_ = mdarray<double, 1>(num_gvec_shells_);
         std::copy(tmp_len.begin(), tmp_len.end(), gvec_shell_len_.at<CPU>());
     }
-
+    
+    /// Initialize everything.
     void init()
     {
         PROFILE("sddk::Gvec::init");
@@ -295,8 +334,7 @@ class Gvec
 
         distribute_z_columns();
 
-        gvec_index_by_xy_ = mdarray<int, 3>(2, fft_grid.limits(0), fft_grid.limits(1), memory_t::host,
-                                            "Gvec.gvec_index_by_xy_");
+        gvec_index_by_xy_ = mdarray<int, 3>(2, fft_grid.limits(0), fft_grid.limits(1), memory_t::host, "Gvec.gvec_index_by_xy_");
         std::fill(gvec_index_by_xy_.at<CPU>(), gvec_index_by_xy_.at<CPU>() + gvec_index_by_xy_.size(), -1);
 
         /* build the full G-vector index and reverse mapping */
@@ -305,8 +343,9 @@ class Gvec
         for (size_t i = 0; i < z_columns_.size(); i++) {
             /* starting G-vector index for a z-stick */
             gvec_index_by_xy_(0, z_columns_[i].x, z_columns_[i].y) = ig;
-            /* size of a z-stick */
-            gvec_index_by_xy_(1, z_columns_[i].x, z_columns_[i].y) = static_cast<int>((z_columns_[i].z.size() << 20) + i);
+            /* pack size of a z-stick and column index in one number */
+            gvec_index_by_xy_(1, z_columns_[i].x, z_columns_[i].y) =
+                static_cast<int>((z_columns_[i].z.size() << 20) + i);
             for (size_t j = 0; j < z_columns_[i].z.size(); j++) {
                 gvec_full_index_[ig++] = static_cast<uint32_t>((i << 12) + j);
             }
@@ -331,18 +370,37 @@ class Gvec
 
         find_gvec_shells();
 
-        /* create default partition for G-vectors */
-        //gvec_partition_ = std::unique_ptr<Gvec_partition>(new Gvec_partition(*this, *comm_fft_));
+        if (gvec_base_) {
+            /* the size of the mapping is equal to the local number of G-vectors in the base set */
+            gvec_base_mapping_ = mdarray<int, 1>(gvec_base_->count());
+            /* loop over local G-vectors of a base set */
+            for (int igloc = 0; igloc < gvec_base_->count(); igloc++) {
+                /* G-vector in lattice coordinates */
+                auto G = gvec_base_->gvec(gvec_base_->offset() + igloc);
+                /* global index of G-vector in the current set */
+                int ig = index_by_gvec(G);
+                /* the same MPI rank must store this G-vector */
+                ig -= offset();
+                if (ig >= 0 && ig < count()) {
+                    gvec_base_mapping_(igloc) = ig;
+                } else {
+                    std::stringstream s;
+                    s << "local G-vector index is not found" << std::endl
+                      << " G-vector: " << G << std::endl
+                      << " G-vector index in base distribution : " << gvec_base_->offset() + igloc << std::endl
+                      << " G-vector index in base distribution (by G-vector): " << gvec_base_->index_by_gvec(G) << std::endl
+                      << " G-vector index in new distribution : " << index_by_gvec(G) << std::endl
+                      << " offset in G-vector index for this rank: " << offset() << std::endl
+                      << " local number of G-vectors for this rank: " << count();
+                    TERMINATE(s);
+                }
+            }
+        }
     }
 
     Gvec& operator=(Gvec&& src__) = delete;
 
   public:
-    /// Default constructor.
-    //Gvec()
-    //{
-    //}
-
     /// Constructor for G+k vectors.
     /** \param [in] vk          K-point vector of G+k
      *  \param [in] M           Reciprocal lattice vecotors in comumn order
@@ -351,11 +409,7 @@ class Gvec
      *  \param [in] comm_fft    FFT communicator
      *  \param [in] reduce_gvec True if G-vectors need to be reduced by inversion symmetry.
      */
-    Gvec(vector3d<double>    vk__,
-         matrix3d<double>    M__,
-         double              Gmax__,
-         Communicator const& comm__,
-         bool                reduce_gvec__)
+    Gvec(vector3d<double> vk__, matrix3d<double> M__, double Gmax__, Communicator const& comm__, bool reduce_gvec__)
         : vk_(vk__)
         , Gmax_(Gmax__)
         , lattice_vectors_(M__)
@@ -366,10 +420,7 @@ class Gvec
     }
 
     /// Constructor for G-vectors.
-    Gvec(matrix3d<double>    M__,
-         double              Gmax__,
-         Communicator const& comm__,
-         bool                reduce_gvec__)
+    Gvec(matrix3d<double> M__, double Gmax__, Communicator const& comm__, bool reduce_gvec__)
         : vk_({0, 0, 0})
         , Gmax_(Gmax__)
         , lattice_vectors_(M__)
@@ -379,32 +430,51 @@ class Gvec
         init();
     }
 
-    //== /// Move assigment operator.
-    //== Gvec& operator=(Gvec&& src__)
-    //== {
-    //==     if (this != &src__) {
-    //==         vk_                    = src__.vk_;
-    //==         Gmax_                  = src__.Gmax_;
-    //==         lattice_vectors_       = src__.lattice_vectors_;
-    //==         comm_                  = std::move(src__.comm_);
-    //==         reduce_gvec_           = src__.reduce_gvec_;
-    //==         num_gvec_              = src__.num_gvec_;
-    //==         gvec_full_index_       = std::move(src__.gvec_full_index_);
-    //==         gvec_shell_            = std::move(src__.gvec_shell_);
-    //==         num_gvec_shells_       = src__.num_gvec_shells_;
-    //==         gvec_shell_len_        = std::move(src__.gvec_shell_len_);
-    //==         gvec_index_by_xy_      = std::move(src__.gvec_index_by_xy_);
-    //==         z_columns_             = std::move(src__.z_columns_);
-    //==         gvec_distr_            = std::move(src__.gvec_distr_);
-    //==         zcol_distr_            = std::move(src__.zcol_distr_);
-    //==     }
-    //==     return *this;
-    //== }
+    /// Constructor for G-vector distribution based on a previous set.
+    /** Previous set of G-vectors must be a subset of the current set. */
+    Gvec(double Gmax__, Gvec const& gvec_base__)
+        : vk_({0, 0, 0})
+        , Gmax_(Gmax__)
+        , lattice_vectors_(gvec_base__.lattice_vectors())
+        , comm_(gvec_base__.comm())
+        , reduce_gvec_(gvec_base__.reduced())
+        , gvec_base_(&gvec_base__)
+    {
+        init();
+    }
+
+    vector3d<double> const& vk() const
+    {
+        return vk_;
+    }
+
+    Communicator const& comm() const
+    {
+        return comm_;
+    }
+
+    inline matrix3d<double> const& lattice_vectors() const
+    {
+        return lattice_vectors_;
+    }
 
     /// Return the total number of G-vectors within the cutoff.
     inline int num_gvec() const
     {
         return num_gvec_;
+    }
+
+    /// Number of z-columns for a fine-grained distribution.
+    inline int zcol_count(int rank__) const
+    {
+        assert(rank__ < comm().size());
+        return zcol_distr_.counts[rank__];
+    }
+
+    inline int zcol_offset(int rank__) const
+    {
+        assert(rank__ < comm().size());
+        return zcol_distr_.offsets[rank__];
     }
 
     /// Number of G-vectors for a fine-grained distribution.
@@ -497,8 +567,15 @@ class Gvec
         return 0;
     }
 
+    /// Return a global G-vector index in the range [0, num_gvec) by the G-vector.
+    /** The information about a G-vector index is encoded by two numbers: a starting index for the 
+     *  column of G-vectors and column's size. Depending on the geometry of the reciprocal lattice,
+     *  z-columns may have only negative, only positive or both negative and positive frequencies for
+     *  a given x and y. This information is used to compute the offset which is added to the starting index
+     *  in order to get a full G-vector index. */
     inline int index_by_gvec(vector3d<int> const& G__) const
     {
+        /* reduced G-vector set does not have negative z for x=y=0 */
         if (reduced() && G__[0] == 0 && G__[1] == 0 && G__[2] < 0) {
             return -1;
         }
@@ -506,12 +583,31 @@ class Gvec
         if (ig0 == -1) {
             return -1;
         }
-        int icol     = gvec_index_by_xy_(1, G__[0], G__[1]) & 0xFFFFF;
+        /* index of the column */
+        int icol = gvec_index_by_xy_(1, G__[0], G__[1]) & 0xFFFFF;
+        /* size of the column */
         int col_size = gvec_index_by_xy_(1, G__[0], G__[1]) >> 20;
-        int z0       = G__[2] - z_columns_[icol].z[0];
-        int offs     = (z0 >= 0) ? z0 : z0 + col_size;
-        int ig       = ig0 + offs;
-        assert(ig < num_gvec());
+
+        /* three possible options for the z-column location
+           
+              frequency                ... -4, -3, -2, -1, 0, 1, 2, 3, 4 ...
+           -----------------------------------------------------------------------------
+              G-vec ordering
+           #1 (all negative)           ___  0   1   2   3 __________________               
+           #2 (negative and positive)  ____________ 3   4  0  1  2 _________
+           #3 (all positive)           _____________________  0  1  2  3 ___
+
+           Remember how FFT frequencies are stored: firs positive frequences, then negative in the reverse order
+
+           subtract first z-coordinate in column from the current z-coordinate of G-vector: in case #1 or #3 this
+           already gives a proper offset, in case #2 storage of FFT frequencies must be taken into account
+        */
+        int z0 = G__[2] - z_columns_[icol].z[0];
+        /* calculate proper offset */
+        int offs = (z0 >= 0) ? z0 : z0 + col_size;
+        /* full index */
+        int ig = ig0 + offs;
+        assert(ig >= 0 && ig < num_gvec());
         return ig;
     }
 
@@ -530,37 +626,19 @@ class Gvec
         return z_columns_[idx__];
     }
 
-    //inline Gvec_partition const& partition() const
-    //{
-    //    return *gvec_partition_;
-    //}
-
-    vector3d<double> const& vk() const
+    inline int gvec_base_mapping(int igloc_base__) const
     {
-        return vk_;
-    }
-
-    Communicator const& comm() const
-    {
-        return comm_;
-    }
-
-    //Communicator const& comm_ortho_fft() const
-    //{
-    //    return *comm_ortho_fft_;
-    //}
-
-    inline matrix3d<double> const& lattice_vectors() const
-    {
-        return lattice_vectors_;
+        assert(gvec_base_ != nullptr);
+        return gvec_base_mapping_(igloc_base__);
     }
 };
 
 /// Stores information about G-vector partitioning between MPI ranks for the FFT transformation.
+/** FFT driver works with a small communicator. G-vectors are distributed over the entire communicator which is
+    larger than the FFT communicator. In order to transform the functions, G-vectors must be redistributed to the
+    FFT-friendly "fat" slabs based on the FFT communicator size. */
 class Gvec_partition
 {
-    //friend class Gvec;
-
   private:
     /// Pointer to the G-vector instance.
     Gvec const& gvec_;
@@ -568,13 +646,15 @@ class Gvec_partition
     /// Communicator for the FFT.
     Communicator const& fft_comm_;
 
+    Communicator const& comm_ortho_fft_;
+
     /// Distribution of G-vectors for FFT.
     block_data_descriptor gvec_distr_fft_;
 
     /// Distribution of z-columns for FFT.
     block_data_descriptor zcol_distr_fft_;
 
-    /// Distribution of G-vectors inside FFT slab.
+    /// Distribution of G-vectors inside FFT-friendly "fat" slab.
     block_data_descriptor gvec_fft_slab_;
 
     /// Offset of the z-column in the local data buffer.
@@ -587,18 +667,19 @@ class Gvec_partition
         gvec_distr_fft_ = block_data_descriptor(fft_comm().size());
         zcol_distr_fft_ = block_data_descriptor(fft_comm().size());
 
-        int nrc = gvec_->num_ranks_ / fft_comm_->size();
+        /* number of extra ranks that will do the same FFT */
+        int nrc = gvec().comm().size() / fft_comm().size();
 
-        if (gvec_->num_ranks_ != nrc * fft_comm_->size()) {
+        if (gvec().comm().size() != nrc * fft_comm().size()) {
             TERMINATE("wrong number of MPI ranks");
         }
 
-        for (int rank = 0; rank < fft_comm_->size(); rank++) {
+        for (int rank = 0; rank < fft_comm().size(); rank++) {
             for (int i = 0; i < nrc; i++) {
                 /* fine-grained rank */
                 int r = rank * nrc + i;
-                gvec_distr_fft_.counts[rank] += gvec_->gvec_distr_.counts[r];
-                zcol_distr_fft_.counts[rank] += gvec_->zcol_distr_.counts[r];
+                gvec_distr_fft_.counts[rank] += gvec().gvec_count(r);
+                zcol_distr_fft_.counts[rank] += gvec().zcol_count(r);
             }
         }
         /* get offsets of z-columns */
@@ -610,15 +691,15 @@ class Gvec_partition
     /// Calculate offsets of z-columns inside each local buffer of PW coefficients.
     inline void calc_offsets()
     {
-        zcol_offs_ = mdarray<int, 1>(gvec_->num_zcol(), memory_t::host, "Gvec_partition.zcol_offs_");
-        for (int rank = 0; rank < fft_comm_->size(); rank++) {
+        zcol_offs_ = mdarray<int, 1>(gvec().num_zcol(), memory_t::host, "Gvec_partition.zcol_offs_");
+        for (int rank = 0; rank < fft_comm().size(); rank++) {
             int offs{0};
             /* loop over local number of z-columns */
             for (int i = 0; i < zcol_distr_fft_.counts[rank]; i++) {
                 /* global index of z-column */
                 int icol         = zcol_distr_fft_.offsets[rank] + i;
                 zcol_offs_[icol] = offs;
-                offs += static_cast<int>(gvec_->z_columns_[icol].z.size());
+                offs += static_cast<int>(gvec().zcol(icol).z.size());
             }
             assert(offs == gvec_distr_fft_.counts[rank]);
         }
@@ -626,8 +707,9 @@ class Gvec_partition
 
     inline void pile_gvec()
     {
-        /* build a table of {offset, count} values for G-vectors in the swapped wfs;
-         * we are preparing to swap wave-functions from a default slab distribution to a FFT-friendly distribution
+        /* build a table of {offset, count} values for G-vectors in the swapped distribution;
+         * we are preparing to swap plane-wave coefficients from a default slab distribution to a FFT-friendly
+         * distribution
          * +--------------+      +----+----+----+
          * |    :    :    |      |    |    |    |
          * +--------------+      |....|....|....|
@@ -638,16 +720,16 @@ class Gvec_partition
          *
          * i.e. we will make G-vector slabs more fat (pile-of-slabs) and at the same time reshulffle wave-functions
          * between columns of the 2D MPI grid */
-        int rank_row = fft_comm_->rank();
+        int rank_row = fft_comm().rank();
 
-        int nrc = gvec_->num_ranks_ / fft_comm_->size();
-        if (gvec_->num_ranks_ != nrc * fft_comm_->size()) {
+        int nrc = gvec().comm().size() / fft_comm().size();
+        if (gvec().comm().size() != nrc * fft_comm().size()) {
             TERMINATE("wrong number of MPI ranks");
         }
 
         gvec_fft_slab_ = block_data_descriptor(nrc);
         for (int i = 0; i < nrc; i++) {
-            gvec_fft_slab_.counts[i] = gvec_->gvec_count(rank_row * nrc + i);
+            gvec_fft_slab_.counts[i] = gvec().gvec_count(rank_row * nrc + i);
         }
         gvec_fft_slab_.calc_offsets();
 
@@ -655,39 +737,49 @@ class Gvec_partition
     }
 
   public:
-    Gvec_partition(Gvec const& gvec__, Communicator const& fft_comm__)
-        : gvec_(&gvec__)
-        , fft_comm_(&fft_comm__)
+    Gvec_partition(Gvec const& gvec__, Communicator const& fft_comm__, Communicator const& comm_ortho_fft__)
+        : gvec_(gvec__)
+        , fft_comm_(fft_comm__)
+        , comm_ortho_fft_(comm_ortho_fft__)
     {
         build_fft_distr();
         calc_offsets();
         pile_gvec();
     }
 
+    /// Return FFT communicator
     inline Communicator const& fft_comm() const
     {
         return fft_comm_;
     }
 
-    inline int gvec_count_fft() const
+    inline Communicator const& comm_ortho_fft() const
     {
-        return gvec_distr_fft_.counts[fft_comm_->rank()];
+        return comm_ortho_fft_;
     }
 
+    /// Local number of G-vectors for FFT-friendly distibution.
+    inline int gvec_count_fft() const
+    {
+        return gvec_distr_fft_.counts[fft_comm().rank()];
+    }
+
+    /// Offset of G-vector index for FFT-friendly distibution.
+    /** Global index of G-vector can be obtained by adding offset to a local G-vector index. */
     inline int gvec_offset_fft() const
     {
-        return gvec_distr_fft_.offsets[fft_comm_->rank()];
+        return gvec_distr_fft_.offsets[fft_comm().rank()];
     }
 
     /// Return local number of z-columns.
     inline int zcol_count_fft() const
     {
-        return zcol_distr_fft_.counts[fft_comm_->rank()];
+        return zcol_distr_fft_.counts[fft_comm().rank()];
     }
 
     inline int zcol_offset_fft() const
     {
-        return zcol_distr_fft_.offsets[fft_comm_->rank()];
+        return zcol_distr_fft_.offsets[fft_comm().rank()];
     }
 
     inline block_data_descriptor const& zcol_distr_fft() const
@@ -707,42 +799,14 @@ class Gvec_partition
 
     inline Gvec const& gvec() const
     {
-        return *gvec_;
+        return gvec_;
     }
-
-    inline int num_gvec() const;
-
-    inline int num_zcol() const;
-
-    inline z_column_descriptor const& zcol(size_t idx__) const;
-
-    inline bool reduced() const;
 };
 
-//inline int Gvec_partition::num_gvec() const
-//{
-//    return gvec_->num_gvec();
-//}
-//
-//inline int Gvec_partition::num_zcol() const
-//{
-//    return gvec_->num_zcol();
-//}
-//
-//inline z_column_descriptor const& Gvec_partition::zcol(size_t idx__) const
-//{
-//    return gvec_->zcol(idx__);
-//}
-//
-//inline bool Gvec_partition::reduced() const
-//{
-//    return gvec_->reduced();
-//}
-
 /// Helper class to redistribute G-vectors for symmetrization.
-/** G-vectors are remapped from default distribution which balances both the local number 
+/** G-vectors are remapped from default distribution which balances both the local number
  *  of z-columns and G-vectors to the distributio of G-vector shells in which each MPI rank stores
- *  local set of complete G-vector shells such that the "rotated" G-vector remains on the same MPI rank. */  
+ *  local set of complete G-vector shells such that the "rotated" G-vector remains on the same MPI rank. */
 struct remap_gvec_to_shells
 {
     /// Sending counts and offsets.
@@ -753,15 +817,15 @@ struct remap_gvec_to_shells
 
     /// Split global index of G-shells between MPI ranks.
     splindex<block_cyclic> spl_num_gsh;
-    
+
     /// List of G-vectors in the remapped storage.
     mdarray<int, 2> gvec_remapped_;
-    
+
     /// Mapping between index of local G-vector and global index of G-vector shell.
     mdarray<int, 1> gvec_shell_remapped_;
-    
+
     /* mapping beween G-shell index and local G-vector index */
-    //std::map<int, std::vector<int>> gvec_sh_;
+    // std::map<int, std::vector<int>> gvec_sh_;
 
     Communicator const& comm_;
 
@@ -834,11 +898,11 @@ struct remap_gvec_to_shells
         for (int ig = 0; ig < a2a_recv.size(); ig++) {
             vector3d<int> G(&gvec_remapped_(0, ig));
             idx_gvec[G] = ig;
-            //int igsh = gvec_shell_remapped_(ig);
-            //if (!gvec_sh_.count(igsh)) {
+            // int igsh = gvec_shell_remapped_(ig);
+            // if (!gvec_sh_.count(igsh)) {
             //    gvec_sh_[igsh] = std::vector<int>();
             //}
-            //gvec_sh_[igsh].push_back(ig);
+            // gvec_sh_[igsh].push_back(ig);
         }
     }
 

--- a/src/SDDK/gvec.hpp
+++ b/src/SDDK/gvec.hpp
@@ -710,13 +710,13 @@ inline void Gvec_partition::pile_gvec()
 {
     /* build a table of {offset, count} values for G-vectors in the swapped wfs;
      * we are preparing to swap wave-functions from a default slab distribution to a FFT-friendly distribution
-     * +==============+      +----+----+----+
-     * |    :    :    |      I    I    I    I
-     * +==============+      I....I....I....I
-     * |    :    :    |  ->  I    I    I    I
-     * +==============+      I....I....I....I
-     * |    :    :    |      I    I    I    I
-     * +==============+      +----+----+----+
+     * +--------------+      +----+----+----+
+     * |    :    :    |      |    |    |    |
+     * +--------------+      |....|....|....|
+     * |    :    :    |  ->  |    |    |    |
+     * +--------------+      |....|....|....|
+     * |    :    :    |      |    |    |    |
+     * +--------------+      +----+----+----+
      *
      * i.e. we will make G-vector slabs more fat (pile-of-slabs) and at the same time reshulffle wave-functions
      * between columns of the 2D MPI grid */

--- a/src/band.h
+++ b/src/band.h
@@ -230,8 +230,8 @@ class Band
     {
         PROFILE("sirius::Band::diag_pseudo_potential");
 
-        H_.local_op().prepare(kp__->gkvec());
-        ctx_.fft_coarse().prepare(kp__->gkvec().partition());
+        H_.local_op().prepare(kp__->gkvec_partition());
+        ctx_.fft_coarse().prepare(kp__->gkvec_partition());
         H_.create_d_and_q_operator<T>();
         H_.initialize_D_and_Q_operators<T>();
         /* D_operator<T> d_op(ctx_, kp__->beta_projectors()); */

--- a/src/density.h
+++ b/src/density.h
@@ -354,12 +354,12 @@ class Density
             
             /*  allocate charge density and magnetization on a coarse grid */
             for (int i = 0; i < ctx_.num_mag_dims() + 1; i++) {
-                rho_mag_coarse_[i] = std::unique_ptr<Smooth_periodic_function<double>>(new Smooth_periodic_function<double>(ctx_.fft_coarse(), ctx_.gvec_coarse()));
+                rho_mag_coarse_[i] = std::unique_ptr<Smooth_periodic_function<double>>(new Smooth_periodic_function<double>(ctx_.fft_coarse(), ctx_.gvec_coarse_partition()));
             }
 
             /* core density of the pseudopotential method */
             if (!ctx_.full_potential()) {
-                rho_pseudo_core_ = std::unique_ptr<Smooth_periodic_function<double>>(new Smooth_periodic_function<double>(ctx_.fft(), ctx_.gvec()));
+                rho_pseudo_core_ = std::unique_ptr<Smooth_periodic_function<double>>(new Smooth_periodic_function<double>(ctx_.fft(), ctx_.gvec_partition()));
                 rho_pseudo_core_->zero();
 
                 generate_pseudo_core_charge_density();

--- a/src/matching_coefficients.h
+++ b/src/matching_coefficients.h
@@ -54,7 +54,6 @@ class Matching_coefficients
 
         int num_gkvec_;
 
-        //std::vector<gklo_basis_descriptor> const& gklo_basis_descriptors_;
         std::vector<int>& igk_;
 
         Gvec const& gkvec_;

--- a/src/periodic_function.h
+++ b/src/periodic_function.h
@@ -93,7 +93,7 @@ class Periodic_function: public Smooth_periodic_function<T>
         /// Constructor
         Periodic_function(Simulation_context& ctx__,
                           int angular_domain_size__)
-            : Smooth_periodic_function<T>(ctx__.fft(), ctx__.gvec())
+            : Smooth_periodic_function<T>(ctx__.fft(), ctx__.gvec_partition())
             , ctx_(ctx__)
             , unit_cell_(ctx__.unit_cell())
             , step_function_(ctx__.step_function())

--- a/src/potential.h
+++ b/src/potential.h
@@ -366,16 +366,16 @@ class Potential
             xc_energy_density_->allocate_mt(false);
 
             for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
-                vsigma_[ispn] = std::unique_ptr<Smooth_periodic_function<double>>(new Smooth_periodic_function<double>(ctx_.fft(), ctx_.gvec()));
+                vsigma_[ispn] = std::unique_ptr<Smooth_periodic_function<double>>(new Smooth_periodic_function<double>(ctx_.fft(), ctx_.gvec_partition()));
             }
 
             if (!ctx_.full_potential()) {
-                local_potential_ = std::unique_ptr<Smooth_periodic_function<double>>(new Smooth_periodic_function<double>(ctx_.fft(), ctx_.gvec()));
+                local_potential_ = std::unique_ptr<Smooth_periodic_function<double>>(new Smooth_periodic_function<double>(ctx_.fft(), ctx_.gvec_partition()));
                 local_potential_->zero();
 
                 generate_local_potential();
 
-                dveff_ = std::unique_ptr<Smooth_periodic_function<double>>(new Smooth_periodic_function<double>(ctx_.fft(), ctx_.gvec()));
+                dveff_ = std::unique_ptr<Smooth_periodic_function<double>>(new Smooth_periodic_function<double>(ctx_.fft(), ctx_.gvec_partition()));
             }
 
             vh_el_ = mdarray<double, 1>(unit_cell_.num_atoms());

--- a/src/simulation_context_base.h
+++ b/src/simulation_context_base.h
@@ -76,10 +76,14 @@ class Simulation_context_base: public Simulation_parameters
         std::unique_ptr<FFT3D> fft_coarse_;
 
         /// G-vectors within the Gmax cutoff.
-        Gvec gvec_;
+        std::unique_ptr<Gvec> gvec_;
+
+        std::unique_ptr<Gvec_partition> gvec_partition_;
         
         /// G-vectors within the 2 * |Gmax^{WF}| cutoff.
-        Gvec gvec_coarse_;
+        std::unique_ptr<Gvec> gvec_coarse_;
+
+        std::unique_ptr<Gvec_partition> gvec_coarse_partition_;
 
         std::unique_ptr<remap_gvec_to_shells> remap_gvec_; 
 
@@ -130,20 +134,25 @@ class Simulation_context_base: public Simulation_parameters
             /* create FFT driver for dense mesh (density and potential) */
             fft_ = std::unique_ptr<FFT3D>(new FFT3D(find_translations(pw_cutoff(), rlv), comm_fft(), processing_unit())); 
 
-            /* create a list of G-vectors for dense FFT grid; G-vectors are divided between all available MPI ranks.*/
-            gvec_ = Gvec(rlv, pw_cutoff(), comm(), comm_fft(), comm_ortho_fft(), control().reduce_gvec_);
-
-            remap_gvec_ = std::unique_ptr<remap_gvec_to_shells>(new remap_gvec_to_shells(comm(), gvec()));
-
-            /* prepare fine-grained FFT driver for the entire simulation */
-            fft_->prepare(gvec_.partition());
-
             /* create FFT driver for coarse mesh */
             auto fft_coarse_grid = FFT3D_grid(find_translations(2 * gk_cutoff(), rlv));
             fft_coarse_ = std::unique_ptr<FFT3D>(new FFT3D(fft_coarse_grid, comm_fft_coarse(), processing_unit()));
 
             /* create a list of G-vectors for corase FFT grid */
-            gvec_coarse_ = Gvec(rlv, gk_cutoff() * 2, comm(), comm_fft_coarse(), comm_ortho_fft_coarse(), control().reduce_gvec_);
+            gvec_coarse_ = std::unique_ptr<Gvec>(new Gvec(rlv, gk_cutoff() * 2, comm(), control().reduce_gvec_));
+
+            gvec_coarse_partition_ = std::unique_ptr<Gvec_partition>(new Gvec_partition(*gvec_coarse_, comm_fft_coarse(), comm_ortho_fft_coarse()));
+
+            /* create a list of G-vectors for dense FFT grid; G-vectors are divided between all available MPI ranks.*/
+            //gvec_ = std::unique_ptr<Gvec>(new Gvec(rlv, pw_cutoff(), comm(), control().reduce_gvec_));
+            gvec_ = std::unique_ptr<Gvec>(new Gvec(pw_cutoff(), *gvec_coarse_));
+
+            gvec_partition_ = std::unique_ptr<Gvec_partition>(new Gvec_partition(*gvec_, comm_fft(), comm_ortho_fft()));
+
+            remap_gvec_ = std::unique_ptr<remap_gvec_to_shells>(new remap_gvec_to_shells(comm(), gvec()));
+
+            /* prepare fine-grained FFT driver for the entire simulation */
+            fft_->prepare(*gvec_partition_);
         }
 
         /* copy constructor is forbidden */
@@ -292,12 +301,22 @@ class Simulation_context_base: public Simulation_parameters
 
         Gvec const& gvec() const
         {
-            return gvec_;
+            return *gvec_;
+        }
+
+        Gvec_partition const& gvec_partition() const
+        {
+            return *gvec_partition_;
         }
 
         Gvec const& gvec_coarse() const
         {
-            return gvec_coarse_;
+            return *gvec_coarse_;
+        }
+
+        Gvec_partition const& gvec_coarse_partition() const
+        {
+            return *gvec_coarse_partition_;
         }
 
         remap_gvec_to_shells const& remap_gvec() const
@@ -382,14 +401,14 @@ class Simulation_context_base: public Simulation_parameters
                 fout["parameters"].write("num_mag_dims", num_mag_dims());
                 fout["parameters"].write("num_bands", num_bands());
 
-                mdarray<int, 2> gv(3, gvec_.num_gvec());
-                for (int ig = 0; ig < gvec_.num_gvec(); ig++) {
-                    auto G = gvec_.gvec(ig);
+                mdarray<int, 2> gv(3, gvec().num_gvec());
+                for (int ig = 0; ig < gvec().num_gvec(); ig++) {
+                    auto G = gvec().gvec(ig);
                     for (int x: {0, 1, 2}) {
                         gv(x, ig) = G[x];
                     }
                 }
-                fout["parameters"].write("num_gvec", gvec_.num_gvec());
+                fout["parameters"].write("num_gvec", gvec().num_gvec());
                 fout["parameters"].write("gvec", gv);
 
                 fout.create_node("unit_cell");
@@ -440,7 +459,7 @@ class Simulation_context_base: public Simulation_parameters
         /// Phase factors \f$ e^{i {\bf G} {\bf r}_{\alpha}} \f$
         inline double_complex gvec_phase_factor(int ig__, int ia__) const
         {
-            return gvec_phase_factor(gvec_.gvec(ig__), ia__);
+            return gvec_phase_factor(gvec().gvec(ig__), ia__);
         }
 
         inline mdarray<int, 2> const& gvec_coord() const
@@ -462,10 +481,10 @@ class Simulation_context_base: public Simulation_parameters
             switch (processing_unit_) {
                 case CPU: {
                     #pragma omp parallel for
-                    for (int igloc = 0; igloc < gvec_.count(); igloc++) {
-                        int ig = gvec_.offset() + igloc;
+                    for (int igloc = 0; igloc < gvec().count(); igloc++) {
+                        int ig = gvec().offset() + igloc;
                         for (int i = 0; i < na; i++) {
-                            int ia = unit_cell_.atom_type(iat__).atom_id(i);
+                            int ia = unit_cell().atom_type(iat__).atom_id(i);
                             phase_factors__(igloc, i) = gvec_phase_factor(ig, ia);
                         }
                     }
@@ -473,7 +492,7 @@ class Simulation_context_base: public Simulation_parameters
                 }
                 case GPU: {
                     #ifdef __GPU
-                    generate_phase_factors_gpu(gvec_.count(), na, gvec_coord().at<GPU>(), atom_coord(iat__).at<GPU>(),
+                    generate_phase_factors_gpu(gvec().count(), na, gvec_coord().at<GPU>(), atom_coord(iat__).at<GPU>(),
                                                phase_factors__.at<GPU>());
                     #else
                     TERMINATE_NO_GPU
@@ -492,13 +511,13 @@ class Simulation_context_base: public Simulation_parameters
 
             double fourpi_omega = fourpi / unit_cell_.omega();
 
-            int ngv = (index_domain == index_domain_t::local) ? gvec_.count() : gvec().num_gvec();
+            int ngv = (index_domain == index_domain_t::local) ? gvec().count() : gvec().num_gvec();
             std::vector<double_complex> f_pw(ngv, double_complex(0, 0));
 
             #pragma omp parallel for schedule(static)
-            for (int igloc = 0; igloc < gvec_.count(); igloc++) {
+            for (int igloc = 0; igloc < gvec().count(); igloc++) {
                 /* global index of G-vector */
-                int ig = gvec_.offset() + igloc;
+                int ig = gvec().offset() + igloc;
                 double g = gvec().gvec_len(ig);
 
                 int j = (index_domain == index_domain_t::local) ? igloc : ig;
@@ -509,7 +528,7 @@ class Simulation_context_base: public Simulation_parameters
             }
 
             if (index_domain == index_domain_t::global) {
-                comm_.allgather(&f_pw[0], gvec_.offset(), gvec_.count());
+                comm_.allgather(&f_pw[0], gvec().offset(), gvec().count());
             }
 
             return std::move(f_pw);
@@ -679,9 +698,9 @@ inline void Simulation_context_base::initialize()
     }
 
     if (unit_cell_.num_atoms() != 0 && use_symmetry()) {
-        unit_cell_.symmetry().check_gvec_symmetry(gvec_, comm_);
+        unit_cell_.symmetry().check_gvec_symmetry(gvec(), comm());
         if (!full_potential()) {
-            unit_cell_.symmetry().check_gvec_symmetry(gvec_coarse_, comm_);
+            unit_cell_.symmetry().check_gvec_symmetry(gvec_coarse(), comm());
         }
     }
 
@@ -815,10 +834,10 @@ inline void Simulation_context_base::initialize()
     
 
     if (processing_unit() == GPU) {
-        gvec_coord_ = mdarray<int, 2>(gvec_.count(), 3, memory_t::host | memory_t::device, "gvec_coord_");
-        for (int igloc = 0; igloc < gvec_.count(); igloc++) {
-            int ig = gvec_.offset() + igloc;
-            auto G = gvec_.gvec(ig);
+        gvec_coord_ = mdarray<int, 2>(gvec().count(), 3, memory_t::host | memory_t::device, "gvec_coord_");
+        for (int igloc = 0; igloc < gvec().count(); igloc++) {
+            int ig = gvec().offset() + igloc;
+            auto G = gvec().gvec(ig);
             for (int x: {0, 1, 2}) {
                 gvec_coord_(igloc, x) = G[x];
             }
@@ -900,9 +919,9 @@ inline void Simulation_context_base::print_info()
                                                                                 fft_grid.limits(1).second,
                                                                                 fft_grid.limits(2).first,
                                                                                 fft_grid.limits(2).second);
-    printf("  number of G-vectors within the cutoff : %i\n", gvec_.num_gvec());
-    printf("  local number of G-vectors             : %i\n", gvec_.gvec_count(0));
-    printf("  number of G-shells                    : %i\n", gvec_.num_shells());
+    printf("  number of G-vectors within the cutoff : %i\n", gvec().num_gvec());
+    printf("  local number of G-vectors             : %i\n", gvec().gvec_count(0));
+    printf("  number of G-shells                    : %i\n", gvec().num_shells());
     printf("\n");
     printf("FFT context for coarse grid\n");
     printf("===========================\n");
@@ -919,8 +938,8 @@ inline void Simulation_context_base::print_info()
                                                                                 fft_grid.limits(1).second,
                                                                                 fft_grid.limits(2).first,
                                                                                 fft_grid.limits(2).second);
-    printf("  number of G-vectors within the cutoff : %i\n", gvec_coarse_.num_gvec());
-    printf("  number of G-shells                    : %i\n", gvec_coarse_.num_shells());
+    printf("  number of G-vectors within the cutoff : %i\n", gvec_coarse().num_gvec());
+    printf("  number of G-shells                    : %i\n", gvec_coarse().num_shells());
     printf("\n");
 
     unit_cell_.print_info(control().verbosity_);
@@ -929,12 +948,12 @@ inline void Simulation_context_base::print_info()
     }
 
     printf("\n");
-    printf("total nuclear charge               : %i\n", unit_cell_.total_nuclear_charge());
-    printf("number of core electrons           : %f\n", unit_cell_.num_core_electrons());
-    printf("number of valence electrons        : %f\n", unit_cell_.num_valence_electrons());
-    printf("total number of electrons          : %f\n", unit_cell_.num_electrons());
-    printf("total number of aw basis functions : %i\n", unit_cell_.mt_aw_basis_size());
-    printf("total number of lo basis functions : %i\n", unit_cell_.mt_lo_basis_size());
+    printf("total nuclear charge               : %i\n", unit_cell().total_nuclear_charge());
+    printf("number of core electrons           : %f\n", unit_cell().num_core_electrons());
+    printf("number of valence electrons        : %f\n", unit_cell().num_valence_electrons());
+    printf("total number of electrons          : %f\n", unit_cell().num_electrons());
+    printf("total number of aw basis functions : %i\n", unit_cell().mt_aw_basis_size());
+    printf("total number of lo basis functions : %i\n", unit_cell().mt_lo_basis_size());
     printf("number of first-variational states : %i\n", num_fv_states());
     printf("number of bands                    : %i\n", num_bands());
     printf("number of spins                    : %i\n", num_spins());

--- a/src/smooth_periodic_function.h
+++ b/src/smooth_periodic_function.h
@@ -46,7 +46,7 @@ class Smooth_periodic_function
         FFT3D* fft_{nullptr};
 
         /// Distribution of G-vectors.
-        Gvec const* gvec_{nullptr};
+        Gvec_partition const* gvecp_{nullptr};
 
         /// Function on the regular real-space grid.
         mdarray<T, 1> f_rg_;
@@ -58,18 +58,18 @@ class Smooth_periodic_function
         mdarray<double_complex, 1> f_pw_fft_;
 
         /// Distribution of G-vectors inside FFT slab.
-        block_data_descriptor gvec_fft_slab_;
+        //block_data_descriptor gvec_fft_slab_;
 
         /// Gather plane-wave coefficients for the subsequent FFT call.
         inline void gather_f_pw_fft()
         {
-            int rank = fft_->comm().rank() * gvec_->comm_ortho_fft().size() + gvec_->comm_ortho_fft().rank();
+            int rank = fft_->comm().rank() * gvecp_->comm_ortho_fft().size() + gvecp_->comm_ortho_fft().rank();
             /* collect scattered PW coefficients */
-            gvec_->comm_ortho_fft().allgather(f_pw_local_.at<CPU>(),
-                                              gvec_->gvec_count(rank),
-                                              f_pw_fft_.at<CPU>(),
-                                              gvec_fft_slab_.counts.data(), 
-                                              gvec_fft_slab_.offsets.data());
+            gvecp_->comm_ortho_fft().allgather(f_pw_local_.at<CPU>(),
+                                               gvecp_->gvec().gvec_count(rank),
+                                               f_pw_fft_.at<CPU>(),
+                                               gvecp_->gvec_fft_slab().counts.data(), 
+                                               gvecp_->gvec_fft_slab().offsets.data());
         }
 
     public:
@@ -79,25 +79,25 @@ class Smooth_periodic_function
         {
         }
 
-        Smooth_periodic_function(FFT3D& fft__, Gvec const& gvec__)
+        Smooth_periodic_function(FFT3D& fft__, Gvec_partition const& gvecp__)
             : fft_(&fft__)
-            , gvec_(&gvec__)
+            , gvecp_(&gvecp__)
         {
             f_rg_       = mdarray<T, 1>(fft_->local_size(), memory_t::host, "Smooth_periodic_function.f_rg_");
-            f_pw_fft_   = mdarray<double_complex, 1>(gvec_->partition().gvec_count_fft(), memory_t::host, "Smooth_periodic_function.f_pw_fft_");
-            f_pw_local_ = mdarray<double_complex, 1>(gvec_->count(), memory_t::host, "Smooth_periodic_function.f_pw_local_");
+            f_pw_fft_   = mdarray<double_complex, 1>(gvecp_->gvec_count_fft(), memory_t::host, "Smooth_periodic_function.f_pw_fft_");
+            f_pw_local_ = mdarray<double_complex, 1>(gvecp_->gvec().count(), memory_t::host, "Smooth_periodic_function.f_pw_local_");
 
             /* check ordering of mpi ranks */
-            int rank = fft_->comm().rank() * gvec_->comm_ortho_fft().size() + gvec_->comm_ortho_fft().rank();
-            if (rank != gvec_->comm().rank()) {
+            int rank = fft_->comm().rank() * gvecp_->comm_ortho_fft().size() + gvecp_->comm_ortho_fft().rank();
+            if (rank != gvecp_->gvec().comm().rank()) {
                 TERMINATE("wrong order of MPI ranks");
             }
 
-            gvec_fft_slab_ = block_data_descriptor(gvec_->comm_ortho_fft().size());
-            for (int i = 0; i < gvec_->comm_ortho_fft().size(); i++) {
-                gvec_fft_slab_.counts[i] = gvec_->gvec_count(fft_->comm().rank() * gvec_->comm_ortho_fft().size() + i);
-            }
-            gvec_fft_slab_.calc_offsets();
+            //gvec_fft_slab_ = block_data_descriptor(gvecp_->comm_ortho_fft().size());
+            //for (int i = 0; i < gvecp_->comm_ortho_fft().size(); i++) {
+            //    gvec_fft_slab_.counts[i] = gvecp_->gvec().gvec_count(fft_->comm().rank() * gvecp_->comm_ortho_fft().size() + i);
+            //}
+            //gvec_fft_slab_.calc_offsets();
         }
 
         inline void zero()
@@ -133,10 +133,10 @@ class Smooth_periodic_function
         inline double_complex f_0() const
         {
             double_complex z;
-            if (gvec_->comm().rank() == 0) {
+            if (gvecp_->gvec().comm().rank() == 0) {
                 z = f_pw_local_(0);
             }
-            gvec_->comm().bcast(&z, 1, 0);
+            gvecp_->gvec().comm().bcast(&z, 1, 0);
             return z;
         }
 
@@ -154,15 +154,20 @@ class Smooth_periodic_function
 
         Gvec const& gvec() const
         {
-            assert(gvec_ != nullptr);
-            return *gvec_;
+            assert(gvecp_ != nullptr);
+            return gvecp_->gvec();
+        }
+
+        Gvec_partition const& gvec_partition() const
+        {
+            return *gvecp_;
         }
 
         void fft_transform(int direction__)
         {
             PROFILE("sirius::Smooth_periodic_function::fft_transform");
 
-            assert(gvec_ != nullptr);
+            assert(gvecp_ != nullptr);
 
             switch (direction__) {
                 case 1: {
@@ -174,8 +179,8 @@ class Smooth_periodic_function
                 case -1: {
                     fft_->input(f_rg_.template at<CPU>());
                     fft_->transform<-1>(f_pw_fft_.at<CPU>());
-                    int count  = gvec_fft_slab_.counts[gvec_->comm_ortho_fft().rank()];
-                    int offset = gvec_fft_slab_.offsets[gvec_->comm_ortho_fft().rank()];
+                    int count  = gvecp_->gvec_fft_slab().counts[gvecp_->comm_ortho_fft().rank()];
+                    int offset = gvecp_->gvec_fft_slab().offsets[gvecp_->comm_ortho_fft().rank()];
                     std::memcpy(f_pw_local_.at<CPU>(), f_pw_fft_.at<CPU>(offset), count * sizeof(double_complex));
                     break;
                 }
@@ -191,15 +196,15 @@ class Smooth_periodic_function
 
             gather_f_pw_fft();
 
-            std::vector<double_complex> fpw(gvec_->num_gvec());
-            fft_->comm().allgather(f_pw_fft_.at<CPU>(), fpw.data(), gvec_->partition().gvec_offset_fft(), gvec_->partition().gvec_count_fft());
+            std::vector<double_complex> fpw(gvecp_->gvec().num_gvec());
+            fft_->comm().allgather(f_pw_fft_.at<CPU>(), fpw.data(), gvecp_->gvec_offset_fft(), gvecp_->gvec_count_fft());
 
             return std::move(fpw);
         }
 
         inline void scatter_f_pw(std::vector<double_complex> const& f_pw__)
         {
-            std::copy(&f_pw__[gvec_->offset()], &f_pw__[gvec_->offset()] + gvec_->count(), &f_pw_local_(0));
+            std::copy(&f_pw__[gvecp_->gvec().offset()], &f_pw__[gvecp_->gvec().offset()] + gvecp_->gvec().count(), &f_pw_local_(0));
         }
 
         void add(Smooth_periodic_function<T> const& g__)
@@ -238,7 +243,7 @@ class Smooth_periodic_function
                 #pragma omp critical
                 result_rg += rt;
             }
-            double omega = std::pow(twopi, 3) / std::abs(this->gvec_->lattice_vectors().det());
+            double omega = std::pow(twopi, 3) / std::abs(this->gvec().lattice_vectors().det());
 
             result_rg *= (omega / this->fft_->size());
 
@@ -250,11 +255,11 @@ class Smooth_periodic_function
         inline uint64_t hash_f_pw() const
         {
             auto h = f_pw_local_.hash();
-            gvec_->comm().bcast(&h, 1, 0);
+            gvecp_->gvec().comm().bcast(&h, 1, 0);
 
-            for (int r = 1; r < gvec_->comm().size(); r++) {
+            for (int r = 1; r < gvecp_->gvec().comm().size(); r++) {
                 h = f_pw_local_.hash(h);
-                gvec_->comm().bcast(&h, 1, r);
+                gvecp_->gvec().comm().bcast(&h, 1, r);
             }
             return h;
         }
@@ -282,7 +287,7 @@ class Smooth_periodic_function_gradient
         FFT3D* fft_{nullptr};
 
         /// Distribution of G-vectors.
-        Gvec const* gvec_{nullptr};
+        Gvec_partition const* gvecp_{nullptr};
 
         std::array<Smooth_periodic_function<T>, 3> grad_f_;
 
@@ -292,12 +297,12 @@ class Smooth_periodic_function_gradient
         {
         }
 
-        Smooth_periodic_function_gradient(FFT3D& fft__, Gvec const& gvec__)
+        Smooth_periodic_function_gradient(FFT3D& fft__, Gvec_partition const& gvecp__)
             : fft_(&fft__)
-            , gvec_(&gvec__)
+            , gvecp_(&gvecp__)
         {
             for (int x: {0, 1, 2}) {
-                grad_f_[x] = Smooth_periodic_function<T>(fft__, gvec__);
+                grad_f_[x] = Smooth_periodic_function<T>(fft__, gvecp__);
             }
         }
 
@@ -312,17 +317,17 @@ class Smooth_periodic_function_gradient
             return *fft_;
         }
 
-        Gvec const& gvec() const
+        Gvec_partition const& gvec_partition() const
         {
-            assert(gvec_ != nullptr);
-            return *gvec_;
+            assert(gvecp_ != nullptr);
+            return *gvecp_;
         }
 };
 
 /// Gradient of the function in the plane-wave domain.
 inline Smooth_periodic_function_gradient<double> gradient(Smooth_periodic_function<double>& f__)
 {
-    Smooth_periodic_function_gradient<double> g(f__.fft(), f__.gvec());
+    Smooth_periodic_function_gradient<double> g(f__.fft(), f__.gvec_partition());
 
     #pragma omp parallel for schedule(static)
     for (int igloc = 0; igloc < f__.gvec().count(); igloc++) {
@@ -338,7 +343,7 @@ inline Smooth_periodic_function_gradient<double> gradient(Smooth_periodic_functi
 /// Laplacian of the function in the plane-wave domain.
 inline Smooth_periodic_function<double> laplacian(Smooth_periodic_function<double>& f__)
 {
-    Smooth_periodic_function<double> g(f__.fft(), f__.gvec());
+    Smooth_periodic_function<double> g(f__.fft(), f__.gvec_partition());
 
     #pragma omp parallel for schedule(static)
     for (int igloc = 0; igloc < f__.gvec().count(); igloc++) {
@@ -356,9 +361,9 @@ inline Smooth_periodic_function<T> dot(Smooth_periodic_function_gradient<T>& gra
 
 {
     assert(&grad_f__.fft() == &grad_g__.fft());
-    assert(&grad_f__.gvec() == &grad_g__.gvec());
+    assert(&grad_f__.gvec_partition() == &grad_g__.gvec_partition());
 
-    Smooth_periodic_function<T> result(grad_f__.fft(), grad_f__.gvec());
+    Smooth_periodic_function<T> result(grad_f__.fft(), grad_f__.gvec_partition());
 
     #pragma omp parallel for schedule(static)
     for (int ir = 0; ir < grad_f__.fft().local_size(); ir++) {

--- a/src/step_function.h
+++ b/src/step_function.h
@@ -101,7 +101,7 @@ class Step_function
             }
             step_function_pw_[0] += 1.0;
             
-            ctx__.fft().transform<1>(&step_function_pw_[ctx__.gvec().partition().gvec_offset_fft()]);
+            ctx__.fft().transform<1>(&step_function_pw_[ctx__.gvec_partition().gvec_offset_fft()]);
             ctx__.fft().output(&step_function_[0]);
             
             double vit{0};


### PR DESCRIPTION
G-vector partition describes how plane-wave coefficients must be redistributed for the FFT. For each G-vector class one or several G-vector partitions may exist.