### PR TITLE
Develop

### DIFF
--- a/apps/dft_loop/sirius.scf.cpp
+++ b/apps/dft_loop/sirius.scf.cpp
@@ -263,6 +263,7 @@ void run_tasks(cmd_args const& args)
             band.initialize_subspace(ks, H);
             if (ctx->hubbard_correction()) {
                 H.U().hubbard_compute_occupation_numbers(ks);
+                H.U().calculate_hubbard_potential_and_energy();
             }
         }
         band.solve_for_kset(ks, H, true);

--- a/src/Hubbard/apply_hubbard_potential.hpp
+++ b/src/Hubbard/apply_hubbard_potential.hpp
@@ -13,6 +13,12 @@ void apply_hubbard_potential(K_point& kp,
     // First calculate the local part of the projections
     // dm(i, n)  = <phi_i | psi_{nk}>
 
+
+    // for colinear magnetism the wavefunctions of the up and down block
+    // are stored in the up and down part of the "spinor" so we
+    // calculate Overlap ^ up = <phi_i^up | phi_j^up> stored in the
+    // first half of dm the down part in the other half
+
     int Nfc = 1;
     if (ctx_.num_mag_dims() == 1)
         Nfc *= 2;
@@ -35,22 +41,10 @@ void apply_hubbard_potential(K_point& kp,
               0,
               0);
     } else {
-        inner(ctx_.processing_unit(),
-              0,
-              hub_wf,
-              0,
-              this->number_of_hubbard_orbitals(),
-              phi,
-              idx__,
-              n__,
-              dm,
-              0,
-              0);
-
-        // colinear case
-        if (ctx_.num_spins() == 2) {
+        // compute the overlaps
+        for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
             inner(ctx_.processing_unit(),
-                  1,
+                  ispn,
                   hub_wf,
                   0,
                   this->number_of_hubbard_orbitals(),
@@ -59,10 +53,9 @@ void apply_hubbard_potential(K_point& kp,
                   n__,
                   dm,
                   0,
-                  n__);
+                  ispn * n__);
         }
     }
