### PR TITLE
jenkins: upgrade to CDT 18.08 and cuda 9.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
                     dir('SIRIUS') {
                         sh '''
                            #!/bin/bash -l
+                           export ENVFILE=$(realpath ci/env-gnu-gpu)
                            sbatch --wait ci/build-daint-gpu.sh
                            echo "---------- build-daint-gpu.out ----------"
                            cat build-daint-gpu.out
@@ -40,6 +41,7 @@ pipeline {
                     	     cd build
                            export SIRIUS_BINARIES=$(realpath apps/dft_loop)
                            type -f ${SIRIUS_BINARIES}/sirius.scf
+                           export ENVFILE=$(realpath ../ci/env-gnu-gpu)
                            sbatch --wait ../ci/run-mc-verification.sh
                            cat *err
                            cat *out

--- a/ci/build-daint-gpu.sh
+++ b/ci/build-daint-gpu.sh
@@ -9,39 +9,17 @@
 
 set -e
 
-loadDependencies()
-{
-    module purge
-    export EASYBUILD_PREFIX=/users/simonpi/jenkins
-    module load modules
-    module load craype
-    module load PrgEnv-gnu
-    module load daint-gpu
-    module unload cray-libsci
-    module load EasyBuild-custom/cscs
-    module load cray-hdf5
-    module load cudatoolkit
-    module load CMake/3.8.1
-    module load intel
-    module load gcc
-    module load cray-python/3.6.1.1
-    module load git
-
-    module load libxc/4.2.3-CrayGNU-17.08
-    module load GSL/2.4-CrayGNU-17.08
-    module load spglib/1.10.3-CrayGNU-17.08
-    module load magma/2.3.0-CrayGNU-17.08-cuda-8.0
-}
-
-#compile easybuild modules and load env
-loadDependencies
+source ${ENVFILE}
 
 mkdir -p build
 (
     cd build
-    cmake -DUSE_MKL=On -DUSE_ELPA=Off \
+    cmake -DUSE_MKL=On \
+          -DUSE_ELPA=Off \
           -DGPU_MODEL=P100 \
-          -DUSE_MAGMA=On -DUSE_CUDA=On \
+          -DUSE_MAGMA=On \
+          -DUSE_CUDA=On \
+          -DCREATE_PYTHON_MODULE=On \
           ../
     make -j24 VERBOSE=1
 ) && echo "build successful"

--- a/ci/easybuild-jenkins.sh
+++ b/ci/easybuild-jenkins.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -l
+
+# compile easybuild modules required by jenkins to build SIRIUS
+# required easyblocks which can be found in the following git repo
+# git clone https://github.com/simonpintarelli/production.git
+# clone it into $HOME/production
+
+module purge
+export EB_CUSTOM_PREFIX=${HOME}/production/easybuild
+export EASYBUILD_PREFIX=${HOME}/jenkins/daint-haswell
+
+module load modules
+module load craype
+module load PrgEnv-gnu
+module load daint-gpu
+module load git
+module unload cray-libsci
+module load EasyBuild-custom/cscs
+
+eb libxc-4.2.3-CrayGNU-18.08.eb -r
+eb GSL-2.5-CrayGNU-18.08.eb -r
+eb spglib-1.10.3-CrayGNU-18.08.eb -r
+eb magma-2.4.0-CrayGNU-18.08-cuda-9.1.eb -r
+
+# make newly installed modules world readable
+find ${HOME}/jenkins -type d -exec chmod ao+rx {} \;
+find ${HOME}/jenkins -type f -exec chmod ao+r {} \;

--- a/ci/env-gnu-gpu
+++ b/ci/env-gnu-gpu
@@ -1,0 +1,18 @@
+module purge
+export EASYBUILD_PREFIX=/users/simonpi/jenkins/daint-haswell
+module load modules
+module load craype
+module load PrgEnv-gnu
+module load cudatoolkit/9.1.85_3.18-6.0.7.0_5.1__g2eb7c52
+module load daint-gpu
+module load git/2.13.1
+module load EasyBuild-custom/cscs
+module load intel
+module load cray-hdf5
+module load CMake/3.8.1
+module load libxc/4.2.3-CrayGNU-18.08
+module load GSL/2.5-CrayGNU-18.08
+module load spglib/1.10.3-CrayGNU-18.08
+module load magma/2.4.0-CrayGNU-18.08-cuda-9.1
+module load gcc
+module load cray-python/3.6.5.1

--- a/ci/run-mc-verification.sh
+++ b/ci/run-mc-verification.sh
@@ -9,31 +9,7 @@
 
 set -e
 
-loadDependencies()
-{
-    module purge
-    export EASYBUILD_PREFIX=/users/simonpi/jenkins
-    module load modules
-    module load craype
-    module load PrgEnv-gnu
-    module load daint-gpu
-    module unload cray-libsci
-    module load EasyBuild-custom/cscs
-    module load cray-hdf5
-    module load cudatoolkit
-    module load CMake/3.8.1
-    module load intel
-    module load gcc
-    module load cray-python/3.6.1.1
-    module load git
-
-    module load libxc/4.2.3-CrayGNU-17.08
-    module load GSL/2.4-CrayGNU-17.08
-    module load spglib/1.10.3-CrayGNU-17.08
-    module load magma/2.3.0-CrayGNU-17.08-cuda-8.0
-}
-
-loadDependencies
+source ${ENVFILE}
 
 (
     export OMP_NUM_THREADS=2


### PR DESCRIPTION
- use cuda 9.1 (official CUDA version on daint), cuda 9.2 crashes for some reason
- add bash script which was used to build easybuild modules for jenkins