### PR TITLE
cleanup cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_STANDARD 11)
 
 # user variables
 set(CREATE_PYTHON_MODULE OFF CACHE BOOL "create sirius python module")
+set(CREATE_FORTRAN_BINDINGS ON CACHE BOOL "build Fortran bindings")
 set(BUILD_DOCS OFF CACHE BOOL "build doxygen doc")
 set(USE_ELPA OFF CACHE BOOL "use scalapack")
 set(USE_MAGMA OFF CACHE BOOL "use MAGMA")
@@ -155,24 +156,29 @@ configure_file("${PROJECT_SOURCE_DIR}/src/version.hpp.in" "${PROJECT_BINARY_DIR}
 include_directories(BEFORE ${PROJECT_BINARY_DIR}/src)
 
 MACRO(SIRIUS_SETUP_TARGET _target)
-  add_dependencies(${_target} sirius)
+  if(USE_CUDA)
+    add_dependencies(${_target} sirius_cu)
+  endif()
+
   if(USE_MKL)
     # TODO: handle -lpthread properly
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-      target_link_libraries(${_target} PRIVATE "${sirius_location};${SYSTEM_LIBRARIES};${HDF5_C_LIBRARIES};${HDF5_C_HL_LIBRARIES};-Wl,--no-as-needed;${MKL_LIBRARIES};-lpthread -lm -ldl -lgomp")
+      target_link_libraries(${_target} PRIVATE "${sirius_cu_location};${SYSTEM_LIBRARIES};${HDF5_C_LIBRARIES};${HDF5_C_HL_LIBRARIES};-Wl,--no-as-needed;${MKL_LIBRARIES};-lpthread -lm -ldl -lgomp")
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-      target_link_libraries(${_target} PRIVATE "${sirius_location};${SYSTEM_LIBRARIES};${MKL_LIBRARIES};${HDF5_C_LIBRARIES};${HDF5_C_HL_LIBRARIES};-lpthread")
+      target_link_libraries(${_target} PRIVATE "${sirius_cu_location};${SYSTEM_LIBRARIES};${MKL_LIBRARIES};${HDF5_C_LIBRARIES};${HDF5_C_HL_LIBRARIES};-lpthread")
     else()
       message(FATAL_ERROR "Unknown compiler")
     endif()
   else()
-    target_link_libraries(${_target} PRIVATE "${sirius_location};${SYSTEM_LIBRARIES};${LAPACK_LIBRARIES};${FFTW_LIBRARIES};${HDF5_C_LIBRARIES};${HDF5_C_HL_LIBRARIES}")
+    target_link_libraries(${_target} PRIVATE "${sirius_cu_location};${SYSTEM_LIBRARIES};${LAPACK_LIBRARIES};${FFTW_LIBRARIES};${HDF5_C_LIBRARIES};${HDF5_C_HL_LIBRARIES}")
   endif()
 ENDMACRO()
 
 # sirius library
 add_subdirectory(src)
-set(sirius_location $<TARGET_FILE:sirius>)
+if(USE_CUDA)
+  set(sirius_cu_location $<TARGET_FILE:sirius_cu>)
+endif()
 
 # applications
 add_subdirectory(apps/atoms)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,24 +8,18 @@ if(USE_CUDA)
   file(GLOB_RECURSE CUFILES_SDDK "SDDK/*.cu")
   file(GLOB_RECURSE CUFILES_KERNELS "Kernels/*.cu")
   add_library(sirius_f "sirius_api.cpp;sirius.f90;${CUFILES_KERNELS};${CUFILES_SDDK}")
-  add_library(sirius "${CUFILES_KERNELS};${CUFILES_SDDK}")
-else()
-  add_library(sirius "dummy.cpp")
+  add_library(sirius_cu "${CUFILES_KERNELS};${CUFILES_SDDK}")
+  set_target_properties(sirius_cu PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  INSTALL (TARGETS sirius_cu ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/)
+elseif(CREATE_FORTRAN_BINDINGS)
   add_library(sirius_f "sirius_api.cpp;sirius.f90")
+  INSTALL (TARGETS sirius_f ARCHIVE DESTINATION
+    ${CMAKE_INSTALL_PREFIX}/lib/)
+  set_target_properties(sirius_f PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  set_target_properties(sirius_f PROPERTIES Fortran_MODULE_DIRECTORY mod_files)
+  INSTALL ( CODE
+    "EXECUTE_PROCESS (COMMAND \"${CMAKE_COMMAND}\" -E copy_directory \"${PROJECT_BINARY_DIR}/src/mod_files\" \"${CMAKE_INSTALL_PREFIX}/fortran\")"
+    )
 endif()
 
-INSTALL (TARGETS sirius ARCHIVE DESTINATION
-  ${CMAKE_INSTALL_PREFIX}/lib/)
-INSTALL (TARGETS sirius_f ARCHIVE DESTINATION
-  ${CMAKE_INSTALL_PREFIX}/lib/)
-
-set_target_properties(sirius PROPERTIES POSITION_INDEPENDENT_CODE ON)
-set_target_properties(sirius_f PROPERTIES POSITION_INDEPENDENT_CODE ON)
-set_target_properties(sirius_f PROPERTIES Fortran_MODULE_DIRECTORY mod_files)
-
-# ugly hack, path below contains ${PROJECT_BINARY_DIR}/src/mod_files. In case the name of the current directory is
-# changed, the path below needs to be adapted as well...
-INSTALL ( CODE
-  "EXECUTE_PROCESS (COMMAND \"${CMAKE_COMMAND}\" -E copy_directory \"${PROJECT_BINARY_DIR}/src/mod_files\" \"${CMAKE_INSTALL_PREFIX}/fortran\")"
-)
 install(DIRECTORY ./ DESTINATION "${CMAKE_INSTALL_PREFIX}/include/sirius" FILES_MATCHING REGEX ".*(hpp|h)$")


### PR DESCRIPTION
- add flag CREATE_FORTRAN_BINDINGS to cmake, default is ON
- rename libsirius.a -> libsirius_cu.a