-
 
     for (int ia = 0; ia < ctx_.unit_cell().num_atoms(); ++ia) {
         const auto& atom = ctx_.unit_cell().atom(ia);
@@ -74,26 +67,43 @@ void apply_hubbard_potential(K_point& kp,
             if (ctx_.num_mag_dims() == 3) {
                 dmatrix<double_complex> Up(lmax_at * ctx_.num_spins(), n__);
                 Up.zero();
-#pragma omp parallel for
-                for (int nbnd = 0; nbnd < n__; nbnd++) {
-                    for (int s1 = 0; s1 < ctx_.num_spins(); s1++) {
-                        for (int m1 = 0; m1 < lmax_at; m1++) {
-                            double_complex temp = linalg_const<double_complex>::zero();
-
-                            // computes \f[
-                            // \sum_{\sigma,m} V^{\sigma\sigma'}_{m,m'} \left<\phi_m^\sigma|\Psi_{nk}\right>
-                            // \f]
-                            for (int s2 = 0; s2 < ctx_.num_spins(); s2++) {
-                                const int ind = (s1 == s2) * s1 + (1 + 2 * s2 + s1) * (s1 != s2);
-                                for (int m2 = 0; m2 < lmax_at; m2++) {
-                                    temp += this->hubbard_potential_(m1, m2, ind, ia, 0) *
-                                        dm(this->offset[ia] + s2 * lmax_at + m2, nbnd);
-                                }
-                            }
-                            Up(s1 * lmax_at + m1, nbnd) = temp;
-                        }
+                for (int s1 = 0; s1 < ctx_.num_spins(); s1++) {
+                    for (int s2 = 0; s2 < ctx_.num_spins(); s2++) {
+                        const int ind = (s1 == s2) * s1 + (1 + 2 * s2 + s1) * (s1 != s2);
+                        linalg<ctx_.processing_unit()>::gemm(0, 0,
+                                                             lmax_at,
+                                                             n__,
+                                                             lmax_at,
+                                                             linalg_const<double_complex>::one(),
+                                                             this->hubbard_potential_.template at<CPU>(0, 0, ind, ia, 0),
+                                                             this->hubbard_potential_.ld(),
+                                                             dm.template at<ctx_.processing_unit()>(this->offset[ia] + s2 * lmax_at, 0),
+                                                             dm.ld(),
+                                                             linalg_const<double_complex>::one(),
+                                                             Up.template at<ctx_.processing_unit()>(s1 * lmax_at, 0), Up.ld());
                     }
                 }
+
+// #pragma omp parallel for
+//                 for (int nbnd = 0; nbnd < n__; nbnd++) {
+//                     for (int s1 = 0; s1 < ctx_.num_spins(); s1++) {
+//                         for (int m1 = 0; m1 < lmax_at; m1++) {
+//                             double_complex temp = linalg_const<double_complex>::zero();
+
+//                             // computes \f[
+//                             // \sum_{\sigma,m} V^{\sigma\sigma'}_{m,m'} \left<\phi_m^\sigma|\Psi_{nk}\right>
+//                             // \f]
+//                             for (int s2 = 0; s2 < ctx_.num_spins(); s2++) {
+//                                 const int ind = (s1 == s2) * s1 + (1 + 2 * s2 + s1) * (s1 != s2);
+//                                 for (int m2 = 0; m2 < lmax_at; m2++) {
+//                                     temp += this->hubbard_potential_(m1, m2, ind, ia, 0) *
+//                                         dm(this->offset[ia] + s2 * lmax_at + m2, nbnd);
+//                                 }
+//                             }
+//                             Up(s1 * lmax_at + m1, nbnd) = temp;
+//                         }
+//                     }
+//                 }
 
                 transform<double_complex>(ctx_.processing_unit(),
                                           2,
@@ -111,8 +121,9 @@ void apply_hubbard_potential(K_point& kp,
             } else {
                 //Conventional LDA or colinear magnetism
                 dmatrix<double_complex> Up(lmax_at, n__);
-                Up.zero();
                 for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
+                    Up.zero();
+
 #pragma omp parallel for
                     for (int nbnd = 0; nbnd < n__; nbnd++) {
                         for (int m1 = 0; m1 < lmax_at; m1++) {

--- a/src/Hubbard/apply_hubbard_potential.hpp
+++ b/src/Hubbard/apply_hubbard_potential.hpp
@@ -13,8 +13,12 @@ void apply_hubbard_potential(K_point& kp,
     // First calculate the local part of the projections
     // dm(i, n)  = <phi_i | psi_{nk}>
 
+    int Nfc = 1;
+    if (ctx_.num_mag_dims() == 1)
+        Nfc *= 2;
+
     dmatrix<double_complex> dm(this->number_of_hubbard_orbitals(),
-                               n__);
+                               n__ * Nfc);
 
     dm.zero();
 
@@ -32,7 +36,7 @@ void apply_hubbard_potential(K_point& kp,
               0);
     } else {
         inner(ctx_.processing_unit(),
-              ctx_.num_spins() - 1,
+              0,
               hub_wf,
               0,
               this->number_of_hubbard_orbitals(),
@@ -42,6 +46,21 @@ void apply_hubbard_potential(K_point& kp,
               dm,
               0,
               0);
+
+        // colinear case
+        if (ctx_.num_spins() == 2) {
+            inner(ctx_.processing_unit(),
+                  1,
+                  hub_wf,
+                  0,
+                  this->number_of_hubbard_orbitals(),
+                  phi,
+                  idx__,
+                  n__,
+                  dm,
+                  0,
+                  n__);
+        }
     }
 
 
@@ -49,33 +68,33 @@ void apply_hubbard_potential(K_point& kp,
         const auto& atom = ctx_.unit_cell().atom(ia);
         const int lmax_at = 2 * atom.type().hubbard_l() + 1;
         if (atom.type().hubbard_correction()) {
-            dmatrix<double_complex> Up(lmax_at * ctx_.num_spins(), n__);
-            Up.zero();
             // we apply the hubbard correction. For now I have no papers
             // giving me the formula for the SO case so I rely on QE for it
             // but I do not like it at all
-            #pragma omp parallel for
-            for (int nbnd = 0; nbnd < n__; nbnd++) {
-                for (int s1 = 0; s1 < ctx_.num_spins(); s1++) {
-                    for (int m1 = 0; m1 < lmax_at; m1++) {
-                        double_complex temp = linalg_const<double_complex>::zero();
+            if (ctx_.num_mag_dims() == 3) {
+                dmatrix<double_complex> Up(lmax_at * ctx_.num_spins(), n__);
+                Up.zero();
+#pragma omp parallel for
+                for (int nbnd = 0; nbnd < n__; nbnd++) {
+                    for (int s1 = 0; s1 < ctx_.num_spins(); s1++) {
+                        for (int m1 = 0; m1 < lmax_at; m1++) {
+                            double_complex temp = linalg_const<double_complex>::zero();
 
-                        // computes \f[
-                        // \sum_{\sigma,m} V^{\sigma\sigma'}_{m,m'} \left<\phi_m^\sigma|\Psi_{nk}\right>
-                        // \f]
-                        for (int s2 = 0; s2 < ctx_.num_spins(); s2++) {
-                            const int ind = (s1 == s2) * s1 + (1 + 2 * s2 + s1) * (s1 != s2);
-                            for (int m2 = 0; m2 < lmax_at; m2++) {
-                                temp += this->hubbard_potential_(m1, m2, ind, ia, 0) *
+                            // computes \f[
+                            // \sum_{\sigma,m} V^{\sigma\sigma'}_{m,m'} \left<\phi_m^\sigma|\Psi_{nk}\right>
+                            // \f]
+                            for (int s2 = 0; s2 < ctx_.num_spins(); s2++) {
+                                const int ind = (s1 == s2) * s1 + (1 + 2 * s2 + s1) * (s1 != s2);
+                                for (int m2 = 0; m2 < lmax_at; m2++) {
+                                    temp += this->hubbard_potential_(m1, m2, ind, ia, 0) *
                                         dm(this->offset[ia] + s2 * lmax_at + m2, nbnd);
+                                }
                             }
+                            Up(s1 * lmax_at + m1, nbnd) = temp;
                         }
-                        Up(s1 * lmax_at + m1, nbnd) = temp;
                     }
                 }
-            }
 
-            if(ctx_.num_mag_dims() == 3) {
                 transform<double_complex>(ctx_.processing_unit(),
                                           2,
                                           1.0,
@@ -90,19 +109,39 @@ void apply_hubbard_potential(K_point& kp,
                                           idx__,
                                           n__);
             } else {
-                transform<double_complex>(ctx_.processing_unit(),
-                                          ctx_.num_spins() - 1,
-                                          1.0,
-                                          hub_wf,
-                                          this->offset[ia],
-                                          lmax_at,
-                                          Up,
-                                          0,
-                                          0,
-                                          1.0,
-                                          ophi,
-                                          idx__,
-                                          n__);
+                //Conventional LDA or colinear magnetism
+                dmatrix<double_complex> Up(lmax_at, n__);
+                Up.zero();
+                for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
+#pragma omp parallel for
+                    for (int nbnd = 0; nbnd < n__; nbnd++) {
+                        for (int m1 = 0; m1 < lmax_at; m1++) {
+                            double_complex temp = linalg_const<double_complex>::zero();
+
+                            // computes \f[
+                            // \sum_{\sigma,m} V^{\sigma\sigma'}_{m,m'} \left<\phi_m^\sigma|\Psi_{nk}\right>
+                            // \f]
+                            for (int m2 = 0; m2 < lmax_at; m2++) {
+                                    temp += this->hubbard_potential_(m1, m2, ispn, ia, 0) *
+                                        dm(this->offset[ia] + m2, nbnd + ispn * n__);
+                            }
+                            Up(m1, nbnd) = temp;
+                        }
+                    }
+                    transform<double_complex>(ctx_.processing_unit(),
+                                              ispn,
+                                              1.0,
+                                              hub_wf,
+                                              this->offset[ia],
+                                              lmax_at,
+                                              Up,
+                                              0,
+                                              0,
+                                              1.0,
+                                              ophi,
+                                              idx__,
+                                              n__);
+                }
             }
         }
     }

--- a/src/Hubbard/hubbard_generate_atomic_orbitals.hpp
+++ b/src/Hubbard/hubbard_generate_atomic_orbitals.hpp
@@ -133,27 +133,19 @@ void generate_atomic_orbitals(K_point& kp, Q_operator<double_complex>& q_op)
             /* generate beta-projectors for a block of atoms */
             kp.beta_projectors().generate(i);
             /* non-collinear case */
-            if (ctx_.num_mag_dims() == 3) {
-                for (int ispn = 0; ispn < 2; ispn++) {
+            for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
 
-                    auto beta_phi = kp.beta_projectors().inner<double_complex>(i, sphi, ispn, 0,
-                                                                               this->number_of_hubbard_orbitals());
+              auto beta_phi = kp.beta_projectors().inner<double_complex>(i, sphi, ispn, 0,
+                                                                         this->number_of_hubbard_orbitals());
 
-                    /* apply Q operator (diagonal in spin) */
-                    q_op.apply(i, ispn, kp.hubbard_wave_functions(), 0, this->number_of_hubbard_orbitals(), kp.beta_projectors(),
-                               beta_phi);
-                    /* apply non-diagonal spin blocks */
-                    if (ctx_.so_correction()) {
-                        q_op.apply(i, ispn ^ 3, kp.hubbard_wave_functions(), 0, this->number_of_hubbard_orbitals(), kp.beta_projectors(),
-                                   beta_phi);
-                    }
-
-                }
-            } else { /* non-magnetic or collinear case */
-                auto beta_phi = kp.beta_projectors().inner<double_complex>(i, kp.hubbard_wave_functions(), 0, 0,
-                                                                           this->number_of_hubbard_orbitals());
-
-                q_op.apply(i, 0, kp.hubbard_wave_functions(), 0, this->number_of_hubbard_orbitals(), kp.beta_projectors(), beta_phi);
+              /* apply Q operator (diagonal in spin) */
+              q_op.apply(i, ispn, kp.hubbard_wave_functions(), 0, this->number_of_hubbard_orbitals(), kp.beta_projectors(),
+                         beta_phi);
+              /* apply non-diagonal spin blocks */
+              if (ctx_.so_correction()) {
+                q_op.apply(i, ispn ^ 3, kp.hubbard_wave_functions(), 0, this->number_of_hubbard_orbitals(), kp.beta_projectors(),
+                           beta_phi);
+              }
             }
         }
         kp.beta_projectors().dismiss();
@@ -179,7 +171,7 @@ void generate_atomic_orbitals(K_point& kp, Q_operator<double_complex>& q_op)
           // colinear case because the up and down components are
           // identical
             inner<double_complex>(ctx_.processing_unit(),
-                                  ctx_.num_spins() - 1,
+                                  0,
                                   kp.hubbard_wave_functions(),
                                   0,
                                   this->number_of_hubbard_orbitals(),

--- a/src/Hubbard/hubbard_occupancy.hpp
+++ b/src/Hubbard/hubbard_occupancy.hpp
@@ -21,29 +21,36 @@ void hubbard_compute_occupation_numbers(K_point_set& kset_)
 
         // now for each spin components and each atom we need to calculate
         // <psi_{nk}|phi^I_m'><phi^I_m|psi_{nk}>
+        dmatrix<double_complex> dm(this->number_of_hubbard_orbitals(),
+                                   kp->num_occupied_bands(0));
 
-        mdarray<double_complex, 2> dm = kp->hubbard_wave_functions().overlap<double_complex>(ctx_.processing_unit(),
-                                                                                             kp->spinor_wave_functions(),
-                                                                                             0,
-                                                                                             this->number_of_hubbard_orbitals(),
-                                                                                             0,
-                                                                                             kp->num_occupied_bands());
+        dm.zero();
 
-        // for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
-        //     /* compute <phi_{i,\sigma}|psi_nk> the bands been distributed over the pool */
-        //     linalg<CPU>::gemm(2, 0,
-        //                       this->number_of_hubbard_orbitals(),
-        //                       kp->num_occupied_bands(),
-        //                       kp->hubbard_wave_functions().pw_coeffs(ispn).num_rows_loc(),
-        //                       linalg_const<double_complex>::one(),
-        //                       kp->hubbard_wave_functions().pw_coeffs(ispn).prime().at<CPU>(0, 0),
-        //                       kp->hubbard_wave_functions().pw_coeffs(ispn).prime().ld(),
-        //                       kp->spinor_wave_functions().pw_coeffs(ispn).prime().at<CPU>(0, 0),
-        //                       kp->spinor_wave_functions().pw_coeffs(ispn).prime().ld(),
-        //                       linalg_const<double_complex>::one(),
-        //                       dm.at<CPU>(0, 0),
-        //                       dm.ld());
-        // }
+        if (ctx_.num_mag_dims() == 3) {
+            inner(ctx_.processing_unit(),
+                  2,
+                  kp->hubbard_wave_functions(),
+                  0,
+                  this->number_of_hubbard_orbitals(),
+                  kp->spinor_wave_functions(),
+                  0,
+                  kp->num_occupied_bands(),
+                  dm,
+                  0,
+                  0);
+        } else {
+            inner(ctx_.processing_unit(),
+                  ctx_.num_spins() - 1,
+                  kp->hubbard_wave_functions(),
+                  0,
+                  this->number_of_hubbard_orbitals(),
+                  kp->spinor_wave_functions(),
+                  0,
+                  kp->num_occupied_bands(0),
+                  dm,
+                  0,
+                  0);
+        }
 
         // now compute O_{ij}^{sigma,sigma'} = \sum_{nk} <psi_nk|phi_{i,sigma}><phi_{j,sigma^'}|psi_nk> f_{nk}
 
@@ -51,17 +58,18 @@ void hubbard_compute_occupation_numbers(K_point_set& kset_)
         #pragma omp parallel for schedule(static)
         for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
             const auto& atom = unit_cell_.atom(ia);
+            const int lmax_at = 2 * atom.type().hubbard_l() + 1;
             if (atom.type().hubbard_correction()) {
                 for (int s1 = 0; s1 < ctx_.num_spins(); s1++) {
                     for (int s2 = 0; s2 < ctx_.num_spins(); s2++) {
                         int s = (s1 == s2) * s1 + (s1 != s2) * (1 + 2 * s2 + s1);
-                        for (int nband = 0; nband < kp->num_occupied_bands(); nband++) {
-                            for (int m = 0; m < 2 * atom.type().hubbard_l() + 1; m++) {
-                                for (int mp = 0; mp < 2 * atom.type().hubbard_l() + 1; mp++) {
+                        for (int nband = 0; nband < kp->num_occupied_bands(0); nband++) {
+                            for (int m = 0; m < lmax_at; m++) {
+                                for (int mp = 0; mp < lmax_at; mp++) {
                                     this->occupancy_number_(m, mp, s, ia, 0) +=
                                         std::conj(
-                                            dm(this->offset[ia] + m + s1 * (2 * atom.type().hubbard_l() + 1), nband)) *
-                                        dm(this->offset[ia] + mp + s2 * (2 * atom.type().hubbard_l() + 1), nband) *
+                                            dm(this->offset[ia] + m + s1 * lmax_at, nband)) *
+                                        dm(this->offset[ia] + mp + s2 * lmax_at, nband) *
                                         kp->band_occupancy(nband) * kp->weight();
                                 }
                             }
@@ -76,7 +84,7 @@ void hubbard_compute_occupation_numbers(K_point_set& kset_)
                                                          static_cast<int>(this->occupancy_number_.size()));
 
     // Now symmetrization procedure
-    if (ctx_.use_symmetry()) {
+    if (0) {
         auto& sym = unit_cell_.symmetry();
 
         // check if we have some symmetries
@@ -101,10 +109,11 @@ void hubbard_compute_occupation_numbers(K_point_set& kset_)
                 #pragma omp parallel for schedule(static)
                 for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
                     const auto& atom = unit_cell_.atom(ia);
+                    const int lmax_at = 2 * atom.type().hubbard_l() + 1;
                     if (atom.type().hubbard_correction()) {
-                        for (int ii = 0; ii < 2 * atom.type().hubbard_l() + 1; ii++) {
+                        for (int ii = 0; ii < lmax_at; ii++) {
                             int l1 = Utils::lm_by_l_m(atom.type().hubbard_l(), ii - atom.type().hubbard_l());
-                            for (int ll = 0; ll < 2 * atom.type().hubbard_l() + 1; ll++) {
+                            for (int ll = 0; ll < lmax_at; ll++) {
                                 int l2 = Utils::lm_by_l_m(atom.type().hubbard_l(), ll - atom.type().hubbard_l());
                                 mdarray<double_complex, 1> rot_spa(ctx_.num_spins() * ctx_.num_spins());
                                 rot_spa.zero();
@@ -113,10 +122,10 @@ void hubbard_compute_occupation_numbers(K_point_set& kset_)
                                         // symmetrization procedure
                                         // A_ij B_jk C_kl
 
-                                        for (int jj = 0; jj < 2 * atom.type().hubbard_l() + 1; jj++) {
+                                        for (int jj = 0; jj < lmax_at; jj++) {
                                             int l3 =
                                                 Utils::lm_by_l_m(atom.type().hubbard_l(), jj - atom.type().hubbard_l());
-                                            for (int kk = 0; kk < 2 * atom.type().hubbard_l() + 1; kk++) {
+                                            for (int kk = 0; kk < lmax_at; kk++) {
                                                 int l4 = Utils::lm_by_l_m(atom.type().hubbard_l(),
                                                                           kk - atom.type().hubbard_l());
                                                 rot_spa(2 * s1 + s2) +=
@@ -160,9 +169,10 @@ void hubbard_compute_occupation_numbers(K_point_set& kset_)
 
             for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
                 auto& atom = unit_cell_.atom(ia);
+                const int lmax_at = 2 * atom.type().hubbard_l() + 1;
                 if (atom.type().hubbard_correction()) {
-                    for (int ii = 0; ii < 2 * atom.type().hubbard_l() + 1; ii++) {
-                        for (int ll = 0; ll < 2 * atom.type().hubbard_l() + 1; ll++) {
+                    for (int ii = 0; ii < lmax_at; ii++) {
+                        for (int ll = 0; ll < lmax_at; ll++) {
                             for (int s = 0; s < ctx_.num_spins() * ctx_.num_spins(); s++) {
                                 this->occupancy_number_(ii, ll, s, ia, 0) = rotated_oc(ii, ll, s, ia);
                             }
@@ -175,11 +185,12 @@ void hubbard_compute_occupation_numbers(K_point_set& kset_)
 
     for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
         const auto& atom = unit_cell_.atom(ia);
+        const int lmax_at = 2 * atom.type().hubbard_l() + 1;
         if (atom.type().hubbard_correction()) {
             for (int s1 = 0; s1 < ctx_.num_spins(); s1++) {
                 // diagonal blocks
-                for (int m = 0; m < (2 * atom.type().hubbard_l() + 1); m++) {
-                    for (int mp = m + 1; mp < (2 * atom.type().hubbard_l() + 1); mp++) {
+                for (int m = 0; m < lmax_at; m++) {
+                    for (int mp = m + 1; mp < lmax_at; mp++) {
                         this->occupancy_number_(mp, m, s1, ia, 0) = std::conj(this->occupancy_number_(m, mp, s1, ia, 0));
                     }
                 }
@@ -187,8 +198,8 @@ void hubbard_compute_occupation_numbers(K_point_set& kset_)
 
             if (ctx_.num_mag_dims() == 3) {
                 // off diagonal blocks
-                for (int m = 0; m < (2 * atom.type().hubbard_l() + 1); m++) {
-                    for (int mp = m + 1; mp < (2 * atom.type().hubbard_l() + 1); mp++) {
+                for (int m = 0; m < lmax_at; m++) {
+                    for (int mp = m + 1; mp < lmax_at; mp++) {
                         this->occupancy_number_(mp, m, 2, ia, 0) = std::conj(this->occupancy_number_(m, mp, 3, ia, 0));
                     }
                 }
@@ -196,72 +207,7 @@ void hubbard_compute_occupation_numbers(K_point_set& kset_)
         }
     }
 
-    if (ctx_.control().verbosity_ > 1) {
-        if (ctx_.comm().rank() == 0) {
-            printf("\n");
-            printf("hubbard occupancies\n");
-            printf("----------------------------------------------------------------------\n");
-            for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
-                printf("Atom : %d\n", ia);
-                const auto& atom = unit_cell_.atom(ia);
-                if (atom.type().hubbard_correction()) {
-                    for (int m1 = 0; m1 < 2 * atom.type().hubbard_l() + 1; m1++) {
-                        for (int m2 = 0; m2 < 2 * atom.type().hubbard_l() + 1; m2++) {
-                            printf("%.3lf %.3lf ", this->occupancy_number_(m1, m2, 0, ia, 0).real(),
-                                   this->occupancy_number_(m1, m2, 0, ia, 0).imag());
-                        }
-
-                        if (ctx_.num_mag_dims() == 3) {
-                            printf(" ");
-                            for (int m2 = 0; m2 < 2 * atom.type().hubbard_l() + 1; m2++) {
-                                printf("%.3lf %.3lf ", this->occupancy_number_(m1, m2, 2, ia, 0).real(),
-                                       this->occupancy_number_(m1, m2, 2, ia, 0).imag());
-                            }
-                        }
-                        printf("\n");
-                    }
-                    if (ctx_.num_spins() == 2) {
-                        for (int m1 = 0; m1 < 2 * atom.type().hubbard_l() + 1; m1++) {
-                            for (int m2 = 0; m2 < 2 * atom.type().hubbard_l() + 1; m2++) {
-                                printf("%.3lf %.3lf ", this->occupancy_number_(m1, m2, 3, ia, 0).real(),
-                                       this->occupancy_number_(m1, m2, 3, ia, 0).imag());
-                            }
-                            if (ctx_.num_mag_dims() == 3) {
-                                printf(" ");
-                                for (int m2 = 0; m2 < 2 * atom.type().hubbard_l() + 1; m2++) {
-                                    printf("%.3lf %.3lf ", this->occupancy_number_(m1, m2, 1, ia, 0).real(),
-                                           this->occupancy_number_(m1, m2, 1, ia, 0).imag());
-                                }
-                            }
-                            printf("\n");
-                        }
-                    }
-
-                    double n_up, n_down, n_total;
-                    n_up   = 0.0;
-                    n_down = 0.0;
-                    for (int m1 = 0; m1 < 2 * atom.type().hubbard_l() + 1; m1++) {
-                        n_up += this->occupancy_number_(m1, m1, 0, ia, 0).real();
-                    }
-
-                    if (ctx_.num_spins() == 2) {
-                        for (int m1 = 0; m1 < 2 * atom.type().hubbard_l() + 1; m1++) {
-                            n_down += this->occupancy_number_(m1, m1, 1, ia, 0).real();
-                        }
-                    }
-                    printf("\n");
-                    n_total = n_up + n_down;
-                    if (ctx_.num_spins() == 2) {
-                        printf("Atom charge (total) %.5lf (n_up) %.5lf (n_down) %.5lf (mz) %.5lf\n", n_total, n_up,
-                               n_down, n_up - n_down);
-                    } else {
-                        printf("Atom charge (total) %.5lf\n", n_total);
-                    }
-                }
-            }
-            printf("-------------------------------------------------------------\n");
-        }
-    }
+    print_occupancies();
 }
 
 // The initial occupancy is calculated following Hund rules. We first
@@ -275,6 +221,7 @@ void calculate_initial_occupation_numbers()
 #pragma omp parallel for schedule(static)
     for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
         const auto& atom = unit_cell_.atom(ia);
+        const int lmax_at = 2 * atom.type().hubbard_l() + 1;
         if (atom.type().hubbard_correction()) {
 
             // compute the total charge for the hubbard orbitals
@@ -298,17 +245,17 @@ void calculate_initial_occupation_numbers()
                 if (ctx_.num_mag_dims() != 3) {
                     // colinear case
 
-                    if (charge > (2 * atom.type().hubbard_l() + 1)) {
-                        for (int m = 0; m < 2 * atom.type().hubbard_l() + 1; m++) {
+                    if (charge > (lmax_at)) {
+                        for (int m = 0; m < lmax_at; m++) {
                             this->occupancy_number_(m, m, majs, ia, 0) = 1.0;
                             this->occupancy_number_(m, m, mins, ia, 0) =
-                                (charge - static_cast<double>(2 * atom.type().hubbard_l() + 1)) /
-                                static_cast<double>(2 * atom.type().hubbard_l() + 1);
+                                (charge - static_cast<double>(lmax_at)) /
+                                static_cast<double>(lmax_at);
                         }
                     } else {
-                        for (int m = 0; m < 2 * atom.type().hubbard_l() + 1; m++) {
+                        for (int m = 0; m < lmax_at; m++) {
                             this->occupancy_number_(m, m, majs, ia, 0) =
-                                charge / static_cast<double>(2 * atom.type().hubbard_l() + 1);
+                                charge / static_cast<double>(lmax_at);
                         }
                     }
                 } else {
@@ -319,12 +266,12 @@ void calculate_initial_occupation_numbers()
                         double_complex(cos(atom.type().starting_magnetization_phi()), sin(atom.type().starting_magnetization_phi()));
                     double_complex ns[4];
 
-                    if (charge > (2 * atom.type().hubbard_l() + 1)) {
+                    if (charge > (lmax_at)) {
                         ns[majs] = 1.0;
-                        ns[mins] = (charge - static_cast<double>(2 * atom.type().hubbard_l() + 1)) /
-                                   static_cast<double>(2 * atom.type().hubbard_l() + 1);
+                        ns[mins] = (charge - static_cast<double>(lmax_at)) /
+                                   static_cast<double>(lmax_at);
                     } else {
-                        ns[majs] = charge / static_cast<double>(2 * atom.type().hubbard_l() + 1);
+                        ns[majs] = charge / static_cast<double>(lmax_at);
                         ns[mins] = 0.0;
                     }
 
@@ -338,7 +285,7 @@ void calculate_initial_occupation_numbers()
                     ns[2] = mag * std::conj(cs) * 0.5;
                     ns[3] = mag * cs * 0.5;
 
-                    for (int m = 0; m < 2 * atom.type().hubbard_l() + 1; m++) {
+                    for (int m = 0; m < lmax_at; m++) {
                         this->occupancy_number_(m, m, 0, ia, 0) = ns[0];
                         this->occupancy_number_(m, m, 1, ia, 0) = ns[1];
                         this->occupancy_number_(m, m, 2, ia, 0) = ns[2];
@@ -347,69 +294,151 @@ void calculate_initial_occupation_numbers()
                 }
             } else {
                 for (int s = 0; s < ctx_.num_spins(); s++) {
-                    for (int m = 0; m < 2 * atom.type().hubbard_l() + 1; m++) {
+                    for (int m = 0; m < lmax_at; m++) {
                         this->occupancy_number_(m, m, s, ia, 0) =
-                            charge * 0.5 / static_cast<double>(2 * atom.type().hubbard_l() + 1);
+                            charge * 0.5 / static_cast<double>(lmax_at);
                     }
                 }
             }
         }
     }
 
+    print_occupancies();
+}
+
+
+inline int natural_lm_to_qe(int m, int l)
+{
+    return (m > 0) ? 2 * m - 1 : -2 * m;
+}
+
+inline void set_hubbard_occupancies_matrix(double *occ, int ld)
+{
+    mdarray<double, 4> occupation_(occ, ld, ld, ctx_.num_spins(), ctx_.unit_cell().num_atoms());
+
+    for(int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
+        const int l = ctx_.unit_cell().atom(ia).type().hubbard_l();
+        for (int m1 = -l; m1 <= l; m1++) {
+            const int mm1 = natural_lm_to_qe(m1, l);
+            for (int m2 = -l; m2 <= l ; m2++) {
+                const int mm2 = natural_lm_to_qe(m2, l);
+                for(int s = 0; s < ctx_.num_spins(); s++) {
+                    this->occupancy_number_(l + m1, l + m2, s, ia, 0) = occupation_(mm1, mm2, s, ia);
+                }
+            }
+        }
+    }
+}
+
+inline void set_hubbard_occupancies_matrix_nc(double_complex *occ, int ld)
+{
+    mdarray<double_complex, 4> occupation_(occ, ld, ld, 4, ctx_.unit_cell().num_atoms());
+
+    for(int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
+        const int l = ctx_.unit_cell().atom(ia).type().hubbard_l();
+        for (int m1 = -l; m1 <= -l; m1++) {
+            const int mm1 = natural_lm_to_qe(m1, l);
+            for (int m2 = -l; m2 <= l; m2++) {
+                const int mm2 = natural_lm_to_qe(m2, l);
+                this->occupancy_number_(l + m1, l + m2, 0, ia, 0) = occupation_(mm1, mm2, 0, ia);
+                this->occupancy_number_(l + m1, l + m2, 1, ia, 0) = occupation_(mm1, mm2, 3, ia);
+                this->occupancy_number_(l + m1, l + m2, 2, ia, 0) = occupation_(mm1, mm2, 1, ia);
+                this->occupancy_number_(l + m1, l + m2, 3, ia, 0) = occupation_(mm1, mm2, 2, ia);
+            }
+        }
+    }
+}
+
+inline void get_hubbard_occupancies_matrix(double *occ, int ld)
+{
+    mdarray<double, 4> occupation_(occ, ld, ld, ctx_.num_spins(), ctx_.unit_cell().num_atoms());
+
+    for(int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
+        const int l = ctx_.unit_cell().atom(ia).type().hubbard_l();
+        for (int m1 = -l; m1 <= l; m1++) {
+            const int mm1 = natural_lm_to_qe(m1, l);
+            for (int m2 = -l; m2 <= l; m2++) {
+                const int mm2 = natural_lm_to_qe(m2, l);
+                for (int s = 0; s < ctx_.num_spins(); s++) {
+                        occupation_(mm1, mm2, s, ia) = this->occupancy_number_(l + m1, l + m2, s, ia, 0).real();
+                }
+            }
+        }
+    }
+}
+
+inline void get_hubbard_occupancies_matrix_nc(double_complex *occ, int ld)
+{
+    mdarray<double_complex, 4> occupation_(occ, ld, ld, 4, ctx_.unit_cell().num_atoms());
+
+    for(int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
+        const int l = ctx_.unit_cell().atom(ia).type().hubbard_l();
+        for (int m1 = -l; m1 <= l; m1++) {
+            const int mm1 = natural_lm_to_qe(m1, l);
+            for (int m2 = -l; m2 <= l; m2++) {
+                const int mm2 = natural_lm_to_qe(m2, l);
+                occupation_(mm1, mm2, 0, ia) = this->occupancy_number_(l + m1, l + m2, 0, ia, 0);
+                occupation_(mm1, mm2, 3, ia) = this->occupancy_number_(l + m1, l + m2, 1, ia, 0);
+                occupation_(mm1, mm2, 1, ia) = this->occupancy_number_(l + m1, l + m2, 2, ia, 0);
+                occupation_(mm1, mm2, 2, ia) = this->occupancy_number_(l + m1, l + m2, 3, ia, 0);
+            }
+        }
+    }
+}
+
+inline void print_occupancies()
+{
     if (ctx_.control().verbosity_ > 1) {
         if (ctx_.comm().rank() == 0) {
-            printf("Initial occupancy\n");
+            printf("\n");
+            printf("hubbard occupancies\n");
+            printf("----------------------------------------------------------------------\n");
             for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
                 printf("Atom : %d\n", ia);
                 const auto& atom = unit_cell_.atom(ia);
+                const int lmax_at = 2 * atom.type().hubbard_l() + 1;
                 if (atom.type().hubbard_correction()) {
-                    for (int m1 = 0; m1 < 2 * atom.type().hubbard_l() + 1; m1++) {
-                        for (int m2 = 0; m2 < 2 * atom.type().hubbard_l() + 1; m2++) {
-                            printf("%.3lf %.3lf ", this->occupancy_number_(m1, m2, 0, ia, 0).real(),
-                                   this->occupancy_number_(m1, m2, 0, ia, 0).imag());
+                    for (int m1 = 0; m1 < lmax_at; m1++) {
+                        for (int m2 = 0; m2 < lmax_at; m2++) {
+                            printf("%.3lf ", std::norm(this->occupancy_number_(m1, m2, 0, ia, 0)));
                         }
 
                         if (ctx_.num_mag_dims() == 3) {
                             printf(" ");
-                            for (int m2 = 0; m2 < 2 * atom.type().hubbard_l() + 1; m2++) {
-                                printf("%.3lf %.3lf ", this->occupancy_number_(m1, m2, 2, ia, 0).real(),
-                                       this->occupancy_number_(m1, m2, 2, ia, 0).imag());
+                            for (int m2 = 0; m2 < lmax_at; m2++) {
+                                printf("%.3lf ", std::norm(this->occupancy_number_(m1, m2, 2, ia, 0)));
                             }
                         }
                         printf("\n");
                     }
-                    printf("\n");
                     if (ctx_.num_spins() == 2) {
-                        for (int m1 = 0; m1 < 2 * atom.type().hubbard_l() + 1; m1++) {
-                            for (int m2 = 0; m2 < 2 * atom.type().hubbard_l() + 1; m2++) {
-                                printf("%.3lf %.3lf ", this->occupancy_number_(m1, m2, 3, ia, 0).real(),
-                                       this->occupancy_number_(m1, m2, 3, ia, 0).imag());
+                        for (int m1 = 0; m1 < lmax_at; m1++) {
+                            for (int m2 = 0; m2 < lmax_at; m2++) {
+                                printf("%.3lf ", std::norm(this->occupancy_number_(m1, m2, 3, ia, 0)));
                             }
                             if (ctx_.num_mag_dims() == 3) {
                                 printf(" ");
-                                for (int m2 = 0; m2 < 2 * atom.type().hubbard_l() + 1; m2++) {
-                                    printf("%.3lf %.3lf ", this->occupancy_number_(m1, m2, 1, ia, 0).real(),
-                                           this->occupancy_number_(m1, m2, 1, ia, 0).imag());
+                                for (int m2 = 0; m2 < lmax_at; m2++) {
+                                    printf("%.3lf ", std::norm(this->occupancy_number_(m1, m2, 1, ia, 0)));
                                 }
                             }
                             printf("\n");
                         }
                     }
 
-                    printf("\n");
                     double n_up, n_down, n_total;
                     n_up   = 0.0;
                     n_down = 0.0;
-                    for (int m1 = 0; m1 < 2 * atom.type().hubbard_l() + 1; m1++) {
+                    for (int m1 = 0; m1 < lmax_at; m1++) {
                         n_up += this->occupancy_number_(m1, m1, 0, ia, 0).real();
                     }
 
                     if (ctx_.num_spins() == 2) {
-                        for (int m1 = 0; m1 < 2 * atom.type().hubbard_l() + 1; m1++) {
+                        for (int m1 = 0; m1 < lmax_at; m1++) {
                             n_down += this->occupancy_number_(m1, m1, 1, ia, 0).real();
                         }
                     }
-
+                    printf("\n");
                     n_total = n_up + n_down;
                     if (ctx_.num_spins() == 2) {
                         printf("Atom charge (total) %.5lf (n_up) %.5lf (n_down) %.5lf (mz) %.5lf\n", n_total, n_up,
@@ -419,48 +448,7 @@ void calculate_initial_occupation_numbers()
                     }
                 }
             }
-            printf("\n");
+            printf("-------------------------------------------------------------\n");
         }
     }
-}
-
-void set_hubbard_occupation_matrix(double_complex *occ, int ld)
-{
-    mdarray<double_complex, 4> occupation_(occ, 2 * this->lmax_ + 1, 2 * this->lmax_ + 1, 4, ctx_.unit_cell().num_atoms());
-
-    if(ctx_.num_spins() == 1) {
-        for (int m1 = 0; m1 < (2 * ctx_.unit_cell().atom(ia).type().hubbard_l() + 1); m1++) {
-            int mm1 = ((m1 % 2 == 0) - (m1 %2 == 1)) * ((m1 + 1) >> 1) + ctx_.unit_cell().atom(ia).type().hubbard_l();
-            for (int m2 = 0; m2 < (2 * ctx_.unit_cell().atom(ia).type().hubbard_l() + 1); m2++) {
-                int mm2 = ((m2 % 2 == 0) - (m2 %2 == 1)) * ((m2 + 1) >> 1) + ctx_.unit_cell().atom(ia).type().hubbard_l();
-                this->occupancy_number_(mm1, mm2, 0, ia, 0) = occupation_(m1, m2, 0, ia);
-            }
-        }
-    } else {
-        for(int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
-            if(ctx_.num_mag_dims() == 3) {
-                for (int m1 = 0; m1 < (2 * ctx_.unit_cell().atom(ia).type().hubbard_l() + 1); m1++) {
-                    int mm1 = ((m1 % 2 == 0) - (m1 %2 == 1)) * ((m1 + 1) >> 1) + ctx_.unit_cell().atom(ia).type().hubbard_l();
-                    for (int m2 = 0; m2 < (2 * ctx_.unit_cell().atom(ia).type().hubbard_l() + 1); m2++) {
-                        int mm2 = ((m2 % 2 == 0) - (m2 %2 == 1)) * ((m2 + 1) >> 1) + ctx_.unit_cell().atom(ia).type().hubbard_l();
-                        this->occupancy_number_(mm1, mm2, 0, ia, 0) = occupation_(m1, m2, 0, ia);
-                        this->occupancy_number_(mm1, mm2, 1, ia, 0) = occupation_(m1, m2, 3, ia);
-                        this->occupancy_number_(mm1, mm2, 2, ia, 0) = occupation_(m1, m2, 1, ia);
-                        this->occupancy_number_(mm1, mm2, 3, ia, 0) = occupation_(m1, m2, 2, ia);
-                    }
-                }
-            } else {
-                for (int m1 = 0; m1 < (2 * ctx_.unit_cell().atom(ia).type().hubbard_l() + 1); m1++) {
-                    int mm1 = ((m1 % 2 == 0) - (m1 %2 == 1)) * ((m1 + 1) >> 1) + ctx_.unit_cell().atom(ia).type().hubbard_l();
-                    for (int m2 = 0; m2 < (2 * ctx_.unit_cell().atom(ia).type().hubbard_l() + 1); m2++) {
-                        int mm2 = ((m2 % 2 == 0) - (m2 %2 == 1)) * ((m2 + 1) >> 1) + ctx_.unit_cell().atom(ia).type().hubbard_l();
-                        this->occupancy_number_(mm1, mm2, 0, ia, 0) = occupation_(m1, m2, 0, ia);
-                        this->occupancy_number_(mm1, mm2, 1, ia, 0) = occupation_(m1, m2, 1, ia);
-                    }
-                }
-            }
-        }
-    }
-
-    calculate_hubbard_potential_and_energy();
 }

--- a/src/Hubbard/hubbard_occupancy.hpp
+++ b/src/Hubbard/hubbard_occupancy.hpp
@@ -19,10 +19,19 @@ void hubbard_compute_occupation_numbers(K_point_set& kset_)
         int ik  = kset_.spl_num_kpoints(ikloc);
         auto kp = kset_[ik];
 
+        // if we are doing calculations for non colinear magnetism or
+        // simple LDA then do not change the number of bands. the factor
+        // two is important for colinear magnetism since the up-up and
+        // down-down blocks are decoupled but the wave-functions are up
+        // and down are still stored as a spinor to conserve space.
+        int HowManyBands = kp->num_occupied_bands(0);
+        if (ctx_.num_mag_dims() == 1)
+            HowManyBands += kp->num_occupied_bands(1);
+
         // now for each spin components and each atom we need to calculate
         // <psi_{nk}|phi^I_m'><phi^I_m|psi_{nk}>
         dmatrix<double_complex> dm(this->number_of_hubbard_orbitals(),
-                                   kp->num_occupied_bands(0));
+                                   HowManyBands);
 
         dm.zero();
 
@@ -40,7 +49,7 @@ void hubbard_compute_occupation_numbers(K_point_set& kset_)
                   0);
         } else {
             inner(ctx_.processing_unit(),
-                  ctx_.num_spins() - 1,
+                  0,
                   kp->hubbard_wave_functions(),
                   0,
                   this->number_of_hubbard_orbitals(),
@@ -50,29 +59,66 @@ void hubbard_compute_occupation_numbers(K_point_set& kset_)
                   dm,
                   0,
                   0);
+
+            if (ctx_.num_spins() == 2) {
+                inner(ctx_.processing_unit(),
+                      1,
+                      kp->hubbard_wave_functions(),
+                      0,
+                      this->number_of_hubbard_orbitals(),
+                      kp->spinor_wave_functions(),
+                      0,
+                      kp->num_occupied_bands(1),
+                      dm,
+                      0,
+                      kp->num_occupied_bands(0));
+            }
         }
 
         // now compute O_{ij}^{sigma,sigma'} = \sum_{nk} <psi_nk|phi_{i,sigma}><phi_{j,sigma^'}|psi_nk> f_{nk}
 
-        // there must be a way to do that with matrix multiplication
-        #pragma omp parallel for schedule(static)
-        for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
-            const auto& atom = unit_cell_.atom(ia);
-            const int lmax_at = 2 * atom.type().hubbard_l() + 1;
-            if (atom.type().hubbard_correction()) {
-                for (int s1 = 0; s1 < ctx_.num_spins(); s1++) {
-                    for (int s2 = 0; s2 < ctx_.num_spins(); s2++) {
-                        int s = (s1 == s2) * s1 + (s1 != s2) * (1 + 2 * s2 + s1);
-                        for (int nband = 0; nband < kp->num_occupied_bands(0); nband++) {
+        if (ctx_.num_mag_dims() == 3) {
+            // there must be a way to do that with matrix multiplication
+#pragma omp parallel for schedule(static)
+            for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
+                const auto& atom = unit_cell_.atom(ia);
+                const int lmax_at = 2 * atom.type().hubbard_l() + 1;
+                if (atom.type().hubbard_correction()) {
+                    for (int s1 = 0; s1 < ctx_.num_spins(); s1++) {
+                        for (int s2 = 0; s2 < ctx_.num_spins(); s2++) {
+                            int s = (s1 == s2) * s1 + (s1 != s2) * (1 + 2 * s2 + s1);
+                            for (int nband = 0; nband < kp->num_occupied_bands(0); nband++) {
+                                for (int m = 0; m < lmax_at; m++) {
+                                    for (int mp = 0; mp < lmax_at; mp++) {
+                                        this->occupancy_number_(m, mp, s, ia, 0) +=
+                                            std::conj(dm(this->offset[ia] + m + s1 * lmax_at, nband)) *
+                                            dm(this->offset[ia] + mp + s2 * lmax_at, nband) *
+                                            kp->band_occupancy(nband) * kp->weight();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
+                const int nb = (ispn == 1) * kp->num_occupied_bands(0);
+#pragma omp parallel for schedule(static)
+                for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
+                    const auto& atom = unit_cell_.atom(ia);
+                    const int lmax_at = 2 * atom.type().hubbard_l() + 1;
+                    if (atom.type().hubbard_correction()) {
+                        for (int nband = 0; nband < kp->num_occupied_bands(ispn); nband++) {
                             for (int m = 0; m < lmax_at; m++) {
                                 for (int mp = 0; mp < lmax_at; mp++) {
-                                    this->occupancy_number_(m, mp, s, ia, 0) +=
-                                        std::conj(
-                                            dm(this->offset[ia] + m + s1 * lmax_at, nband)) *
-                                        dm(this->offset[ia] + mp + s2 * lmax_at, nband) *
+                                    this->occupancy_number_(m, mp, ispn, ia, 0) +=
+                                        std::conj(dm(this->offset[ia] + m, nband + nb)) *
+                                        dm(this->offset[ia] + mp, nband + nb) *
                                         kp->band_occupancy(nband) * kp->weight();
                                 }
                             }
+                            printf("%.3lf %.3lf\n", kp->band_occupancy(nband), kp->weight());
                         }
                     }
                 }
@@ -83,103 +129,13 @@ void hubbard_compute_occupation_numbers(K_point_set& kset_)
     ctx_.comm().allreduce<double_complex, mpi_op_t::sum>(this->occupancy_number_.at<CPU>(),
                                                          static_cast<int>(this->occupancy_number_.size()));
 
-    // Now symmetrization procedure
+    // Now symmetrization procedure. We need to review that
+
     if (0) {
-        auto& sym = unit_cell_.symmetry();
-
-        // check if we have some symmetries
-        if (sym.num_mag_sym()) {
-            int lmax  = unit_cell_.lmax();
-            int lmmax = Utils::lmmax(lmax);
-
-            mdarray<double_complex, 2> rotm(lmmax, lmmax);
-            mdarray<double_complex, 4> rotated_oc(lmmax, lmmax, ctx_.num_spins() * ctx_.num_spins(),
-                                                  unit_cell_.num_atoms());
-
-            double alpha = 1.0 / static_cast<double>(sym.num_mag_sym());
-            rotated_oc.zero();
-
-            for (int i = 0; i < sym.num_mag_sym(); i++) {
-                int pr    = sym.magnetic_group_symmetry(i).spg_op.proper;
-                auto eang = sym.magnetic_group_symmetry(i).spg_op.euler_angles;
-                //int isym  = sym.magnetic_group_symmetry(i).isym;
-                SHT::rotation_matrix(lmax, eang, pr, rotm);
-                auto spin_rot_su2 = SHT::rotation_matrix_su2(sym.magnetic_group_symmetry(i).spin_rotation);
-
-                #pragma omp parallel for schedule(static)
-                for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
-                    const auto& atom = unit_cell_.atom(ia);
-                    const int lmax_at = 2 * atom.type().hubbard_l() + 1;
-                    if (atom.type().hubbard_correction()) {
-                        for (int ii = 0; ii < lmax_at; ii++) {
-                            int l1 = Utils::lm_by_l_m(atom.type().hubbard_l(), ii - atom.type().hubbard_l());
-                            for (int ll = 0; ll < lmax_at; ll++) {
-                                int l2 = Utils::lm_by_l_m(atom.type().hubbard_l(), ll - atom.type().hubbard_l());
-                                mdarray<double_complex, 1> rot_spa(ctx_.num_spins() * ctx_.num_spins());
-                                rot_spa.zero();
-                                for (int s1 = 0; s1 < ctx_.num_spins(); s1++) {
-                                    for (int s2 = 0; s2 < ctx_.num_spins(); s2++) {
-                                        // symmetrization procedure
-                                        // A_ij B_jk C_kl
-
-                                        for (int jj = 0; jj < lmax_at; jj++) {
-                                            int l3 =
-                                                Utils::lm_by_l_m(atom.type().hubbard_l(), jj - atom.type().hubbard_l());
-                                            for (int kk = 0; kk < lmax_at; kk++) {
-                                                int l4 = Utils::lm_by_l_m(atom.type().hubbard_l(),
-                                                                          kk - atom.type().hubbard_l());
-                                                rot_spa(2 * s1 + s2) +=
-                                                    std::conj(rotm(l1, l3)) *
-                                                    occupancy_number_(
-                                                                      jj, kk, (s1 == s2) * s1 + (s1 != s2) * (1 + 2 * s1 + s2), ia, 0) *
-                                                    rotm(l2, l4) * alpha;
-                                            }
-                                        }
-                                    }
-                                }
-
-                                if (ctx_.num_mag_dims() == 3) {
-                                    double_complex spin_dm[2][2] = {{0.0, 0.0}, {0.0, 0.0}};
-                                    for (int iii = 0; iii < ctx_.num_spins(); iii++) {
-                                        for (int lll = 0; lll < ctx_.num_spins(); lll++) {
-                                            // A_ij B_jk C_kl
-                                            for (int jj = 0; jj < ctx_.num_spins(); jj++) {
-                                                for (int kk = 0; kk < ctx_.num_spins(); kk++) {
-                                                    spin_dm[iii][lll] += spin_rot_su2(iii, jj) * rot_spa(jj + 2 * kk) *
-                                                                         std::conj(spin_rot_su2(kk, lll));
-                                                }
-                                            }
-                                        }
-                                    }
-
-                                    rotated_oc(ii, ll, 0, ia) += spin_dm[0][0];
-                                    rotated_oc(ii, ll, 1, ia) += spin_dm[1][1];
-                                    rotated_oc(ii, ll, 2, ia) += spin_dm[0][1];
-                                    rotated_oc(ii, ll, 3, ia) += spin_dm[1][0];
-                                } else {
-                                    for (int s = 0; s < ctx_.num_spins(); s++) {
-                                        rotated_oc(ii, ll, s, ia) += rot_spa(s);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
-                auto& atom = unit_cell_.atom(ia);
-                const int lmax_at = 2 * atom.type().hubbard_l() + 1;
-                if (atom.type().hubbard_correction()) {
-                    for (int ii = 0; ii < lmax_at; ii++) {
-                        for (int ll = 0; ll < lmax_at; ll++) {
-                            for (int s = 0; s < ctx_.num_spins() * ctx_.num_spins(); s++) {
-                                this->occupancy_number_(ii, ll, s, ia, 0) = rotated_oc(ii, ll, s, ia);
-                            }
-                        }
-                    }
-                }
-            }
+        if (ctx_.num_mag_dims() == 3) {
+            symmetrize_occupancy_matrix_noncolinear_case();
+        } else {
+            symmetrize_occupancy_matrix();
         }
     }
 
@@ -190,16 +146,18 @@ void hubbard_compute_occupation_numbers(K_point_set& kset_)
             for (int s1 = 0; s1 < ctx_.num_spins(); s1++) {
                 // diagonal blocks
                 for (int m = 0; m < lmax_at; m++) {
-                    for (int mp = m + 1; mp < lmax_at; mp++) {
+                    for (int mp = 0; mp < lmax_at; mp++) {
                         this->occupancy_number_(mp, m, s1, ia, 0) = std::conj(this->occupancy_number_(m, mp, s1, ia, 0));
+                        printf("%.3lf ", std::abs(this->occupancy_number_(mp, m, s1, ia, 0)));
                     }
+                    printf("\n");
                 }
             }
 
             if (ctx_.num_mag_dims() == 3) {
                 // off diagonal blocks
                 for (int m = 0; m < lmax_at; m++) {
-                    for (int mp = m + 1; mp < lmax_at; mp++) {
+                    for (int mp = m; mp < lmax_at; mp++) {
                         this->occupancy_number_(mp, m, 2, ia, 0) = std::conj(this->occupancy_number_(m, mp, 3, ia, 0));
                     }
                 }
@@ -315,6 +273,8 @@ inline int natural_lm_to_qe(int m, int l)
 inline void set_hubbard_occupancies_matrix(double *occ, int ld)
 {
     mdarray<double, 4> occupation_(occ, ld, ld, ctx_.num_spins(), ctx_.unit_cell().num_atoms());
+    this->occupancy_number_.zero();
+    const double scal = 1.0 + (ctx_.num_mag_dims() != 1);
 
     for(int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
         const int l = ctx_.unit_cell().atom(ia).type().hubbard_l();
@@ -323,7 +283,7 @@ inline void set_hubbard_occupancies_matrix(double *occ, int ld)
             for (int m2 = -l; m2 <= l ; m2++) {
                 const int mm2 = natural_lm_to_qe(m2, l);
                 for(int s = 0; s < ctx_.num_spins(); s++) {
-                    this->occupancy_number_(l + m1, l + m2, s, ia, 0) = occupation_(mm1, mm2, s, ia);
+                    this->occupancy_number_(l + m1, l + m2, s, ia, 0) = scal * occupation_(mm1, mm2, s, ia);
                 }
             }
         }
@@ -333,10 +293,10 @@ inline void set_hubbard_occupancies_matrix(double *occ, int ld)
 inline void set_hubbard_occupancies_matrix_nc(double_complex *occ, int ld)
 {
     mdarray<double_complex, 4> occupation_(occ, ld, ld, 4, ctx_.unit_cell().num_atoms());
-
+    this->occupancy_number_.zero();
     for(int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
         const int l = ctx_.unit_cell().atom(ia).type().hubbard_l();
-        for (int m1 = -l; m1 <= -l; m1++) {
+        for (int m1 = -l; m1 <= l; m1++) {
             const int mm1 = natural_lm_to_qe(m1, l);
             for (int m2 = -l; m2 <= l; m2++) {
                 const int mm2 = natural_lm_to_qe(m2, l);
@@ -353,6 +313,11 @@ inline void get_hubbard_occupancies_matrix(double *occ, int ld)
 {
     mdarray<double, 4> occupation_(occ, ld, ld, ctx_.num_spins(), ctx_.unit_cell().num_atoms());
 
+    // we have a factor 1/2 to apply because sirius in the basic LDA
+    // case add up the spin degenary to the band occupation
+    assert(ctx_.num_mag_dims() != 3);
+    const double scal = (ctx_.num_mag_dims() != 1) * 0.5 + (ctx_.num_mag_dims() == 1);
+
     for(int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
         const int l = ctx_.unit_cell().atom(ia).type().hubbard_l();
         for (int m1 = -l; m1 <= l; m1++) {
@@ -360,7 +325,7 @@ inline void get_hubbard_occupancies_matrix(double *occ, int ld)
             for (int m2 = -l; m2 <= l; m2++) {
                 const int mm2 = natural_lm_to_qe(m2, l);
                 for (int s = 0; s < ctx_.num_spins(); s++) {
-                        occupation_(mm1, mm2, s, ia) = this->occupancy_number_(l + m1, l + m2, s, ia, 0).real();
+                    occupation_(mm1, mm2, s, ia) = scal * this->occupancy_number_(l + m1, l + m2, s, ia, 0).real();
                 }
             }
         }
@@ -397,16 +362,17 @@ inline void print_occupancies()
                 printf("Atom : %d\n", ia);
                 const auto& atom = unit_cell_.atom(ia);
                 const int lmax_at = 2 * atom.type().hubbard_l() + 1;
+
                 if (atom.type().hubbard_correction()) {
                     for (int m1 = 0; m1 < lmax_at; m1++) {
                         for (int m2 = 0; m2 < lmax_at; m2++) {
-                            printf("%.3lf ", std::norm(this->occupancy_number_(m1, m2, 0, ia, 0)));
+                            printf("%.3lf ", std::abs(this->occupancy_number_(m1, m2, 0, ia, 0)));
                         }
 
                         if (ctx_.num_mag_dims() == 3) {
                             printf(" ");
                             for (int m2 = 0; m2 < lmax_at; m2++) {
-                                printf("%.3lf ", std::norm(this->occupancy_number_(m1, m2, 2, ia, 0)));
+                                printf("%.3lf ", std::abs(this->occupancy_number_(m1, m2, 2, ia, 0)));
                             }
                         }
                         printf("\n");
@@ -414,12 +380,12 @@ inline void print_occupancies()
                     if (ctx_.num_spins() == 2) {
                         for (int m1 = 0; m1 < lmax_at; m1++) {
                             for (int m2 = 0; m2 < lmax_at; m2++) {
-                                printf("%.3lf ", std::norm(this->occupancy_number_(m1, m2, 3, ia, 0)));
+                                printf("%.3lf ", std::abs(this->occupancy_number_(m1, m2, 3, ia, 0)));
                             }
                             if (ctx_.num_mag_dims() == 3) {
                                 printf(" ");
                                 for (int m2 = 0; m2 < lmax_at; m2++) {
-                                    printf("%.3lf ", std::norm(this->occupancy_number_(m1, m2, 1, ia, 0)));
+                                    printf("%.3lf ", std::abs(this->occupancy_number_(m1, m2, 1, ia, 0)));
                                 }
                             }
                             printf("\n");
@@ -444,11 +410,188 @@ inline void print_occupancies()
                         printf("Atom charge (total) %.5lf (n_up) %.5lf (n_down) %.5lf (mz) %.5lf\n", n_total, n_up,
                                n_down, n_up - n_down);
                     } else {
-                        printf("Atom charge (total) %.5lf\n", n_total);
+                        printf("Atom charge (total) %.5lf\n", 2.0 * n_total);
                     }
                 }
             }
             printf("-------------------------------------------------------------\n");
+        }
+    }
+}
+
+inline void symmetrize_occupancy_matrix_noncolinear_case()
+{
+
+#warning "We need to review this"
+
+    auto& sym = unit_cell_.symmetry();
+
+    // check if we have some symmetries
+    if (sym.num_mag_sym()) {
+        int lmax  = unit_cell_.lmax();
+        int lmmax = Utils::lmmax(lmax);
+
+        mdarray<double_complex, 2> rotm(lmmax, lmmax);
+        mdarray<double_complex, 4> rotated_oc(lmmax, lmmax, ctx_.num_spins() * ctx_.num_spins(),
+                                              unit_cell_.num_atoms());
+
+        double alpha = 1.0 / static_cast<double>(sym.num_mag_sym());
+        rotated_oc.zero();
+
+        for (int i = 0; i < sym.num_mag_sym(); i++) {
+            int pr    = sym.magnetic_group_symmetry(i).spg_op.proper;
+            auto eang = sym.magnetic_group_symmetry(i).spg_op.euler_angles;
+            //int isym  = sym.magnetic_group_symmetry(i).isym;
+            SHT::rotation_matrix(lmax, eang, pr, rotm);
+            auto spin_rot_su2 = SHT::rotation_matrix_su2(sym.magnetic_group_symmetry(i).spin_rotation);
+
+#pragma omp parallel for schedule(static)
+            for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
+                const auto& atom = unit_cell_.atom(ia);
+                const int lmax_at = 2 * atom.type().hubbard_l() + 1;
+                if (atom.type().hubbard_correction()) {
+                    for (int ii = 0; ii < lmax_at; ii++) {
+                        int l1 = Utils::lm_by_l_m(atom.type().hubbard_l(), ii - atom.type().hubbard_l());
+                        for (int ll = 0; ll < lmax_at; ll++) {
+                            int l2 = Utils::lm_by_l_m(atom.type().hubbard_l(), ll - atom.type().hubbard_l());
+                            mdarray<double_complex, 1> rot_spa(ctx_.num_spins() * ctx_.num_spins());
+                            rot_spa.zero();
+                            for (int s1 = 0; s1 < ctx_.num_spins(); s1++) {
+                                for (int s2 = 0; s2 < ctx_.num_spins(); s2++) {
+                                    // symmetrization procedure
+                                    // A_ij B_jk C_kl
+
+                                    for (int jj = 0; jj < lmax_at; jj++) {
+                                        int l3 =
+                                            Utils::lm_by_l_m(atom.type().hubbard_l(), jj - atom.type().hubbard_l());
+                                        for (int kk = 0; kk < lmax_at; kk++) {
+                                            int l4 = Utils::lm_by_l_m(atom.type().hubbard_l(),
+                                                                      kk - atom.type().hubbard_l());
+                                            rot_spa(2 * s1 + s2) +=
+                                                std::conj(rotm(l1, l3)) *
+                                                occupancy_number_(jj, kk, (s1 == s2) * s1 + (s1 != s2) * (1 + 2 * s1 + s2), ia, 0) *
+                                                rotm(l2, l4) * alpha;
+                                        }
+                                    }
+                                }
+                            }
+
+                            double_complex spin_dm[2][2] = {{0.0, 0.0}, {0.0, 0.0}};
+                            for (int iii = 0; iii < ctx_.num_spins(); iii++) {
+                                for (int lll = 0; lll < ctx_.num_spins(); lll++) {
+                                    // A_ij B_jk C_kl
+                                    for (int jj = 0; jj < ctx_.num_spins(); jj++) {
+                                        for (int kk = 0; kk < ctx_.num_spins(); kk++) {
+                                            spin_dm[iii][lll] += spin_rot_su2(iii, jj) * rot_spa(jj + 2 * kk) *
+                                                std::conj(spin_rot_su2(kk, lll));
+                                        }
+                                    }
+                                }
+                            }
+
+                            rotated_oc(ii, ll, 0, ia) += spin_dm[0][0];
+                            rotated_oc(ii, ll, 1, ia) += spin_dm[1][1];
+                            rotated_oc(ii, ll, 2, ia) += spin_dm[0][1];
+                            rotated_oc(ii, ll, 3, ia) += spin_dm[1][0];
+                        }
+                    }
+                }
+            }
+        }
+
+        for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
+            auto& atom = unit_cell_.atom(ia);
+            const int lmax_at = 2 * atom.type().hubbard_l() + 1;
+            if (atom.type().hubbard_correction()) {
+                for (int ii = 0; ii < lmax_at; ii++) {
+                    for (int ll = 0; ll < lmax_at; ll++) {
+                        for (int s = 0; s < ctx_.num_spins() * ctx_.num_spins(); s++) {
+                            this->occupancy_number_(ii, ll, s, ia, 0) = rotated_oc(ii, ll, s, ia);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+inline void symmetrize_occupancy_matrix()
+{
+    auto& sym = unit_cell_.symmetry();
+
+    // check if we have some symmetries
+    if (sym.num_mag_sym()) {
+        int lmax  = unit_cell_.lmax();
+        int lmmax = Utils::lmmax(lmax);
+
+        mdarray<double_complex, 2> rotm(lmmax, lmmax);
+        mdarray<double_complex, 4> rotated_oc(lmmax, lmmax, ctx_.num_spins() * ctx_.num_spins(),
+                                              unit_cell_.num_atoms());
+
+        double alpha = 1.0 / static_cast<double>(sym.num_mag_sym());
+        rotated_oc.zero();
+
+        for (int i = 0; i < sym.num_mag_sym(); i++) {
+            int pr    = sym.magnetic_group_symmetry(i).spg_op.proper;
+            auto eang = sym.magnetic_group_symmetry(i).spg_op.euler_angles;
+            //int isym  = sym.magnetic_group_symmetry(i).isym;
+            SHT::rotation_matrix(lmax, eang, pr, rotm);
+            auto spin_rot_su2 = SHT::rotation_matrix_su2(sym.magnetic_group_symmetry(i).spin_rotation);
+
+#pragma omp parallel for schedule(static)
+            for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
+                const auto& atom = unit_cell_.atom(ia);
+                const int lmax_at = 2 * atom.type().hubbard_l() + 1;
+                if (atom.type().hubbard_correction()) {
+                    dmatrix<double_complex> rot_spa(lmax_at, lmax_at);
+                    rot_spa.zero();
+                    for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
+                        for (int ii = 0; ii < lmax_at; ii++) {
+                            int l1 = Utils::lm_by_l_m(atom.type().hubbard_l(), ii - atom.type().hubbard_l());
+                            for (int ll = 0; ll < lmax_at; ll++) {
+                                int l2 = Utils::lm_by_l_m(atom.type().hubbard_l(), ll - atom.type().hubbard_l());
+                                // symmetrization procedure
+                                // A_ij B_jk C_kl
+                                for (int kk = 0; kk < lmax_at; kk++) {
+                                    int l4 = Utils::lm_by_l_m(atom.type().hubbard_l(),
+                                                              kk - atom.type().hubbard_l());
+                                    for (int jj = 0; jj < lmax_at; jj++) {
+                                        int l3 =
+                                            Utils::lm_by_l_m(atom.type().hubbard_l(), jj - atom.type().hubbard_l());
+                                        rot_spa(ii, kk) +=
+                                            std::conj(rotm(l1, l3)) *
+                                            occupancy_number_(jj, kk, ispn, ia, 0) *
+                                            rotm(l2, l4) * alpha;
+                                    }
+                                }
+                            }
+                        }
+
+                        // we have the rotated occupancy matrix
+                        for (int ii = 0; ii < lmax_at; ii++) {
+                            for (int jj = 0; jj < lmax_at; jj++) {
+                                occupancy_number_(ii, jj, ispn, ia, 0) = rot_spa(ii, jj);
+                            }
+                        }
+                        rot_spa.zero();
+                    }
+
+                }
+            }
+        }
+
+        for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
+            auto& atom = unit_cell_.atom(ia);
+            const int lmax_at = 2 * atom.type().hubbard_l() + 1;
+            if (atom.type().hubbard_correction()) {
+                for (int ii = 0; ii < lmax_at; ii++) {
+                    for (int ll = 0; ll < lmax_at; ll++) {
+                        for (int s = 0; s < ctx_.num_spins(); s++) {
+                            this->occupancy_number_(ii, ll, s, ia, 0) = rotated_oc(ii, ll, s, ia);
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Hubbard/hubbard_potential_energy.hpp
+++ b/src/Hubbard/hubbard_potential_energy.hpp
@@ -329,30 +329,17 @@ void calculate_hubbard_potential_and_energy_non_colinear_case()
 
 inline void set_hubbard_potential(double *occ, int ld)
 {
-    mdarray<double, 4> occupation_(occ, ld, ld, 4, ctx_.unit_cell().num_atoms());
+    mdarray<double, 4> occupation_(occ, ld, ld, ctx_.num_spins(), ctx_.unit_cell().num_atoms());
 
     this->hubbard_potential_.zero();
-    if(ctx_.num_spins() == 1) {
-        for(int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
-            const int l = ctx_.unit_cell().atom(ia).type().hubbard_l();
-            for (int m1 = -l; m1 <= l; m1++) {
-                const int mm1 = natural_lm_to_qe(m1, l);
-                for (int m2 = -l; m2 <= l ; m2++) {
-                    const int mm2 = natural_lm_to_qe(m2, l);
-                    this->hubbard_potential_(l + m1, l + m2, 0, ia, 0) = 0.5 * occupation_(mm1, mm2, 0, ia);
-                }
-            }
-        }
-    } else {
-        for(int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
-            const int l = ctx_.unit_cell().atom(ia).type().hubbard_l();
-            for (int m1 = -l; m1 <= l; m1++) {
-                const int mm1 = natural_lm_to_qe(m1, l);
-                for (int m2 = -l; m2 <= l; m2++) {
-                    const int mm2 = natural_lm_to_qe(m2, l);
-                    this->hubbard_potential_(l + m1, l + m2, 0, ia, 0) = 0.5 * occupation_(mm1, mm2, 0, ia);
-                    this->hubbard_potential_(l + m1, l + m2, 1, ia, 0) = 0.5 * occupation_(mm1, mm2, 1, ia);
-                }
+    for(int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
+        const int l = ctx_.unit_cell().atom(ia).type().hubbard_l();
+        for (int m1 = -l; m1 <= l; m1++) {
+            const int mm1 = natural_lm_to_qe(m1, l);
+            for (int m2 = -l; m2 <= l ; m2++) {
+                const int mm2 = natural_lm_to_qe(m2, l);
+                for (int ispn = 0; ispn < ctx_.num_spins(); ispn++)
+                    this->hubbard_potential_(l + m1, l + m2, ispn, ia, 0) = 0.5 * occupation_(mm1, mm2, ispn, ia);
             }
         }
     }

--- a/src/Hubbard/hubbard_potential_energy.hpp
+++ b/src/Hubbard/hubbard_potential_energy.hpp
@@ -121,7 +121,7 @@ void calculate_hubbard_potential_and_energy_colinear_case()
             for (int is = 0; is < ctx_.num_spins(); is++) {
                 for (int m1 = 0; m1 < 2 * atom.type().hubbard_l() + 1; m1++) {
                     this->U(m1, m1, is, ia) += atom.type().Hubbard_J() * n_updown[is] +
-                                               0.5 * (atom.type().Hubbard_U() + atom.type().Hubbard_J()) -
+                                               0.5 * (atom.type().Hubbard_U() - atom.type().Hubbard_J()) -
                                                atom.type().Hubbard_U() * n_total;
 
                     // the u contributions
@@ -146,13 +146,13 @@ void calculate_hubbard_potential_and_energy_colinear_case()
                                     this->occupancy_number_(m3, m4, is, ia, 0);
 
                                 this->hubbard_energy_u_ += 0.5 *
-                                    ((atom.type().hubbard_matrix(m1, m3, m2, m4) -
-                                      atom.type().hubbard_matrix(m1, m3, m4, m2)) *
-                                     this->occupancy_number_(m1, m2, is, ia, 0) *
-                                     this->occupancy_number_(m3, m4, is, ia, 0) +
-                                     atom.type().hubbard_matrix(m1, m3, m2, m4) *
-                                     this->occupancy_number_(m1, m2, is, ia, 0) *
-                                     this->occupancy_number_(m3, m4, (is + 1) % 2, ia, 0))
+                                    ((atom.type().hubbard_matrix(m1, m2, m3, m4) -
+                                      atom.type().hubbard_matrix(m1, m2, m4, m3)) *
+                                     this->occupancy_number_(m1, m3, is, ia, 0) *
+                                     this->occupancy_number_(m2, m4, is, ia, 0) +
+                                     atom.type().hubbard_matrix(m1, m2, m3, m4) *
+                                     this->occupancy_number_(m1, m3, is, ia, 0) *
+                                     this->occupancy_number_(m2, m4, (is + 1) % 2, ia, 0))
                                     .real();
                             }
                         }
@@ -182,6 +182,7 @@ void calculate_hubbard_potential_and_energy_non_colinear_case()
     this->hubbard_potential_.zero();
     for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
         auto& atom = unit_cell_.atom(ia);
+        const int lmax_at = 2 * atom.type().hubbard_l() + 1;
         if (atom.type().hubbard_correction()) {
             // compute the charge and magnetization of the hubbard bands for
             // calculation of the double counting term in the hubbard correction
@@ -196,7 +197,7 @@ void calculate_hubbard_potential_and_energy_non_colinear_case()
             mx      = (this->occupancy_number_(0, 0, 2, ia, 0) + this->occupancy_number_(0, 0, 3, ia, 0)).real();
             my      = (this->occupancy_number_(0, 0, 2, ia, 0) - this->occupancy_number_(0, 0, 3, ia, 0)).imag();
 
-            for (int m = 1; m < 2 * atom.type().hubbard_l() + 1; m++) {
+            for (int m = 1; m < lmax_at; m++) {
                 n_total += this->occupancy_number_(m, m, 0, ia, 0) + this->occupancy_number_(m, m, 1, ia, 0);
                 mz += (this->occupancy_number_(m, m, 0, ia, 0) - this->occupancy_number_(m, m, 1, ia, 0)).real();
                 mx += (this->occupancy_number_(m, m, 2, ia, 0) + this->occupancy_number_(m, m, 3, ia, 0)).real();
@@ -206,7 +207,7 @@ void calculate_hubbard_potential_and_energy_non_colinear_case()
             double magnetization = mz * mz + mx * mx + my * my;
 
             mx = n_total.real();
-            this->hubbard_energy_dc_contribution_ +=
+            this->hubbard_energy_dc_contribution_ += 0.5 *
                 (atom.type().Hubbard_U() * mx * (mx - 1.0) - atom.type().Hubbard_J() * mx * (0.5 * mx - 1.0) -
                  0.5 * atom.type().Hubbard_J() * magnetization);
 
@@ -230,36 +231,36 @@ void calculate_hubbard_potential_and_energy_non_colinear_case()
 
                 if (is1 == is) {
                     // non spin flip contributions for the hubbard energy
-                    for (int m1 = 0; m1 < 2 * atom.type().hubbard_l() + 1; ++m1) {
-                        for (int m2 = 0; m2 < 2 * atom.type().hubbard_l() + 1; ++m2) {
-                            for (int m3 = 0; m3 < 2 * atom.type().hubbard_l() + 1; ++m3) {
-                                for (int m4 = 0; m4 < 2 * atom.type().hubbard_l() + 1; ++m4) {
+                    for (int m1 = 0; m1 < lmax_at; ++m1) {
+                        for (int m2 = 0; m2 < lmax_at; ++m2) {
+                            for (int m3 = 0; m3 < lmax_at; ++m3) {
+                                for (int m4 = 0; m4 < lmax_at; ++m4) {
                                     // 2 - is - 1 = 0 if is = 1
                                     //            = 1 if is = 0
 
                                     this->hubbard_energy_noflip_ +=
-                                        ((atom.type().hubbard_matrix(m1, m3, m2, m4) -
-                                          atom.type().hubbard_matrix(m1, m3, m4, m2)) *
-                                             this->occupancy_number_(m1, m2, is, ia, 0) *
-                                             this->occupancy_number_(m3, m4, is, ia, 0) +
-                                         atom.type().hubbard_matrix(m1, m3, m2, m4) *
-                                             this->occupancy_number_(m1, m2, is, ia, 0) *
-                                             this->occupancy_number_(m3, m4, (is + 1) % 2, ia, 0))
-                                            .real();
+                                        0.5 * ((atom.type().hubbard_matrix(m1, m2, m3, m4) -
+                                                atom.type().hubbard_matrix(m1, m2, m4, m3)) *
+                                               this->occupancy_number_(m1, m3, is, ia, 0) *
+                                               this->occupancy_number_(m2, m4, is, ia, 0) +
+                                               atom.type().hubbard_matrix(m1, m2, m3, m4) *
+                                               this->occupancy_number_(m1, m3, is, ia, 0) *
+                                               this->occupancy_number_(m2, m4, (is + 1) % 2, ia, 0))
+                                        .real();
                                 }
                             }
                         }
                     }
                 } else {
                     // spin flip contributions
-                    for (int m1 = 0; m1 < 2 * atom.type().hubbard_l() + 1; ++m1) {
-                        for (int m2 = 0; m2 < 2 * atom.type().hubbard_l() + 1; ++m2) {
-                            for (int m3 = 0; m3 < 2 * atom.type().hubbard_l() + 1; ++m3) {
-                                for (int m4 = 0; m4 < 2 * atom.type().hubbard_l() + 1; ++m4) {
-                                    this->hubbard_energy_flip_ -= (atom.type().hubbard_matrix(m1, m3, m2, m4) *
-                                                                   this->occupancy_number_(m1, m2, is, ia, 0) *
-                                                                   this->occupancy_number_(m3, m4, is1, ia, 0))
-                                                                      .real();
+                    for (int m1 = 0; m1 < lmax_at; ++m1) {
+                        for (int m2 = 0; m2 < lmax_at; ++m2) {
+                            for (int m3 = 0; m3 < lmax_at; ++m3) {
+                                for (int m4 = 0; m4 < lmax_at; ++m4) {
+                                    this->hubbard_energy_flip_ -= 0.5 * (atom.type().hubbard_matrix(m1, m2, m4, m3) *
+                                                                         this->occupancy_number_(m1, m3, is, ia, 0) *
+                                                                         this->occupancy_number_(m2, m4, is1, ia, 0))
+                                        .real();
                                 }
                             }
                         }
@@ -269,10 +270,10 @@ void calculate_hubbard_potential_and_energy_non_colinear_case()
                 // same thing for the hubbard potential
                 if (is1 == is) {
                     // non spin flip
-                    for (int m1 = 0; m1 < 2 * atom.type().hubbard_l() + 1; ++m1) {
-                        for (int m2 = 0; m2 < 2 * atom.type().hubbard_l() + 1; ++m2) {
-                            for (int m3 = 0; m3 < 2 * atom.type().hubbard_l() + 1; ++m3) {
-                                for (int m4 = 0; m4 < 2 * atom.type().hubbard_l() + 1; ++m4) {
+                    for (int m1 = 0; m1 < lmax_at; ++m1) {
+                        for (int m2 = 0; m2 < lmax_at; ++m2) {
+                            for (int m3 = 0; m3 < lmax_at; ++m3) {
+                                for (int m4 = 0; m4 < lmax_at; ++m4) {
                                     this->U(m1, m2, is, ia) += atom.type().hubbard_matrix(m1, m3, m2, m4) *
                                                                (this->occupancy_number_(m3, m4, 0, ia, 0) +
                                                                 this->occupancy_number_(m3, m4, 1, ia, 0));
@@ -285,11 +286,11 @@ void calculate_hubbard_potential_and_energy_non_colinear_case()
                 // double counting contribution
 
                 double_complex n_aux = 0.0;
-                for (int m1 = 0; m1 < 2 * atom.type().hubbard_l() + 1; m1++) {
+                for (int m1 = 0; m1 < lmax_at; m1++) {
                     n_aux += this->occupancy_number_(m1, m1, is1, ia, 0);
                 }
 
-                for (int m1 = 0; m1 < 2 * atom.type().hubbard_l() + 1; m1++) {
+                for (int m1 = 0; m1 < lmax_at; m1++) {
 
                     // hubbard potential : dc contribution
 
@@ -301,9 +302,9 @@ void calculate_hubbard_potential_and_energy_non_colinear_case()
                     }
 
                     // spin flip contributions
-                    for (int m2 = 0; m2 < 2 * atom.type().hubbard_l() + 1; m2++) {
-                        for (int m3 = 0; m3 < 2 * atom.type().hubbard_l() + 1; m3++) {
-                            for (int m4 = 0; m4 < 2 * atom.type().hubbard_l() + 1; m4++) {
+                    for (int m2 = 0; m2 < lmax_at; m2++) {
+                        for (int m3 = 0; m3 < lmax_at; m3++) {
+                            for (int m4 = 0; m4 < lmax_at; m4++) {
                                 this->U(m1, m2, is, ia) -= atom.type().hubbard_matrix(m1, m3, m4, m2) *
                                     this->occupancy_number_(m3, m4, is1, ia, 0);
                             }
@@ -314,59 +315,64 @@ void calculate_hubbard_potential_and_energy_non_colinear_case()
         }
     }
 
-    this->hubbard_energy_noflip_ *= 0.5;
-    this->hubbard_energy_flip_ *= 0.5;
-    this->hubbard_energy_dc_contribution_ *= 0.5;
+    // this->hubbard_energy_noflip_ *= 0.5;
+    // this->hubbard_energy_flip_ *= 0.5;
+    // this->hubbard_energy_dc_contribution_ *= 0.5;
     this->hubbard_energy_ =
         this->hubbard_energy_noflip_ + this->hubbard_energy_flip_ - this->hubbard_energy_dc_contribution_;
 
-    if ((ctx_.control().verbosity_ >= 1) && (ctx_.comm().rank() == 0)) {
+    //    if ((ctx_.control().verbosity_ >= 1) && (ctx_.comm().rank() == 0)) {
         printf("\n hub Energy (total) %.5lf (no-flip) %.5lf (flip) %.5lf (dc) %.5lf\n", this->hubbard_energy_,
                this->hubbard_energy_noflip_, this->hubbard_energy_flip_, this->hubbard_energy_dc_contribution_);
-    }
+        // }
 }
 
-void set_hubbard_potential(double_complex *pot_, int ld)
+inline void set_hubbard_potential(double *occ, int ld)
 {
-    mdarray<double_complex, 4> occupation_(pot_,
-                                           2 * this->lmax_ + 1,
-                                           2 * this->lmax_ + 1,
-                                           4,
-                                           ctx_.unit_cell().num_atoms());
+    mdarray<double, 4> occupation_(occ, ld, ld, 4, ctx_.unit_cell().num_atoms());
 
     this->hubbard_potential_.zero();
-    for(int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
-        if (ctx_.unit_cell().atom(ia).type().hubbard_correction()) {
-            if(ctx_.num_mag_dims() == 3) {
-                for (int m1 = 0; m1 < (2 * ctx_.unit_cell().atom(ia).type().hubbard_l() + 1); m1++) {
-                    int mm1 = ((m1 % 2 == 0) - (m1 %2 == 1)) * ((m1 + 1) >> 1) + ctx_.unit_cell().atom(ia).type().hubbard_l();
-                    for (int m2 = 0; m2 < (2 * ctx_.unit_cell().atom(ia).type().hubbard_l() + 1); m2++) {
-                        int mm2 = ((m2 % 2 == 0) - (m2 %2 == 1)) * ((m2 + 1) >> 1) + ctx_.unit_cell().atom(ia).type().hubbard_l();
-                        this->hubbard_potential_(mm1, mm2, 0, ia, 0) = occupation_(m1, m2, 0, ia);
-                        this->hubbard_potential_(mm1, mm2, 1, ia, 0) = occupation_(m1, m2, 3, ia);
-                        this->hubbard_potential_(mm1, mm2, 2, ia, 0) = occupation_(m1, m2, 1, ia);
-                        this->hubbard_potential_(mm1, mm2, 3, ia, 0) = occupation_(m1, m2, 2, ia);
-                    }
-                }
-            } else {
-                for (int m1 = 0; m1 < (2 * ctx_.unit_cell().atom(ia).type().hubbard_l() + 1); m1++) {
-                    int mm1 = ((m1 % 2 == 0) - (m1 %2 == 1)) * ((m1 + 1) >> 1) + ctx_.unit_cell().atom(ia).type().hubbard_l();
-                    for (int m2 = 0; m2 < (2 * ctx_.unit_cell().atom(ia).type().hubbard_l() + 1); m2++) {
-                        int mm2 = ((m2 % 2 == 0) - (m2 %2 == 1)) * ((m2 + 1) >> 1) + ctx_.unit_cell().atom(ia).type().hubbard_l();
-                        this->hubbard_potential_(mm1, mm2, 0, ia, 0) = occupation_(m1, m2, 0, ia);
-                        this->hubbard_potential_(mm1, mm2, 1, ia, 0) = occupation_(m1, m2, 1, ia);
-                    }
+    if(ctx_.num_spins() == 1) {
+        for(int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
+            const int l = ctx_.unit_cell().atom(ia).type().hubbard_l();
+            for (int m1 = -l; m1 <= l; m1++) {
+                const int mm1 = natural_lm_to_qe(m1, l);
+                for (int m2 = -l; m2 <= l ; m2++) {
+                    const int mm2 = natural_lm_to_qe(m2, l);
+                    this->hubbard_potential_(l + m1, l + m2, 0, ia, 0) = 0.5 * occupation_(mm1, mm2, 0, ia);
                 }
             }
         }
-
-        if(ctx_.num_spins() == 1) {
-            for (int m1 = 0; m1 < (2 * ctx_.unit_cell().atom(ia).type().hubbard_l() + 1); m1++) {
-                int mm1 = ((m1 % 2 == 0) - (m1 %2 == 1)) * ((m1 + 1) >> 1) + ctx_.unit_cell().atom(ia).type().hubbard_l();
-                for (int m2 = 0; m2 < (2 * ctx_.unit_cell().atom(ia).type().hubbard_l() + 1); m2++) {
-                    int mm2 = ((m2 % 2 == 0) - (m2 %2 == 1)) * ((m2 + 1) >> 1) + ctx_.unit_cell().atom(ia).type().hubbard_l();
-                    this->hubbard_potential_(mm1, mm2, 0, ia, 0) = occupation_(m1, m2, 0, ia);
+    } else {
+        for(int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
+            const int l = ctx_.unit_cell().atom(ia).type().hubbard_l();
+            for (int m1 = -l; m1 <= l; m1++) {
+                const int mm1 = natural_lm_to_qe(m1, l);
+                for (int m2 = -l; m2 <= l; m2++) {
+                    const int mm2 = natural_lm_to_qe(m2, l);
+                    this->hubbard_potential_(l + m1, l + m2, 0, ia, 0) = 0.5 * occupation_(mm1, mm2, 0, ia);
+                    this->hubbard_potential_(l + m1, l + m2, 1, ia, 0) = 0.5 * occupation_(mm1, mm2, 1, ia);
                 }
+            }
+        }
+    }
+}
+
+inline void set_hubbard_potential_nc(double_complex *occ, int ld)
+{
+    mdarray<double_complex, 4> occupation_(occ, ld, ld, 4, ctx_.unit_cell().num_atoms());
+    //this->calculate_hubbard_potential_and_energy();
+    this->hubbard_potential_.zero();
+    for(int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
+        const int l = ctx_.unit_cell().atom(ia).type().hubbard_l();
+        for (int m1 = -l; m1 <= l; m1++) {
+            const int mm1 = natural_lm_to_qe(m1, l);
+            for (int m2 = -l; m2 <= l; m2++) {
+                const int mm2 = natural_lm_to_qe(m2, l);
+                this->hubbard_potential_(l + m1, l + m2, 0, ia, 0) = 0.5 * occupation_(mm1, mm2, 0, ia);
+                this->hubbard_potential_(l + m1, l + m2, 1, ia, 0) = 0.5 * occupation_(mm1, mm2, 3, ia);
+                this->hubbard_potential_(l + m1, l + m2, 2, ia, 0) = 0.5 * occupation_(mm1, mm2, 1, ia);
+                this->hubbard_potential_(l + m1, l + m2, 3, ia, 0) = 0.5 * occupation_(mm1, mm2, 2, ia);
             }
         }
     }

--- a/src/SDDK/fft3d.hpp
+++ b/src/SDDK/fft3d.hpp
@@ -1,24 +1,24 @@
 // Copyright (c) 2013-2017 Anton Kozhevnikov, Thomas Schulthess
 // All rights reserved.
-// 
-// Redistribution and use in source and binary forms, with or without modification, are permitted provided that 
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that
 // the following conditions are met:
-// 
-// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the 
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
 //    following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions 
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
 //    and the following disclaimer in the documentation and/or other materials provided with the distribution.
-// 
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED 
-// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
-// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR 
-// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
-// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 // OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /** \file fft3d.hpp
- *   
+ *
  *  \brief Contains declaration and partial implementation of FFT3D class.
  */
 
@@ -41,13 +41,13 @@ namespace sddk {
  *  \f[
  *      f({\bf r}) = \sum_{{\bf G}} e^{i{\bf G}{\bf r}} f({\bf G})
  *  \f]
- *  is a \em backward transformation from a set of pw coefficients to a function.  
+ *  is a \em backward transformation from a set of pw coefficients to a function.
  *
  *  \f[
- *      f({\bf G}) = \frac{1}{\Omega} \int e^{-i{\bf G}{\bf r}} f({\bf r}) d {\bf r} = 
+ *      f({\bf G}) = \frac{1}{\Omega} \int e^{-i{\bf G}{\bf r}} f({\bf r}) d {\bf r} =
  *          \frac{1}{N} \sum_{{\bf r}_j} e^{-i{\bf G}{\bf r}_j} f({\bf r}_j)
  *  \f]
- *  is a \em forward transformation from a function to a set of coefficients. 
+ *  is a \em forward transformation from a function to a set of coefficients.
  *
  *  The following cases are handeled by the FFT driver:
  *    - transformation of a single real / complex function (serial / parallel, cpu / gpu)
@@ -72,7 +72,7 @@ namespace sddk {
  *  \f]
  *  it leads to the following symmetry
  *  \f[
- *   \psi_{1,2}^{*}(G_x, G_y, z) = \sum_{G_z} e^{-izG_z} \psi_{1,2}^{*}(G_x, G_y, G_z) = 
+ *   \psi_{1,2}^{*}(G_x, G_y, z) = \sum_{G_z} e^{-izG_z} \psi_{1,2}^{*}(G_x, G_y, G_z) =
  *      \sum_{G_z} e^{-izG_z} \psi_{1,2}(-G_x, -G_y, -G_z) = \psi_{1,2}(-G_x, -G_y, z)
  *  \f]
  *
@@ -82,16 +82,16 @@ namespace sddk {
 class FFT3D
 {
     protected:
-        
+
         /// Communicator for the parallel FFT.
         Communicator const& comm_;
 
         /// Main processing unit of this FFT.
         device_t pu_;
-        
+
         /// Split z-direction.
         splindex<block> spl_z_;
-        
+
         /// Definition of the FFT grid.
         FFT3D_grid grid_;
 
@@ -103,13 +103,13 @@ class FFT3D
 
         /// Main input/output buffer.
         mdarray<double_complex, 1> fft_buffer_;
-        
+
         /// Auxiliary array to store z-sticks for all-to-all or GPU.
         mdarray<double_complex, 1> fft_buffer_aux1_;
-        
+
         /// Auxiliary array in case of simultaneous transformation of two wave-functions.
         mdarray<double_complex, 1> fft_buffer_aux2_;
-        
+
         /// Internal buffer for independent z-transforms.
         std::vector<double_complex*> fftw_buffer_z_;
 
@@ -119,13 +119,13 @@ class FFT3D
         std::vector<fftw_plan> plan_backward_z_;
 
         std::vector<fftw_plan> plan_backward_xy_;
-        
+
         std::vector<fftw_plan> plan_forward_z_;
 
         std::vector<fftw_plan> plan_forward_xy_;
 
         bool is_gpu_direct_{false};
-        
+
         #ifdef __GPU
         /// Handler for xy-transform cuFFT plan.
         cufftHandle cufft_plan_xy_;
@@ -135,7 +135,7 @@ class FFT3D
 
         /// offsets  for z-buffer
         mdarray<int,1> z_offsets_;
-        
+
         /// local sizes for z-buffer
         mdarray<int,1> z_sizes_;
 
@@ -144,26 +144,26 @@ class FFT3D
 
         /// Work buffer, required by cuFFT.
         mdarray<char, 1> cufft_work_buf_;
-       
+
         /// Mapping of the G-vectors to the FFT buffer for batched 1D transform.
         mdarray<int, 1> map_gvec_to_fft_buffer_;
 
         /// Mapping of the {0,0,z} G-vectors to the FFT buffer for batched 1D transform in case of reduced G-vector list.
         mdarray<int, 1> map_gvec_to_fft_buffer_x0y0_;
-        
+
         int const cufft_stream_id{0};
         #endif
 
-        /// Position of z-columns inside 2D FFT buffer. 
+        /// Position of z-columns inside 2D FFT buffer.
         mdarray<int, 2> z_col_pos_;
-        
+
         memory_t host_memory_type_;
-        
+
         /// Maximum number of z-columns ever transformed.
-        /** This is used to recreate the cuFFT plan only when the number of columns has increased */ 
+        /** This is used to recreate the cuFFT plan only when the number of columns has increased */
         int zcol_count_max_{0};
-        
-        /// Defines the distribution of G-vectors between the MPI ranks of FFT communicator. 
+
+        /// Defines the distribution of G-vectors between the MPI ranks of FFT communicator.
         Gvec_partition const* gvec_partition_{nullptr};
 
         /// Serial part of 1D transformation of columns.
@@ -175,11 +175,11 @@ class FFT3D
 
             int num_zcol_local = gvec_partition_->zcol_count_fft();
             double norm = 1.0 / size();
-            
+
             bool is_reduced = gvec_partition_->gvec().reduced();
 
             assert(static_cast<int>(fft_buffer_aux__.size()) >= gvec_partition_->zcol_count_fft() * grid_.size(2));
-            
+
             /* input/output data buffer is on GPU */
             if (data_ptr_type == GPU) {
                 sddk::timer t("sddk::FFT3D::transform_z_serial|gpu");
@@ -189,7 +189,7 @@ class FFT3D
                         /* load all columns into FFT buffer */
                         cufft_batch_load_gpu(num_zcol_local * grid_.size(2),
                                              gvec_partition_->gvec_count_fft(),
-                                             1, 
+                                             1,
                                              map_gvec_to_fft_buffer_.at<GPU>(),
                                              (cuDoubleComplex*)data__,
                                              (cuDoubleComplex*)fft_buffer_aux__.at<GPU>(),
@@ -203,10 +203,10 @@ class FFT3D
                         }
                         /* transform all columns */
                         cufft::backward_transform(cufft_plan_z_, (cuDoubleComplex*)fft_buffer_aux__.at<GPU>());
-                        
+
                         /* copy to temp buffer*/
                         acc::copy<char>((char*)cufft_work_buf_.at<GPU>(), (char*)fft_buffer_aux__.at<GPU>(), sizeof(double_complex)*fft_buffer_aux__.size());
-                        
+
                         /* repack the buffer */
                         cufft_repack_z_buffer(direction,
                                               comm_.size(),
@@ -223,7 +223,7 @@ class FFT3D
                     case -1: {
                         /* copy to temp buffer*/
                         acc::copy<char>((char*)cufft_work_buf_.at<GPU>(), (char*)fft_buffer_aux__.at<GPU>(), sizeof(double_complex)*fft_buffer_aux__.size());
-                        
+
                         /* repack the buffer back*/
                         cufft_repack_z_buffer(direction,
                                               comm_.size(),
@@ -234,7 +234,7 @@ class FFT3D
                                               z_sizes_.at<GPU>(),
                                               (cuDoubleComplex*)fft_buffer_aux__.at<GPU>(),
                                               (cuDoubleComplex*)cufft_work_buf_.at<GPU>());
-                        
+
                         /* transform all columns */
                         cufft::forward_transform(cufft_plan_z_, (cuDoubleComplex*)fft_buffer_aux__.at<GPU>());
                         /* get all columns from FFT buffer */
@@ -256,7 +256,7 @@ class FFT3D
                 acc::sync_stream(cufft_stream_id);
                 #endif
             }
-            
+
             if (data_ptr_type == CPU) {
                 sddk::timer t("sddk::FFT3D::transform_z_serial|cpu");
                 #pragma omp parallel
@@ -290,7 +290,7 @@ class FFT3D
 
                                 /* perform local FFT transform of a column */
                                 fftw_execute(plan_backward_z_[tid]);
-                                
+
                                 /* redistribute z-column for a forthcoming all-to-all or just load the
                                  * full column into auxiliary buffer in serial case */
                                 for (int r = 0; r < comm_.size(); r++) {
@@ -298,7 +298,7 @@ class FFT3D
                                     int offs = spl_z_.global_offset(r);
 
                                     std::copy(&fftw_buffer_z_[tid][offs],
-                                              &fftw_buffer_z_[tid][offs] + lsz, 
+                                              &fftw_buffer_z_[tid][offs] + lsz,
                                               &fft_buffer_aux__[offs * num_zcol_local + i * lsz]);
                                 }
                                 break;
@@ -350,7 +350,7 @@ class FFT3D
                     sddk::timer t("sddk::FFT3D::transform_z|comm|d-1|DtoH");
                     fft_buffer_aux__.copy<memory_t::device, memory_t::host>(local_size_z_ * gvec_partition_->gvec().num_zcol());
                 }
-                
+
                 /* collect full sticks */
                 if (comm_.size() > 1) {
                     sddk::timer t("sddk::FFT3D::transform_z|d-1|comm");
@@ -363,8 +363,8 @@ class FFT3D
                     }
                     send.calc_offsets();
                     recv.calc_offsets();
-                
-                    if (data_ptr_type == CPU || !is_gpu_direct_) {    
+
+                    if (data_ptr_type == CPU || !is_gpu_direct_) {
                         /* copy auxiliary buffer because it will be use as the output buffer in the following mpi_a2a */
                         std::copy(&fft_buffer_aux__[0], &fft_buffer_aux__[0] + gvec_partition_->gvec().num_zcol() * local_size_z_,
                                   &fft_buffer_[0]);
@@ -376,10 +376,10 @@ class FFT3D
                     }
 
                     #ifdef __GPU
-                    if (data_ptr_type == GPU && is_gpu_direct_) {    
+                    if (data_ptr_type == GPU && is_gpu_direct_) {
                         /* copy auxiliary buffer because it will be use as the output buffer in the following mpi_a2a */
                         acc::copy<double_complex>(fft_buffer_.at<GPU>(), fft_buffer_aux__.at<GPU>(), gvec_partition_->gvec().num_zcol() * local_size_z_);
-                        
+
                         comm_.barrier();
                         sddk::timer t("sddk::FFT3D::transform_z|comm|d-1|a2a_gpu");
                         comm_.alltoall(fft_buffer_.at<GPU>(), &send.counts[0], &send.offsets[0], fft_buffer_aux__.at<GPU>(), &recv.counts[0], &recv.offsets[0]);
@@ -423,7 +423,7 @@ class FFT3D
 
                     if (data_ptr_type == CPU || !is_gpu_direct_){
                         comm_.barrier();
-                        sddk::timer t("sddk::FFT3D::transform_z|comm|d1|a2a_cpu"); 
+                        sddk::timer t("sddk::FFT3D::transform_z|comm|d1|a2a_cpu");
                         /* scatter z-columns */
                         comm_.alltoall(&fft_buffer_aux__[0], &send.counts[0], &send.offsets[0], &fft_buffer_[0], &recv.counts[0], &recv.offsets[0]);
                         comm_.barrier();
@@ -435,7 +435,7 @@ class FFT3D
 
                     #ifdef __GPU
                     if (data_ptr_type == GPU && is_gpu_direct_) {
-                        comm_.barrier(); 
+                        comm_.barrier();
                         sddk::timer t("sddk::FFT3D::transform_z|comm|d1|a2a_gpu");
                         /* scatter z-columns */
                         comm_.alltoall(fft_buffer_aux__.at<GPU>(), &send.counts[0], &send.offsets[0], fft_buffer_.at<GPU>(), &recv.counts[0], &recv.offsets[0]);
@@ -453,8 +453,8 @@ class FFT3D
                 }
                 #endif
             }
-        } 
-        
+        }
+
         /// Apply 2D FFT transformation to z-columns of one complex function.
         template <int direction>
         void transform_xy(mdarray<double_complex, 1>& fft_buffer_aux__)
@@ -521,13 +521,13 @@ class FFT3D
                                         fftw_buffer_xy_[tid][z_col_pos_(i, 1)] = std::conj(fftw_buffer_xy_[tid][z_col_pos_(i, 0)]);
                                     }
                                 }
-                                
+
                                 /* execute local FFT transform */
                                 fftw_execute(plan_backward_xy_[tid]);
 
                                 /* copy xy plane to the main FFT buffer */
                                 std::copy(fftw_buffer_xy_[tid], fftw_buffer_xy_[tid] + size_xy, &fft_buffer_[iz * size_xy]);
-                                
+
                                 break;
                             }
                             case -1: {
@@ -555,7 +555,7 @@ class FFT3D
 
         /// Apply 2D FFT transformation to z-columns of two real functions.
         template <int direction>
-        void transform_xy(mdarray<double_complex, 1>& fft_buffer_aux1__, 
+        void transform_xy(mdarray<double_complex, 1>& fft_buffer_aux1__,
                           mdarray<double_complex, 1>& fft_buffer_aux2__)
         {
             PROFILE("sddk::FFT3D::transform_xy");
@@ -617,26 +617,26 @@ class FFT3D
                                 std::fill(fftw_buffer_xy_[tid], fftw_buffer_xy_[tid] + size_xy, 0);
 
                                 /* load first z-column into proper location */
-                                fftw_buffer_xy_[tid][z_col_pos_(0, 0)] = fft_buffer_aux1__[iz] + 
+                                fftw_buffer_xy_[tid][z_col_pos_(0, 0)] = fft_buffer_aux1__[iz] +
                                     double_complex(0, 1) * fft_buffer_aux2__[iz];
 
                                 /* load remaining z-columns into proper location */
                                 for (int i = 1; i < gvec_partition_->gvec().num_zcol(); i++) {
                                     /* {x, y} part */
-                                    fftw_buffer_xy_[tid][z_col_pos_(i, 0)] = fft_buffer_aux1__[iz + i * local_size_z_] + 
+                                    fftw_buffer_xy_[tid][z_col_pos_(i, 0)] = fft_buffer_aux1__[iz + i * local_size_z_] +
                                         double_complex(0, 1) * fft_buffer_aux2__[iz + i * local_size_z_];
 
                                     /* {-x, -y} part */
                                     fftw_buffer_xy_[tid][z_col_pos_(i, 1)] = std::conj(fft_buffer_aux1__[iz + i * local_size_z_]) +
                                         double_complex(0, 1) * std::conj(fft_buffer_aux2__[iz + i * local_size_z_]);
                                 }
-                                
+
                                 /* execute local FFT transform */
                                 fftw_execute(plan_backward_xy_[tid]);
 
                                 /* copy xy plane to the main FFT buffer */
                                 std::copy(fftw_buffer_xy_[tid], fftw_buffer_xy_[tid] + size_xy, &fft_buffer_[iz * size_xy]);
-                                
+
                                 break;
                             }
                             case -1: {
@@ -648,10 +648,10 @@ class FFT3D
 
                                 /* get z-columns */
                                 for (int i = 0; i < gvec_partition_->gvec().num_zcol(); i++) {
-                                    fft_buffer_aux1__[iz  + i * local_size_z_] = 0.5 * 
+                                    fft_buffer_aux1__[iz  + i * local_size_z_] = 0.5 *
                                         (fftw_buffer_xy_[tid][z_col_pos_(i, 0)] + std::conj(fftw_buffer_xy_[tid][z_col_pos_(i, 1)]));
 
-                                    fft_buffer_aux2__[iz  + i * local_size_z_] = double_complex(0, -0.5) * 
+                                    fft_buffer_aux2__[iz  + i * local_size_z_] = double_complex(0, -0.5) *
                                         (fftw_buffer_xy_[tid][z_col_pos_(i, 0)] - std::conj(fftw_buffer_xy_[tid][z_col_pos_(i, 1)]));
                                 }
 
@@ -667,7 +667,7 @@ class FFT3D
         }
 
     public:
-        
+
         /// Constructor.
         FFT3D(FFT3D_grid grid__,
               Communicator const& comm__,
@@ -691,7 +691,7 @@ class FFT3D
 
             /* allocate main buffer */
             fft_buffer_ = mdarray<double_complex, 1>(local_size(), host_memory_type_, "FFT3D.fft_buffer_");
-            
+
             /* allocate 1d and 2d buffers */
             for (int i = 0; i < omp_get_max_threads(); i++) {
                 fftw_buffer_z_.push_back((double_complex*)fftw_malloc(grid_.size(2) * sizeof(double_complex)));
@@ -704,22 +704,22 @@ class FFT3D
             plan_backward_xy_ = std::vector<fftw_plan>(omp_get_max_threads());
 
             for (int i = 0; i < omp_get_max_threads(); i++) {
-                plan_forward_z_[i] = fftw_plan_dft_1d(grid_.size(2), (fftw_complex*)fftw_buffer_z_[i], 
+                plan_forward_z_[i] = fftw_plan_dft_1d(grid_.size(2), (fftw_complex*)fftw_buffer_z_[i],
                                                       (fftw_complex*)fftw_buffer_z_[i], FFTW_FORWARD, FFTW_ESTIMATE);
 
-                plan_backward_z_[i] = fftw_plan_dft_1d(grid_.size(2), (fftw_complex*)fftw_buffer_z_[i], 
+                plan_backward_z_[i] = fftw_plan_dft_1d(grid_.size(2), (fftw_complex*)fftw_buffer_z_[i],
                                                        (fftw_complex*)fftw_buffer_z_[i], FFTW_BACKWARD, FFTW_ESTIMATE);
-                
-                plan_forward_xy_[i] = fftw_plan_dft_2d(grid_.size(1), grid_.size(0), (fftw_complex*)fftw_buffer_xy_[i], 
+
+                plan_forward_xy_[i] = fftw_plan_dft_2d(grid_.size(1), grid_.size(0), (fftw_complex*)fftw_buffer_xy_[i],
                                                        (fftw_complex*)fftw_buffer_xy_[i], FFTW_FORWARD, FFTW_ESTIMATE);
 
-                plan_backward_xy_[i] = fftw_plan_dft_2d(grid_.size(1), grid_.size(0), (fftw_complex*)fftw_buffer_xy_[i], 
+                plan_backward_xy_[i] = fftw_plan_dft_2d(grid_.size(1), grid_.size(0), (fftw_complex*)fftw_buffer_xy_[i],
                                                         (fftw_complex*)fftw_buffer_xy_[i], FFTW_BACKWARD, FFTW_ESTIMATE);
             }
-            
+
             #ifdef __GPU
             if (pu_ == GPU) {
-                
+
                 #ifdef __GPU_DIRECT
                 #pragma message "=========== GPU direct is enabled =============="
                 is_gpu_direct_ = true;
@@ -754,7 +754,7 @@ class FFT3D
             }
             #endif
         }
-        
+
         /// Destructor.
         ~FFT3D()
         {
@@ -790,7 +790,7 @@ class FFT3D
                 fft_buffer_.copy<memory_t::host, memory_t::device>();
             }
         }
-        
+
         /// Get real-space values from the FFT buffer.
         /** \param [out] data CPU pointer to the real-space data. */
         inline void output(double* data__)
@@ -802,7 +802,7 @@ class FFT3D
                 data__[i] = fft_buffer_[i].real();
             }
         }
-        
+
         /// Get real-space values from the FFT buffer.
         /** \param [out] data CPU pointer to the real-space data. */
         inline void output(double_complex* data__)
@@ -820,19 +820,19 @@ class FFT3D
                 }
             }
         }
-        
+
         /// Informational about the FFT grid.
         FFT3D_grid const& grid() const
         {
             return grid_;
         }
-        
+
         /// Total size of the FFT grid.
         inline int size() const
         {
             return grid_.size();
         }
-        
+
         /// Size of the local part of FFT buffer.
         inline int local_size() const
         {
@@ -854,32 +854,32 @@ class FFT3D
         {
             return fft_buffer_[idx__];
         }
-        
+
         /// FFT buffer.
         inline mdarray<double_complex, 1>& buffer()
         {
             return fft_buffer_;
         }
-        
+
         /// Communicator of the FFT transform.
         Communicator const& comm() const
         {
             return comm_;
         }
-        
+
         /// True if this FFT transformation is parallel.
         inline bool parallel() const
         {
             return (comm_.size() != 1);
         }
-        
+
         /// Return the type of processing unit.
         inline device_t pu() const
         {
             return pu_;
         }
-        
-        /// Prepare FFT driver to transfrom functions with the specific G-vector distribution. 
+
+        /// Prepare FFT driver to transfrom functions with the specific G-vector distribution.
         void prepare(Gvec_partition const& gvec__)
         {
             PROFILE("sddk::FFT3D::prepare");
@@ -891,7 +891,7 @@ class FFT3D
             gvec_partition_ = &gvec__;
 
             int nc = gvec__.gvec().reduced() ? 2 : 1;
-            
+
             sddk::timer t1("sddk::FFT3D::prepare|cpu");
             /* get positions of z-columns in xy plane */
             z_col_pos_ = mdarray<int, 2>(gvec__.gvec().num_zcol(), nc, memory_t::host, "FFT3D.z_col_pos_");
@@ -934,7 +934,7 @@ class FFT3D
                     }
                 }
                 map_gvec_to_fft_buffer_.copy<memory_t::host, memory_t::device>();
-                
+
                 /* for the rank that stores {x=0,y=0} column we need to create a small second mapping */
                 if (gvec__.gvec().reduced() && comm_.rank() == 0) {
                     map_gvec_to_fft_buffer_x0y0_ = mdarray<int, 1>(gvec__.gvec().zcol(0).z.size(), memory_t::host | memory_t::device,
@@ -946,7 +946,7 @@ class FFT3D
                     }
                     map_gvec_to_fft_buffer_x0y0_.copy<memory_t::host, memory_t::device>();
                 }
-                
+
                 int dim_z[] = {grid_.size(2)};
                 int dims_xy[] = {grid_.size(1), grid_.size(0)};
 
@@ -959,24 +959,24 @@ class FFT3D
 
                     cufft::create_batch_plan(cufft_plan_z_, 1, dim_z, dim_z, 1, grid_.size(2), zcol_count_max_, 0);
                 }
-                
+
                 /* maximum worksize of z and xy transforms */
                 work_size = std::max(cufft::get_work_size(2, dims_xy, local_size_z_),
                                      cufft::get_work_size(1, dim_z, gvec__.zcol_count_fft()));
-                
+
                 /* use as temp array also after z-transform*/
                 work_size = std::max(work_size, sizeof(double_complex) * grid_.size(2) * local_size_z_);
 
                 /* allocate cufft work buffer */
                 cufft_work_buf_ = mdarray<char, 1>(work_size, memory_t::device, "FFT3D.cufft_work_buf_");
-                               
-                /* set work area for cufft */ 
+
+                /* set work area for cufft */
                 cufft::set_work_area(cufft_plan_xy_, cufft_work_buf_.at<GPU>());
                 cufft::set_work_area(cufft_plan_z_, cufft_work_buf_.at<GPU>());
 
                 fft_buffer_aux1_.allocate(memory_t::device);
                 fft_buffer_aux2_.allocate(memory_t::device);
-                
+
                 fft_buffer_.allocate(memory_t::device);
 
                 z_col_pos_.allocate(memory_t::device);
@@ -992,13 +992,15 @@ class FFT3D
                 fft_buffer_aux2_.deallocate(memory_t::device);
                 z_col_pos_.deallocate(memory_t::device);
                 fft_buffer_.deallocate(memory_t::device);
+                #ifdef __GPU
                 cufft_work_buf_.deallocate(memory_t::device);
                 map_gvec_to_fft_buffer_.deallocate(memory_t::device);
                 map_gvec_to_fft_buffer_x0y0_.deallocate(memory_t::device);
+                #endif
             }
             gvec_partition_ = nullptr;
         }
-        
+
         /// Transform a single functions.
         template <int direction, device_t data_ptr_type = CPU>
         void transform(double_complex* data__)
@@ -1042,7 +1044,7 @@ class FFT3D
                 }
             }
         }
-        
+
         /// Transform two real functions.
         template <int direction, device_t data_ptr_type = CPU>
         void transform(double_complex* data1__, double_complex* data2__)
@@ -1067,7 +1069,7 @@ class FFT3D
             } else {
                 sz_max = grid_.size(2) * gvec_partition_->gvec().num_zcol();
             }
-            
+
             if (sz_max > fft_buffer_aux1_.size()) {
                 fft_buffer_aux1_ = mdarray<double_complex, 1>(sz_max, host_memory_type_, "fft_buffer_aux1_");
                 if (pu_ == GPU) {
@@ -1108,7 +1110,7 @@ class FFT3D
  *
  *  We use plane waves in two different cases: a) plane waves (or augmented plane waves in the case of APW+lo method)
  *  as a basis for expanding Kohn-Sham wave functions and b) plane waves are used to expand charge density and
- *  potential. When we are dealing with plane wave basis functions it is convenient to adopt the following 
+ *  potential. When we are dealing with plane wave basis functions it is convenient to adopt the following
  *  normalization:
  *  \f[
  *      \langle {\bf r} |{\bf G+k} \rangle = \frac{1}{\sqrt \Omega} e^{i{\bf (G+k)r}}
@@ -1117,17 +1119,16 @@ class FFT3D
  *  \f[
  *      \langle {\bf G+k} |{\bf G'+k} \rangle_{\Omega} = \delta_{{\bf GG'}}
  *  \f]
- *  in the unit cell. However, for the expansion of periodic functions such as density or potential, the following 
+ *  in the unit cell. However, for the expansion of periodic functions such as density or potential, the following
  *  convention is more appropriate:
  *  \f[
  *      \rho({\bf r}) = \sum_{\bf G} e^{i{\bf Gr}} \rho({\bf G})
  *  \f]
  *  where
  *  \f[
- *      \rho({\bf G}) = \frac{1}{\Omega} \int_{\Omega} e^{-i{\bf Gr}} \rho({\bf r}) d{\bf r} = 
- *          \frac{1}{\Omega} \sum_{{\bf r}_i} e^{-i{\bf Gr}_i} \rho({\bf r}_i) \frac{\Omega}{N} = 
- *          \frac{1}{N} \sum_{{\bf r}_i} e^{-i{\bf Gr}_i} \rho({\bf r}_i) 
+ *      \rho({\bf G}) = \frac{1}{\Omega} \int_{\Omega} e^{-i{\bf Gr}} \rho({\bf r}) d{\bf r} =
+ *          \frac{1}{\Omega} \sum_{{\bf r}_i} e^{-i{\bf Gr}_i} \rho({\bf r}_i) \frac{\Omega}{N} =
+ *          \frac{1}{N} \sum_{{\bf r}_i} e^{-i{\bf Gr}_i} \rho({\bf r}_i)
  *  \f]
  *  i.e. with such convention the plane-wave expansion coefficients are obtained with a normalized FFT.
  */
-

--- a/src/Unit_cell/atom_type.h
+++ b/src/Unit_cell/atom_type.h
@@ -452,6 +452,7 @@ class Atom_type
         if (augment_) {
             TERMINATE("can't add more beta projectors");
         }
+        std::cout << l__ << std::endl;
         Spline<double> s(radial_grid_, beta__);
         beta_radial_functions_.push_back(std::move(std::make_pair(l__, std::move(s))));
     }

--- a/src/Unit_cell/atom_type.h
+++ b/src/Unit_cell/atom_type.h
@@ -436,7 +436,6 @@ class Atom_type
         if (augment_) {
             TERMINATE("can't add more beta projectors");
         }
-        std::cout << l__ << std::endl;
         Spline<double> s(radial_grid_, beta__);
         beta_radial_functions_.push_back(std::move(std::make_pair(l__, std::move(s))));
     }

--- a/src/hubbard.hpp
+++ b/src/hubbard.hpp
@@ -49,7 +49,7 @@ class Hubbard_potential
     bool orthogonalize_hubbard_orbitals_{false};
 
     /// by default we just normalize them
-    bool normalize_orbitals_only_{true};
+    bool normalize_orbitals_only_{false};
 
     /// hubbard correction with next nearest neighbors
     bool hubbard_U_plus_V_{false};
@@ -74,19 +74,19 @@ public:
         hubbard_U_plus_V_ = true;
     }
 
-    void set_hubbard_simple_method(const bool approx)
+    void set_hubbard_simple_correction()
     {
-        approximation_ = approx;
+        approximation_ = true;
     }
 
     void set_orthogonalize_hubbard_orbitals(const bool test)
     {
-        this->orthogonalize_hubbard_orbitals_ = true;
+        this->orthogonalize_hubbard_orbitals_ = test;
     }
 
-    void set_normalize_hubbard_orbitals_only(const bool test)
+    void set_normalize_hubbard_orbitals(const bool test)
     {
-        this->normalize_orbitals_only_ = true;
+        this->normalize_orbitals_only_ = test;
     }
 
     double_complex U(int m1, int m2, int m3, int m4) const
@@ -114,7 +114,7 @@ public:
         return this->orthogonalize_hubbard_orbitals_;
     }
 
-    const bool& normalize_hubbard_orbitals_only() const
+    const bool& normalize_hubbard_orbitals() const
     {
         return this->normalize_orbitals_only_;
     }
@@ -178,8 +178,8 @@ public:
     {
         if (!ctx_.hubbard_correction())
             return;
-        this->orthogonalize_hubbard_orbitals_ = ctx_.Hubbard().hubbard_orthogonalization_;
-        this->normalize_orbitals_only_        = ctx_.Hubbard().hubbard_normalization_;
+        this->orthogonalize_hubbard_orbitals_ = ctx_.Hubbard().orthogonalize_hubbard_orbitals_;
+        this->normalize_orbitals_only_        = ctx_.Hubbard().normalize_hubbard_orbitals_;
         this->projection_method_ = ctx_.Hubbard().projection_method_;
 
         // if the projectors are defined externaly then we need the file
@@ -218,6 +218,7 @@ public:
         this->mixer_input();
         mixer_->initialize();
         calculate_hubbard_potential_and_energy();
+        printf("We are where we should be\n");
     }
 
     inline void mixer_input()

--- a/src/input.h
+++ b/src/input.h
@@ -511,8 +511,9 @@ struct Hubbard_input
 {
     int number_of_species{1};
     bool hubbard_correction_{false};
-    bool hubbard_orthogonalization_{false};
-    bool hubbard_normalization_{false};
+    bool simplified_hubbard_correction_{false};
+    bool orthogonalize_hubbard_orbitals_{false};
+    bool normalize_hubbard_orbitals_{false};
     bool hubbard_starting_magnetization_{false};
     bool hubbard_U_plus_V_{false};
     int projection_method_{0};
@@ -529,16 +530,20 @@ struct Hubbard_input
         if (!parser.count("hubbard"))
             return;
 
-        hubbard_orthogonalization_ = false;
+        orthogonalize_hubbard_orbitals_ = false;
         if (parser["hubbard"].count("orthogonalize_hubbard_wave_functions")) {
-            hubbard_orthogonalization_ = parser["hubbard"].value("orthogonalize_hubbard_wave_functions", hubbard_orthogonalization_);
+            orthogonalize_hubbard_orbitals_ = parser["hubbard"].value("orthogonalize_hubbard_wave_functions", orthogonalize_hubbard_orbitals_);
         }
 
-        hubbard_normalization_ = false;
+        normalize_hubbard_orbitals_ = false;
         if (parser["hubbard"].count("normalize_hubbard_wave_functions")) {
-            hubbard_normalization_ = parser["hubbard"].value("normalize_hubbard_wave_functions", hubbard_normalization_);
+            normalize_hubbard_orbitals_ = parser["hubbard"].value("normalize_hubbard_wave_functions", normalize_hubbard_orbitals_);
         }
 
+        if (parser["hubbard"].count("simplified_hubbard_correction")) {
+            simplified_hubbard_correction_ = parser["hubbard"].value("simplified_hubbard_correction",
+                                                                     simplified_hubbard_correction_);
+        }
         std::vector<double> coef_;
         std::vector<std::string> labels_;
         coef_.clear();

--- a/src/k_point.h
+++ b/src/k_point.h
@@ -54,7 +54,7 @@ class K_point
 
         /// List of G-vectors with |G+k| < cutoff.
         std::unique_ptr<Gvec> gkvec_;
-        
+
         std::unique_ptr<Gvec_partition> gkvec_partition_;
 
         /// First-variational eigen values
@@ -67,7 +67,7 @@ class K_point
         std::unique_ptr<Wave_functions> fv_eigen_vectors_slab_;
 
         std::unique_ptr<Wave_functions> singular_components_;
-        
+
         /// Second-variational eigen vectors.
         /** Second-variational eigen-vectors are stored as one or two \f$ N_{fv} \times N_{fv} \f$ matrices in
          *  case of non-magnetic or collinear magnetic case or as a single \f$ 2 N_{fv} \times 2 N_{fv} \f$
@@ -368,6 +368,12 @@ class K_point
             assert(j__ >= 0 && j__ < static_cast<int>(band_occupancies_.size()));
             return band_occupancies_[j__];
         }
+
+        inline std::vector<double>& band_occupancy()
+        {
+            return band_occupancies_;
+        }
+
 
         inline double band_energy(int j__) const
         {

--- a/src/radial_integrals.h
+++ b/src/radial_integrals.h
@@ -106,9 +106,10 @@ class Radial_integrals_atomic_wf : public Radial_integrals_base<2>
 
             auto& atom_type = unit_cell_.atom_type(iat);
             /* create jl(qx) */
+
             #pragma omp parallel for
             for (int iq = 0; iq < nq(); iq++) {
-                jl(iq) = Spherical_Bessel_functions(atom_type.indexr().lmax(), atom_type.radial_grid(), grid_q_[iq]);
+                jl(iq) = Spherical_Bessel_functions(5, atom_type.radial_grid(), grid_q_[iq]);
             }
 
             int nwf = static_cast<int>(atom_type.pp_desc().atomic_pseudo_wfs_.size());
@@ -131,7 +132,7 @@ class Radial_integrals_atomic_wf : public Radial_integrals_base<2>
                 double norm = inner(wf, wf, 0);
 
                 int l = atom_type.pp_desc().atomic_pseudo_wfs_[i].first;
-                
+                std::cout << l << std::endl;
                 #pragma omp parallel for
                 for (int iq = 0; iq < nq(); iq++) {
                     values_(i, iat)[iq] = sirius::inner(jl(iq)[l], wf, 1) / std::sqrt(norm);
@@ -412,7 +413,7 @@ class Radial_integrals_beta : public Radial_integrals_base<2>
         values_ = mdarray<Spline<double>, 2>(unit_cell_.max_mt_radial_basis_size(), unit_cell_.num_atom_types());
         generate();
     }
-    
+
     /// Get all values for a given atom type and q-point.
     inline mdarray<double, 1> values(int iat__, double q__) const
     {

--- a/src/simulation_parameters.h
+++ b/src/simulation_parameters.h
@@ -138,6 +138,22 @@ class Simulation_parameters
     inline void set_hubbard_correction(bool hubbard_correction__)
     {
         parameters_input_.hubbard_correction_ = hubbard_correction__;
+        hubbard_input_.simplified_hubbard_correction_ = false;
+    }
+
+    inline void set_hubbard_simplified_version()
+    {
+        hubbard_input_.simplified_hubbard_correction_ = true;
+    }
+
+    inline void set_orthogonalize_hubbard_orbitals(const bool test)
+    {
+        hubbard_input_.orthogonalize_hubbard_orbitals_ = true;
+    }
+
+    inline void set_normalize_hubbard_orbitals(const bool test)
+    {
+        hubbard_input_.normalize_hubbard_orbitals_ = true;
     }
 
     inline void set_gamma_point(bool gamma_point__)

--- a/src/sirius.f90
+++ b/src/sirius.f90
@@ -999,12 +999,14 @@ module sirius
             integer,                 intent(in)  :: flg
         end subroutine
 
-        subroutine sirius_add_atom_type_chi(atom_type, l, num_points, chi)&
+        subroutine sirius_add_atom_type_chi(atom_type, l, jchi, num_points, chi, oc)&
             &bind(C, name="sirius_add_atom_type_chi")
             character,         target, dimension(*), intent(in)  :: atom_type
             integer,                                 intent(in)  :: l
+            REAL(8),                                 intent(in)  :: jchi
             integer,                                 intent(in)  :: num_points
             real(8),                                 intent(in)  :: chi
+            real(8),                                 intent(in)  :: oc
         end subroutine
 
         subroutine sirius_set_esm(enable_esm, esm_bc)&
@@ -1013,28 +1015,66 @@ module sirius
             character,         target, dimension(*), intent(in)  :: esm_bc
         end subroutine
 
-        subroutine sirius_set_hubbard_correction(hubbard_correction_)&
+                subroutine sirius_set_hubbard_correction()&
           &bind(C, name="sirius_set_hubbard_correction")
-          logical(1),                                intent(in) :: hubbard_correction_
         end subroutine sirius_set_hubbard_correction
 
-        subroutine sirius_set_hubbard_occupations(occ, ld)&
-          &bind(C, name="sirius_set_hubbard_occupations")
+        subroutine sirius_set_hubbard_occupancies(occ, ld)&
+          &bind(C, name="sirius_set_hubbard_occupancies")
+          real(8),             target, dimension(*),                  intent(in) :: occ
+          integer,                                   intent(in) :: ld
+        end subroutine sirius_set_hubbard_occupancies
+
+        subroutine sirius_get_hubbard_occupancies(occ, ld)&
+             &bind(C, name="sirius_get_hubbard_occupancies")
+          real(8),                                   intent(out) :: occ
+          integer,                                   intent(in) :: ld
+        end subroutine sirius_get_hubbard_occupancies
+
+        subroutine sirius_set_hubbard_occupancies_nc(occ, ld)&
+             &bind(C, name="sirius_set_hubbard_occupancies_nc")
           complex(8),                                intent(in) :: occ
           integer,                                   intent(in) :: ld
-        end subroutine sirius_set_hubbard_occupations
+        end subroutine sirius_set_hubbard_occupancies_nc
 
         subroutine sirius_set_hubbard_potential(occ, ld)&
           &bind(C, name="sirius_set_hubbard_potential")
-          complex(8),                                intent(in) :: occ
+          real(8),                                   intent(in) :: occ
           integer,                                   intent(in) :: ld
         end subroutine sirius_set_hubbard_potential
 
+        subroutine sirius_set_hubbard_potential_nc(occ, ld)&
+             &bind(C, name="sirius_set_hubbard_potential_nc")
+          complex(8),                                intent(in) :: occ
+          integer,                                   intent(in) :: ld
+        end subroutine sirius_set_hubbard_potential_nc
 
-        subroutine sirius_set_atom_type_hubbard(label__, hub_correction, J_, theta_, phi_, alpha_, beta_, J0_)&
+        subroutine sirius_get_hubbard_occupancies_nc(occ, ld)&
+             &bind(C, name="sirius_get_hubbard_occupancies_nc")
+          complex(8),                                intent(out) :: occ
+          integer,                                   intent(in) :: ld
+        end subroutine sirius_get_hubbard_occupancies_nc
+
+        subroutine sirius_calculate_hubbard_potential()&
+             &bind(C, name="sirius_calculate_hubbard_potential")
+        end subroutine sirius_calculate_hubbard_potential
+
+        subroutine sirius_set_hubbard_simplified_method()&
+             &bind(C, name="sirius_set_hubbard_simplified_method")
+        end subroutine sirius_set_hubbard_simplified_method
+
+        subroutine sirius_set_orthogonalize_hubbard_orbitals()&
+             &bind(C, name="sirius_set_orthogonalize_hubbard_orbitals")
+        end subroutine sirius_set_orthogonalize_hubbard_orbitals
+
+        subroutine sirius_set_normalize_hubbard_orbitals()&
+             &bind(C, name="sirius_set_normalize_hubbard_orbitals")
+        end subroutine sirius_set_normalize_hubbard_orbitals
+
+        subroutine sirius_set_atom_type_hubbard(label__, U_, J_, theta_, phi_, alpha_, beta_, J0_)&
           &bind(C, name="sirius_set_atom_type_hubbard")
           character, dimension(*), intent(in) :: label__
-          logical(1),                intent(in) :: hub_correction
+          real(8),                intent(in) :: U_
           real(8),                intent(in) :: J_
           real(8),                intent(in) :: theta_
           real(8),                intent(in) :: phi_
@@ -1042,6 +1082,10 @@ module sirius
           real(8),                intent(in) :: beta_
           real(8),                intent(in) :: J0_
         end subroutine sirius_set_atom_type_hubbard
+
+        subroutine sirius_calculate_hubbard_occupancies()&
+             &bind(C, name="sirius_calculate_hubbard_occupancies")
+        end subroutine sirius_calculate_hubbard_occupancies
 
         subroutine sirius_create_storage_file()&
           &bind(C, name="sirius_create_storage_file")

--- a/src/sirius_api.cpp
+++ b/src/sirius_api.cpp
@@ -398,7 +398,7 @@ void sirius_set_atom_type_radial_grid(char const* label__,
  *  \param [in] J0_ : J0 for the simple hubbard treatment
  */
 void sirius_set_atom_type_hubbard(char const* label__,
-                                  int32_t const* hub_correction,
+                                  double const* U_,
                                   double const* J_,
                                   double const* theta_,
                                   double const* phi_,
@@ -407,17 +407,15 @@ void sirius_set_atom_type_hubbard(char const* label__,
                                   double const* J0_)
 {
     auto& type = sim_ctx->unit_cell().atom_type(std::string(label__));
-    if (*hub_correction > 0) {
-        type.set_hubbard_correction(true);
-        type.set_hubbard_alpha(*alpha_);
-        type.set_hubbard_beta(*alpha_);
-        type.set_hubbard_coefficients(J_);
-        type.set_starting_magnetization_theta(*theta_);
-        type.set_starting_magnetization_phi(*phi_);
-        type.set_hubbard_J0(*J0_);
-    }
-
-    type.set_hubbard_correction(false);
+    type.set_hubbard_U(*U_ * 0.5);
+    type.set_hubbard_J(J_[1] * 0.5);
+    type.set_hubbard_correction(true);
+    type.set_hubbard_alpha(*alpha_);
+    type.set_hubbard_beta(*alpha_);
+    type.set_hubbard_coefficients(J_);
+    type.set_starting_magnetization_theta(*theta_);
+    type.set_starting_magnetization_phi(*phi_);
+    type.set_hubbard_J0(*J0_);
 }
 
 void sirius_set_free_atom_density(char const* label__,
@@ -822,12 +820,15 @@ void sirius_set_band_occupancies(ftn_int*    kset_id__,
     for (int i = 0; i < *num_bands__; i++) {
         (*kset_list[*kset_id__])[ik]->band_occupancy(i) = band_occupancies__[i];
     }
+    for (int i = *num_bands__; i < (*kset_list[*kset_id__])[ik]->band_occupancy().size(); i++) {
+        (*kset_list[*kset_id__])[ik]->band_occupancy(i) = 0.0;
+    }
 }
 
 void sirius_get_band_energies(ftn_int*    kset_id__,
                               ftn_int*    ik__,
                               ftn_double* band_energies__,
-                              ftn_int*    num_bands__) 
+                              ftn_int*    num_bands__)
 {
     int ik = *ik__ - 1;
     for (int i = 0; i < *num_bands__; i++) {
@@ -3253,11 +3254,17 @@ void sirius_get_stress_tensor(ftn_char label__, ftn_double* stress_tensor__)
 
 void sirius_add_atom_type_chi(ftn_char label__,
                               ftn_int* l__,
+                              ftn_double* jchi,
                               ftn_int* num_points__,
-                              ftn_double* chi__)
+                              ftn_double* chi__,
+                              ftn_double* oc)
 {
     auto& type = sim_ctx->unit_cell().atom_type(std::string(label__));
     type.pp_desc().atomic_pseudo_wfs_.push_back(std::make_pair(*l__, std::vector<double>(chi__, chi__ + *num_points__)));
+    if (type.pp_desc().spin_orbit_coupling) {
+        type.pp_desc().total_angular_momentum_wfs.push_back(*jchi);
+    }
+    type.pp_desc().occupation_wfs.push_back(*oc);
 }
 
 void sirius_set_processing_unit(ftn_char pu__)
@@ -3294,23 +3301,66 @@ void sirius_set_esm(ftn_bool* enable_esm__, ftn_char esm_bc__)
     sim_ctx->parameters_input().esm_bc_ = std::string(esm_bc__);
 }
 
-} // extern "C"
-
-void sirius_set_hubbard_correction(int32_t *hubbard_correction_)
-{
-    if (*hubbard_correction_ != 0) {
+    void sirius_set_hubbard_correction()
+    {
         sim_ctx->set_hubbard_correction(true);
-    } else {
-        sim_ctx->set_hubbard_correction(false);
     }
+
+    void sirius_set_hubbard_occupancies(ftn_double *occ, ftn_int *ld)
+    {
+        hamiltonian->U().set_hubbard_occupancies_matrix(occ, *ld);
+    }
+
+    void sirius_get_hubbard_occupancies(ftn_double *occ, ftn_int *ld)
+    {
+        hamiltonian->U().get_hubbard_occupancies_matrix(occ, *ld);
+    }
+
+
+    void sirius_set_hubbard_occupancies_nc(ftn_double_complex *occ, ftn_int *ld)
+    {
+        hamiltonian->U().set_hubbard_occupancies_matrix_nc(occ, *ld);
+    }
+
+    void sirius_get_hubbard_occupancies_nc(ftn_double_complex *occ, ftn_int *ld)
+    {
+        hamiltonian->U().get_hubbard_occupancies_matrix_nc(occ, *ld);
+    }
+
+
+    void sirius_set_hubbard_potential(ftn_double *occ, ftn_int *ld)
+    {
+        hamiltonian->U().set_hubbard_potential(occ, *ld);
+    }
+
+    void sirius_set_hubbard_potential_nc(ftn_double_complex *occ, ftn_int *ld)
+    {
+        hamiltonian->U().set_hubbard_potential_nc(occ, *ld);
+    }
+
+    void sirius_calculate_hubbard_occupancies()
+    {
+        hamiltonian->U().hubbard_compute_occupation_numbers(*kset_list[0]);
+    }
+
+    void sirius_calculate_hubbard_potential()
+    {
+        hamiltonian->U().calculate_hubbard_potential_and_energy();
+    }
+
+    void sirius_set_orthogonalize_hubbard_orbitals()
+    {
+        sim_ctx->set_orthogonalize_hubbard_orbitals(true);
+    }
+
+    void sirius_set_normalize_hubbard_orbitals()
+    {
+        sim_ctx->set_normalize_hubbard_orbitals(true);
+    }
+
+void sirius_set_hubbard_simplified_method()
+{
+    sim_ctx->set_hubbard_simplified_version();
 }
 
-void sirius_set_hubbard_occupations(ftn_double_complex *occ, ftn_int *ld)
-{
-    hamiltonian->U().set_hubbard_occupation_matrix(occ, *ld);
-}
-
-void sirius_set_hubbard_potential(ftn_double_complex *occ, ftn_int *ld)
-{
-    hamiltonian->U().set_hubbard_potential(occ, *ld);
-}
+} // extern "C"

--- a/src/sirius_api.cpp
+++ b/src/sirius_api.cpp
@@ -2131,7 +2131,7 @@ void sirius_set_atom_type_beta_rf(ftn_char     label__,
         double* ptr = &beta_rf(0, i);
         int l = beta_l__[i];
         if (*spin_orbit__) {
-            if (beta_j__[i] < beta_l__[l])
+            if (beta_j__[i] < beta_l__[i])
                 l *= -1;
         }
         type.add_beta_radial_function(l, std::vector<double>(ptr, ptr + num_mesh_points__[i]));

--- a/src/sirius_api.cpp
+++ b/src/sirius_api.cpp
@@ -2129,7 +2129,12 @@ void sirius_set_atom_type_beta_rf(ftn_char     label__,
 
     for (int i = 0; i < *num_beta__; i++) {
         double* ptr = &beta_rf(0, i);
-        type.add_beta_radial_function(beta_l__[i], std::vector<double>(ptr, ptr + num_mesh_points__[i]));
+        int l = beta_l__[i];
+        if (*spin_orbit__) {
+            if (beta_j__[i] < beta_l__[l])
+                l *= -1;
+        }
+        type.add_beta_radial_function(l, std::vector<double>(ptr, ptr + num_mesh_points__[i]));
     }
 }
 


### PR DESCRIPTION
Anton,

This a pull request closing (almost) the initial implementation of the hubbard correction. The interface with q-e is working as well as the standalone version. However running the standalone or q-e+sirius won't give the same final answer. It is not linked to the hubbard correction since the calculations of the occupation numbers and hubbard potential gives the same answewr between q-e and sirius. 

So far the pull request contains

- Hubbard correction (full treatment) for LDA, colinear and non colinear magnetism, SO, bref anything we can through at it.
- Initial infrastructure for the multi-channel LDA+U (which is not in q-e)
- Various refactoring in SDDK (matrix.hpp)
-  complete api for hubbard (may need a bit of refactoring)

remain to be done
- GPU stuff (mostly copy wfc and that's all)
- hubbard force and stresses
- multichannel (can we skip it ?)

best

M.
