### PR TITLE
Remove template at

### DIFF
--- a/apps/tests/test_eigen_v2.cpp
+++ b/apps/tests/test_eigen_v2.cpp
@@ -128,11 +128,11 @@ void test_diag2(BLACS_grid const& blacs_grid__,
         full_mtrx = matrix<double_complex>(n, n);
         h5.read("/mtrx", full_mtrx);
         blacs_grid__.comm().bcast(&n, 1, 0);
-        blacs_grid__.comm().bcast(full_mtrx.at<CPU>(), static_cast<int>(full_mtrx.size()), 0);
+        blacs_grid__.comm().bcast(full_mtrx.at(memory_t::host), static_cast<int>(full_mtrx.size()), 0);
     } else {
         blacs_grid__.comm().bcast(&n, 1, 0);
         full_mtrx = matrix<double_complex>(n, n);
-        blacs_grid__.comm().bcast(full_mtrx.at<CPU>(), static_cast<int>(full_mtrx.size()), 0);
+        blacs_grid__.comm().bcast(full_mtrx.at(memory_t::host), static_cast<int>(full_mtrx.size()), 0);
     }
     if (blacs_grid__.comm().rank() == 0) {
         printf("matrix size: %i\n", n);

--- a/apps/tests/test_gemm.cpp
+++ b/apps/tests/test_gemm.cpp
@@ -45,7 +45,7 @@ double test_gemm(int M, int N, int K, int transa)
     printf("b.ld() = %i\n", b.ld());
     printf("c.ld() = %i\n", c.ld());
     utils::timer t1("gemm_only"); 
-    linalg<CPU>::gemm(transa, 0, M, N, K, a.at<CPU>(), a.ld(), b.at<CPU>(), b.ld(), c.at<CPU>(), c.ld());
+    linalg<CPU>::gemm(transa, 0, M, N, K, a.at(memory_t::host), a.ld(), b.at(memory_t::host), b.ld(), c.at(memory_t::host), c.ld());
     double tval = t1.stop();
     double perf = nop_gemm * 1e-9 * M * N * K / tval;
     printf("execution time (sec) : %12.6f\n", tval);

--- a/apps/unit_tests/test_fft_correctness_1.cpp
+++ b/apps/unit_tests/test_fft_correctness_1.cpp
@@ -44,7 +44,7 @@ int test_fft(cmd_args& args, device_t pu__)
             case GPU: {
                 //f.copy<memory_t::host, memory_t::device>();
                 //fft.transform<1, GPU>(gvec.partition(), f.at<GPU>(gvec.partition().gvec_offset_fft()));
-                fft.transform<1, memory_t::host>(ftmp.at<CPU>(0));
+                fft.transform<1, memory_t::host>(ftmp.at(memory_t::host));
                 fft.buffer().copy_to(memory_t::host);
                 break;
             }

--- a/apps/unit_tests/test_fft_correctness_1.cpp
+++ b/apps/unit_tests/test_fft_correctness_1.cpp
@@ -45,7 +45,7 @@ int test_fft(cmd_args& args, device_t pu__)
                 //f.copy<memory_t::host, memory_t::device>();
                 //fft.transform<1, GPU>(gvec.partition(), f.at<GPU>(gvec.partition().gvec_offset_fft()));
                 fft.transform<1, memory_t::host>(ftmp.at<CPU>(0));
-                fft.buffer().copy<memory_t::device, memory_t::host>();
+                fft.buffer().copy_to(memory_t::host);
                 break;
             }
         }

--- a/apps/unit_tests/test_fft_correctness_2.cpp
+++ b/apps/unit_tests/test_fft_correctness_2.cpp
@@ -24,8 +24,8 @@ int test_fft_complex(cmd_args& args, device_t fft_pu__)
     }
     mdarray<double_complex, 1> g(gvp.gvec_count_fft());
 
-    fft.transform<1>(f.at<CPU>());
-    fft.transform<-1>(g.at<CPU>());
+    fft.transform<1>(f.at(memory_t::host));
+    fft.transform<-1>(g.at(memory_t::host));
 
     double diff{0};
     for (int ig = 0; ig < gvp.gvec_count_fft(); ig++) {

--- a/apps/unit_tests/test_fft_real_1.cpp
+++ b/apps/unit_tests/test_fft_real_1.cpp
@@ -31,7 +31,7 @@ int run_test(cmd_args& args, device_t pu__)
     phi(0) = 1.0;
     fft.transform<1>(&phi[0]);
     if (pu__ == GPU) {
-        fft.buffer().copy<memory_t::device, memory_t::host>();
+        fft.buffer().copy_to(memory_t::host);
     }
 
     for (int i = 0; i < fft.local_size(); i++) {

--- a/apps/unit_tests/test_fft_real_3.cpp
+++ b/apps/unit_tests/test_fft_real_3.cpp
@@ -83,7 +83,7 @@ int main(int argn, char** argv)
 
     sirius::initialize(true);
     printf("running %-30s : ", argv[0]);
-    int result = run_test(args, CPU);
+    int result = run_test(args, device_t::CPU);
     if (result) {
         printf("\x1b[31m" "Failed" "\x1b[0m" "\n");
     } else {

--- a/apps/unit_tests/test_mempool.cpp
+++ b/apps/unit_tests/test_mempool.cpp
@@ -20,67 +20,67 @@ void test2()
     mp.free(ptr);
 }
 
-//void test2a()
-//{
-//    memory_pool mp(memory_t::host);
-//    auto ptr = mp.allocate<double_complex>(1024);
-//    mp.free(ptr);
-//    ptr = mp.allocate<double_complex>(512);
-//    mp.free(ptr);
-//}
-//
-//void test3()
-//{
-//    memory_pool mp(memory_t::host);
-//    auto p1 = mp.allocate<double_complex>(1024);
-//    auto p2 = mp.allocate<double_complex>(2024);
-//    auto p3 = mp.allocate<double_complex>(3024);
-//    mp.free(p1);
-//    mp.free(p2);
-//    mp.free(p3);
-//}
-//
-//void test3a()
-//{
-//    memory_pool mp(memory_t::host);
-//    mp.allocate<double_complex>(1024);
-//    mp.allocate<double_complex>(2024);
-//    mp.allocate<double_complex>(3024);
-//    mp.reset();
-//}
-//
-//void test4()
-//{
-//    memory_pool mp(memory_t::host);
-//    mp.allocate<double_complex>(1024);
-//    mp.reset();
-//    mp.allocate<double_complex>(1024);
-//    mp.allocate<double_complex>(1024);
-//    mp.reset();
-//    mp.allocate<double_complex>(1024);
-//    mp.allocate<double_complex>(1024);
-//    mp.allocate<double_complex>(1024);
-//    mp.reset();
-//}
-//
-//void test5()
-//{
-//    memory_pool mp(memory_t::host);
-//
-//    for (int k = 0; k < 2; k++) {
-//        std::vector<double*> vp;
-//        for (size_t i = 1; i < 20; i++) {
-//            size_t sz = 1 << i;
-//            double* ptr = mp.allocate<double>(sz);
-//            ptr[0] = 0;
-//            ptr[sz - 1] = 0;
-//            vp.push_back(ptr);
-//        }
-//        for (auto& e: vp) {
-//            mp.free(e);
-//        }
-//    }
-//}
+void test2a()
+{
+    memory_pool mp(memory_t::host);
+    auto ptr = mp.allocate<double_complex>(1024);
+    mp.free(ptr);
+    ptr = mp.allocate<double_complex>(512);
+    mp.free(ptr);
+}
+
+void test3()
+{
+    memory_pool mp(memory_t::host);
+    auto p1 = mp.allocate<double_complex>(1024);
+    auto p2 = mp.allocate<double_complex>(2024);
+    auto p3 = mp.allocate<double_complex>(3024);
+    mp.free(p1);
+    mp.free(p2);
+    mp.free(p3);
+}
+
+void test3a()
+{
+    memory_pool mp(memory_t::host);
+    mp.allocate<double_complex>(1024);
+    mp.allocate<double_complex>(2024);
+    mp.allocate<double_complex>(3024);
+    mp.reset();
+}
+
+void test4()
+{
+    memory_pool mp(memory_t::host);
+    mp.allocate<double_complex>(1024);
+    mp.reset();
+    mp.allocate<double_complex>(1024);
+    mp.allocate<double_complex>(1024);
+    mp.reset();
+    mp.allocate<double_complex>(1024);
+    mp.allocate<double_complex>(1024);
+    mp.allocate<double_complex>(1024);
+    mp.reset();
+}
+
+void test5()
+{
+    memory_pool mp(memory_t::host);
+
+    for (int k = 0; k < 2; k++) {
+        std::vector<double*> vp;
+        for (size_t i = 1; i < 20; i++) {
+            size_t sz = 1 << i;
+            double* ptr = mp.allocate<double>(sz);
+            ptr[0] = 0;
+            ptr[sz - 1] = 0;
+            vp.push_back(ptr);
+        }
+        for (auto& e: vp) {
+            mp.free(e);
+        }
+    }
+}
 
 /// Wall-clock time in seconds.
 inline double wtime()
@@ -172,33 +172,33 @@ void test6a()
     utils::timer::print();
 }
 
-//void test7()
-//{
-//    memory_pool mp(memory_t::host);
-//
-//    int N = 10000;
-//    std::vector<double*> v(N);
-//    for (int k = 0; k < 30; k++) {
-//        for (int i = 0; i < N; i++) {
-//            auto n = (utils::rand() & 0b1111111111) + 1;
-//            v[i] = mp.allocate<double>(n);
-//        }
-//        std::random_shuffle(v.begin(), v.end());
-//        for (int i = 0; i < N; i++) {
-//            mp.free(v[i]);
-//        }
-//        if (mp.free_size() != mp.total_size()) {
-//            throw std::runtime_error("wrong free size");
-//        }
-//        if (mp.num_blocks() != 1) {
-//            throw std::runtime_error("wrong number of blocks");
-//        }
-//        if (mp.num_stored_ptr() != 0) {
-//            throw std::runtime_error("wrong number of stored pointers");
-//        }
-//    }
-//}
-//
+void test7()
+{
+    memory_pool mp(memory_t::host);
+
+    int N = 10000;
+    std::vector<double*> v(N);
+    for (int k = 0; k < 30; k++) {
+        for (int i = 0; i < N; i++) {
+            auto n = (utils::rand() & 0b1111111111) + 1;
+            v[i] = mp.allocate<double>(n);
+        }
+        std::random_shuffle(v.begin(), v.end());
+        for (int i = 0; i < N; i++) {
+            mp.free(v[i]);
+        }
+        if (mp.free_size() != mp.total_size()) {
+            throw std::runtime_error("wrong free size");
+        }
+        if (mp.num_blocks() != 1) {
+            throw std::runtime_error("wrong number of blocks");
+        }
+        if (mp.num_stored_ptr() != 0) {
+            throw std::runtime_error("wrong number of stored pointers");
+        }
+    }
+}
+
 //void test8()
 //{
 //    memory_pool mp(memory_t::host);
@@ -219,9 +219,6 @@ void test6a()
 //    }
 //
 //}
-//
-
-
 
 double test_alloc_array(size_t n)
 {
@@ -286,18 +283,18 @@ void test9()
 
 int run_test()
 {
-    //test1();
-    //test2();
-    //test2a();
-    //test3();
-    //test3a();
-    //test4();
-    //test5();
+    test1();
+    test2();
+    test2a();
+    test3();
+    test3a();
+    test4();
+    test5();
     //test6();
     //test6a();
-    //test7();
+    test7();
     //test8();
-    test9();
+    //test9();
     return 0;
 }
 

--- a/python_module/py_sirius.cpp
+++ b/python_module/py_sirius.cpp
@@ -645,7 +645,7 @@ py::class_<Free_atom>(m, "Free_atom")
             int ncols = arr.size(1);
             return py::array_t<complex_double>({nrows, ncols},
                                                {1 * sizeof(complex_double), nrows * sizeof(complex_double)},
-                                               arr.data<CPU>(), obj);
+                                               arr.at(memory_t::host), obj);
         });
 
     py::class_<dmatrix<complex_double>, mdarray<complex_double,2>>(m, "dmatrix");
@@ -680,7 +680,7 @@ py::class_<Free_atom>(m, "Free_atom")
             /* TODO this might be a distributed array, should/can we use dask? */
             return py::array_t<complex_double>({nrows, ncols},
                                                {1 * sizeof(complex_double), nrows * sizeof(complex_double)},
-                                               matrix_storage.prime().data<CPU>(),
+                                               matrix_storage.prime().at(memory_t::host),
                                                obj);
         },
              py::keep_alive<0, 1>())

--- a/python_module/py_sirius.cpp
+++ b/python_module/py_sirius.cpp
@@ -637,7 +637,7 @@ py::class_<Free_atom>(m, "Free_atom")
     py::class_<mdarray<complex_double, 2>>(m, "mdarray2c")
         .def("on_device", &mdarray<complex_double, 2>::on_device)
         .def("copy_to_host", [](mdarray<complex_double, 2>& mdarray) {
-            mdarray.copy<memory_t::device, memory_t::host>();
+            mdarray.copy_to(memory_t::host);
         })
         .def("__array__", [](py::object& obj) {
             mdarray<complex_double, 2>& arr = obj.cast<mdarray<complex_double, 2>&>();

--- a/src/Band/diag_full_potential.hpp
+++ b/src/Band/diag_full_potential.hpp
@@ -212,10 +212,8 @@ inline void Band::get_singular_components(K_point& kp__, Hamiltonian& H__) const
     }
 
     if (ctx_.processing_unit() == GPU) {
-        o_diag.allocate(memory_t::device);
-        o_diag.copy<memory_t::host, memory_t::device>();
-        diag1.allocate(memory_t::device);
-        diag1.copy<memory_t::host, memory_t::device>();
+        o_diag.allocate(memory_t::device).copy_to(memory_t::device);
+        diag1.allocate(memory_t::device).copy_to(memory_t::device);
     }
 
     auto& psi = kp__.singular_components();

--- a/src/Band/diag_full_potential.hpp
+++ b/src/Band/diag_full_potential.hpp
@@ -165,12 +165,12 @@ inline void Band::diag_full_potential_first_variation_exact(K_point& kp, Hamilto
         //                   [this](int ia) {return unit_cell_.atom(ia).mt_lo_basis_size(); }, ctx_.num_fv_states());
         //
         //for (int i = 0; i < ctx_.num_fv_states(); i++) {
-        //    std::memcpy(phi.pw_coeffs().prime().at<CPU>(0, i),
-        //                kp->fv_eigen_vectors().at<CPU>(0, i),
+        //    std::memcpy(phi.pw_coeffs().prime().at(memory_t::host, 0, i),
+        //                kp->fv_eigen_vectors().at(memory_t::host, 0, i),
         //                kp->num_gkvec() * sizeof(double_complex));
         //    if (unit_cell_.mt_lo_basis_size()) {
-        //        std::memcpy(phi.mt_coeffs().prime().at<CPU>(0, i),
-        //                    kp->fv_eigen_vectors().at<CPU>(kp->num_gkvec(), i),
+        //        std::memcpy(phi.mt_coeffs().prime().at(memory_t::host, 0, i),
+        //                    kp->fv_eigen_vectors().at(memory_t::host, kp->num_gkvec(), i),
         //                    unit_cell_.mt_lo_basis_size() * sizeof(double_complex));
         //    }
         //}
@@ -484,8 +484,8 @@ inline void Band::diag_full_potential_first_variation_davidson(K_point& kp__, Ha
     if (ncomp != 0) {
         phi.mt_coeffs(0).zero(memory_t::host, nlo, ncomp);
         for (int j = 0; j < ncomp; j++) {
-            std::memcpy(phi.pw_coeffs(0).prime().at<CPU>(0, nlo + j),
-                        kp__.singular_components().pw_coeffs(0).prime().at<CPU>(0, j),
+            std::memcpy(phi.pw_coeffs(0).prime().at(memory_t::host, 0, nlo + j),
+                        kp__.singular_components().pw_coeffs(0).prime().at(memory_t::host, 0, j),
                         phi.pw_coeffs(0).num_rows_loc() * sizeof(double_complex));
         }
     }

--- a/src/Band/residuals.hpp
+++ b/src/Band/residuals.hpp
@@ -230,8 +230,7 @@ Band::residuals_aux(K_point*             kp__,
 
     mdarray<double, 1> eval(eval__.data(), num_bands__, "residuals_aux::eval");
     if (pu == device_t::GPU) {
-        eval.allocate(memory_t::device);
-        eval.copy<memory_t::host, memory_t::device>();
+        eval.allocate(memory_t::device).copy_to(memory_t::device);
     }
 
     /* compute residuals */
@@ -247,7 +246,7 @@ Band::residuals_aux(K_point*             kp__,
         p_norm[i] = 1.0 / p_norm[i];
     }
     if (pu == device_t::GPU) {
-        p_norm.copy<memory_t::host, memory_t::device>();
+        p_norm.copy_to(memory_t::device);
     }
 
     /* normalize preconditioned residuals */

--- a/src/Band/residuals.hpp
+++ b/src/Band/residuals.hpp
@@ -88,19 +88,19 @@ static void compute_res(device_t            pu__,
             }
             case GPU: {
                 #ifdef __GPU
-                compute_residuals_gpu(hpsi__.pw_coeffs(ispn).prime().at<GPU>(),
-                                      opsi__.pw_coeffs(ispn).prime().at<GPU>(),
-                                      res__.pw_coeffs(ispn).prime().at<GPU>(),
+                compute_residuals_gpu(hpsi__.pw_coeffs(ispn).prime().at(memory_t::device),
+                                      opsi__.pw_coeffs(ispn).prime().at(memory_t::device),
+                                      res__.pw_coeffs(ispn).prime().at(memory_t::device),
                                       res__.pw_coeffs(ispn).num_rows_loc(),
                                       num_bands__,
-                                      eval__.at<GPU>());
+                                      eval__.at(memory_t::device));
                 if (res__.has_mt()) {
-                    compute_residuals_gpu(hpsi__.mt_coeffs(ispn).prime().at<GPU>(),
-                                          opsi__.mt_coeffs(ispn).prime().at<GPU>(),
-                                          res__.mt_coeffs(ispn).prime().at<GPU>(),
+                    compute_residuals_gpu(hpsi__.mt_coeffs(ispn).prime().at(memory_t::device),
+                                          opsi__.mt_coeffs(ispn).prime().at(memory_t::device),
+                                          res__.mt_coeffs(ispn).prime().at(memory_t::device),
                                           res__.mt_coeffs(ispn).num_rows_loc(),
                                           num_bands__,
-                                          eval__.at<GPU>());
+                                          eval__.at(memory_t::device));
                 }
                 #endif
             }
@@ -143,19 +143,19 @@ static void apply_p(device_t            pu__,
             }
             case GPU: {
                 #ifdef __GPU
-                apply_preconditioner_gpu(res__.pw_coeffs(ispn).prime().at<GPU>(),
+                apply_preconditioner_gpu(res__.pw_coeffs(ispn).prime().at(memory_t::device),
                                          res__.pw_coeffs(ispn).num_rows_loc(),
                                          num_bands__,
-                                         eval__.at<GPU>(),
-                                         h_diag__.at<GPU>(0, ispn),
-                                         o_diag__.at<GPU>());
+                                         eval__.at(memory_t::device),
+                                         h_diag__.at(memory_t::device, 0, ispn),
+                                         o_diag__.at(memory_t::device));
                 if (res__.has_mt()) {
-                    apply_preconditioner_gpu(res__.mt_coeffs(ispn).prime().at<GPU>(),
+                    apply_preconditioner_gpu(res__.mt_coeffs(ispn).prime().at(memory_t::device),
                                              res__.mt_coeffs(ispn).num_rows_loc(),
                                              num_bands__,
-                                             eval__.at<GPU>(),
-                                             h_diag__.at<GPU>(res__.pw_coeffs(ispn).num_rows_loc(), ispn),
-                                             o_diag__.at<GPU>(res__.pw_coeffs(ispn).num_rows_loc()));
+                                             eval__.at(memory_t::device),
+                                             h_diag__.at(memory_t::device, res__.pw_coeffs(ispn).num_rows_loc(), ispn),
+                                             o_diag__.at(memory_t::device, res__.pw_coeffs(ispn).num_rows_loc()));
                 }
                 break;
                 #endif
@@ -195,14 +195,14 @@ static void normalize_res(device_t            pu__,
                 #ifdef __GPU
                 scale_matrix_columns_gpu(res__.pw_coeffs(ispn).num_rows_loc(),
                                          num_bands__,
-                                         res__.pw_coeffs(ispn).prime().at<GPU>(),
-                                         p_norm__.at<GPU>());
+                                         res__.pw_coeffs(ispn).prime().at(memory_t::device),
+                                         p_norm__.at(memory_t::device));
 
                 if (res__.has_mt()) {
                     scale_matrix_columns_gpu(res__.mt_coeffs(ispn).num_rows_loc(),
                                              num_bands__,
-                                             res__.mt_coeffs(ispn).prime().at<GPU>(),
-                                             p_norm__.at<GPU>());
+                                             res__.mt_coeffs(ispn).prime().at(memory_t::device),
+                                             p_norm__.at(memory_t::device));
                 }
                 #endif
                 break;
@@ -405,7 +405,7 @@ inline int Band::residuals(K_point*             kp__,
             }
             case GPU: {
 #ifdef __GPU
-                make_real_g0_gpu(res__.pw_coeffs(ispn__).prime().at<GPU>(), res__.pw_coeffs(ispn__).prime().ld(), n);
+                make_real_g0_gpu(res__.pw_coeffs(ispn__).prime().at(memory_t::device), res__.pw_coeffs(ispn__).prime().ld(), n);
 #endif
                 break;
             }

--- a/src/Beta_projectors/beta_projectors.hpp
+++ b/src/Beta_projectors/beta_projectors.hpp
@@ -96,8 +96,7 @@ class Beta_projectors : public Beta_projectors_base
             /* beta projectors for atom types will be stored on GPU for the entire run */
             case device_t::GPU: {
                 reallocate_pw_coeffs_t_on_gpu_ = false;
-                pw_coeffs_t_.allocate(memory_t::device);
-                pw_coeffs_t_.copy<memory_t::host, memory_t::device>();
+                pw_coeffs_t_.allocate(memory_t::device).copy_to(memory_t::device);
                 break;
             }
             /* generate beta projectors for all atoms */

--- a/src/Beta_projectors/beta_projectors_base.hpp
+++ b/src/Beta_projectors/beta_projectors_base.hpp
@@ -330,11 +330,11 @@ class Beta_projectors_base
                 auto& desc = chunk(ichunk__).desc_;
                 create_beta_gk_gpu(chunk(ichunk__).num_atoms_,
                                    num_gkvec_loc(),
-                                   desc.template at<GPU>(),
-                                   pw_coeffs_t_.template at<GPU>(0, 0, j__),
-                                   gkvec_coord_.template at<GPU>(),
-                                   chunk(ichunk__).atom_pos_.template at<GPU>(),
-                                   pw_coeffs_a().template at<GPU>());
+                                   desc.at(memory_t::device),
+                                   pw_coeffs_t_.at(memory_t::device, 0, 0, j__),
+                                   gkvec_coord_.at(memory_t::device),
+                                   chunk(ichunk__).atom_pos_.at(memory_t::device),
+                                   pw_coeffs_a().at(memory_t::device));
 #endif
                 /* wave-functions are on CPU but the beta-projectors are on GPU */
                 if (gkvec_.comm().rank() == 0 && is_host_memory(ctx_.preferred_memory_t())) {

--- a/src/Beta_projectors/beta_projectors_base.hpp
+++ b/src/Beta_projectors/beta_projectors_base.hpp
@@ -428,7 +428,7 @@ inline void Beta_projectors_base::local_inner_aux<double_complex>(double_complex
     if (pp && gkvec_.comm().rank() == 0) {
 #ifdef __GPU
         if (ctx_.blas_linalg_t() == linalg_t::cublas) {
-            acc::sync_stream(-1);
+            acc::sync_stream(stream_id(-1));
         }
 #endif
         double t = t1.stop();

--- a/src/Density/add_k_point_contribution_dm.hpp
+++ b/src/Density/add_k_point_contribution_dm.hpp
@@ -51,7 +51,7 @@ inline void Density::add_k_point_contribution_dm(K_point* kp__, mdarray<double_c
                     /* add |psi_j> n_j <psi_j| to density matrix */
                     linalg<CPU>::gemm(0, 1, mt_basis_size, mt_basis_size, nbnd, linalg_const<double_complex>::one(),
                                       &wf1(0, 0), wf1.ld(), &wf2(0, 0), wf2.ld(), linalg_const<double_complex>::one(),
-                                      density_matrix__.at<CPU>(0, 0, ispn, ia), density_matrix__.ld());
+                                      density_matrix__.at(memory_t::host, 0, 0, ispn, ia), density_matrix__.ld());
                 }
             }
         } else {
@@ -79,13 +79,13 @@ inline void Density::add_k_point_contribution_dm(K_point* kp__, mdarray<double_c
                 for (int ispn = 0; ispn < 2; ispn++) {
                     linalg<CPU>::gemm(0, 1, mt_basis_size, mt_basis_size, nbnd, linalg_const<double_complex>::one(),
                                       &wf1(0, 0, ispn), wf1.ld(), &wf2(0, 0, ispn), wf2.ld(),
-                                      linalg_const<double_complex>::one(), density_matrix__.at<CPU>(0, 0, ispn, ia),
+                                      linalg_const<double_complex>::one(), density_matrix__.at(memory_t::host, 0, 0, ispn, ia),
                                       density_matrix__.ld());
                 }
                 /* offdiagonal term */
                 linalg<CPU>::gemm(0, 1, mt_basis_size, mt_basis_size, nbnd, linalg_const<double_complex>::one(),
                                   &wf1(0, 0, 1), wf1.ld(), &wf2(0, 0, 0), wf2.ld(), linalg_const<double_complex>::one(),
-                                  density_matrix__.at<CPU>(0, 0, 2, ia), density_matrix__.ld());
+                                  density_matrix__.at(memory_t::host, 0, 0, 2, ia), density_matrix__.ld());
             }
         }
     } else { /* pseudopotential */

--- a/src/Density/add_k_point_contribution_rg.hpp
+++ b/src/Density/add_k_point_contribution_rg.hpp
@@ -143,10 +143,10 @@ inline void Density::add_k_point_contribution_rg(K_point* kp__)
         }
     }
 
-    if (fft.pu() == GPU) {
-        density_rg.copy<memory_t::device, memory_t::host>();
+    if (fft.pu() == device_t::GPU) {
+        density_rg.copy_to(memory_t::host);
     }
-    
+
     /* switch from real density matrix to density and magnetization */
     switch (ctx_.num_mag_dims()) {
         case 3: {

--- a/src/Density/add_k_point_contribution_rg.hpp
+++ b/src/Density/add_k_point_contribution_rg.hpp
@@ -71,7 +71,7 @@ inline void Density::add_k_point_contribution_rg(K_point* kp__)
                     }
                     case GPU: {
 #ifdef __GPU
-                        update_density_rg_1_gpu(fft.local_size(), fft.buffer().at<GPU>(), w,
+                        update_density_rg_1_gpu(fft.local_size(), fft.buffer().at(memory_t::device), w,
                                                 density_rg.at(memory_t::device, 0, ispn));
 #else
                         TERMINATE_NO_GPU
@@ -104,7 +104,7 @@ inline void Density::add_k_point_contribution_rg(K_point* kp__)
                 }
                 case device_t::GPU: {
 #ifdef __GPU
-                    acc::copyout(psi_r.at<GPU>(), fft.buffer().at<GPU>(), fft.local_size());
+                    acc::copyout(psi_r.at(memory_t::device), fft.buffer().at(memory_t::device), fft.local_size());
 #endif
                     break;
                 }
@@ -132,12 +132,14 @@ inline void Density::add_k_point_contribution_rg(K_point* kp__)
                 case GPU: {
 #ifdef __GPU
                     /* add up-up contribution */
-                    update_density_rg_1_gpu(fft.local_size(), psi_r.at<GPU>(), w, density_rg.at<GPU>(0, 0));
+                    update_density_rg_1_gpu(fft.local_size(), psi_r.at(memory_t::device), w,
+                                            density_rg.at(memory_t::device, 0, 0));
                     /* add dn-dn contribution */
-                    update_density_rg_1_gpu(fft.local_size(), fft.buffer().at<GPU>(), w, density_rg.at<GPU>(0, 1));
+                    update_density_rg_1_gpu(fft.local_size(), fft.buffer().at(memory_t::device), w,
+                                            density_rg.at(memory_t::device, 0, 1));
                     /* add off-diagonal contribution */
-                    update_density_rg_2_gpu(fft.local_size(), psi_r.at<GPU>(), fft.buffer().at<GPU>(), w,
-                                            density_rg.at<GPU>(0, 2), density_rg.at<GPU>(0, 3));
+                    update_density_rg_2_gpu(fft.local_size(), psi_r.at(memory_t::device), fft.buffer().at(memory_t::device), w,
+                                            density_rg.at(memory_t::device, 0, 2), density_rg.at(memory_t::device, 0, 3));
 #endif
                     break;
                 }

--- a/src/Density/generate_rho_aug.hpp
+++ b/src/Density/generate_rho_aug.hpp
@@ -38,7 +38,7 @@ inline void Density::generate_rho_aug(mdarray<double_complex, 2>& rho_aug__)
 
 #ifdef __GPU
         if (ctx_.processing_unit() == GPU) {
-            acc::sync_stream(0);
+            acc::sync_stream(stream_id(0));
             if (iat + 1 != unit_cell_.num_atom_types() && ctx_.unit_cell().atom_type(iat + 1).augment() &&
                 ctx_.unit_cell().atom_type(iat + 1).num_atoms() > 0) {
                 ctx_.augmentation_op(iat + 1).prepare(stream_id(0));
@@ -145,7 +145,7 @@ inline void Density::generate_rho_aug(mdarray<double_complex, 2>& rho_aug__)
                                    rho_aug__.at(memory_t::device, 0, iv),
                                    1);
             }
-            acc::sync_stream(1);
+            acc::sync_stream(stream_id(1));
             ctx_.augmentation_op(iat).dismiss();
         }
 #endif

--- a/src/Density/generate_rho_aug.hpp
+++ b/src/Density/generate_rho_aug.hpp
@@ -117,9 +117,8 @@ inline void Density::generate_rho_aug(mdarray<double_complex, 2>& rho_aug__)
         }
 
 #ifdef __GPU
-        if (pu == GPU) {
-            dm.allocate(memory_t::device);
-            dm.copy<memory_t::host, memory_t::device>();
+        if (pu == device_t::GPU) {
+            dm.allocate(memory_t::device).copy_to(memory_t::device);
 
             /* treat auxiliary array as double with x2 size */
             mdarray<double, 2> dm_pw(nullptr, nbf * (nbf + 1) / 2, ctx_.gvec().count() * 2);
@@ -132,18 +131,18 @@ inline void Density::generate_rho_aug(mdarray<double_complex, 2>& rho_aug__)
                 generate_dm_pw_gpu(atom_type.num_atoms(),
                                    ctx_.gvec().count(),
                                    nbf,
-                                   ctx_.unit_cell().atom_coord(iat).at<GPU>(),
-                                   ctx_.gvec_coord().at<GPU>(),
-                                   phase_factors.at<GPU>(),
-                                   dm.at<GPU>(0, 0, iv),
-                                   dm_pw.at<GPU>(),
+                                   ctx_.unit_cell().atom_coord(iat).at(memory_t::device),
+                                   ctx_.gvec_coord().at(memory_t::device),
+                                   phase_factors.at(memory_t::device),
+                                   dm.at(memory_t::device, 0, 0, iv),
+                                   dm_pw.at(memory_t::device),
                                    1);
                 sum_q_pw_dm_pw_gpu(ctx_.gvec().count(), 
                                    nbf,
-                                   ctx_.augmentation_op(iat).q_pw().at<GPU>(),
-                                   dm_pw.at<GPU>(),
-                                   ctx_.augmentation_op(iat).sym_weight().at<GPU>(),
-                                   rho_aug__.at<GPU>(0, iv),
+                                   ctx_.augmentation_op(iat).q_pw().at(memory_t::device),
+                                   dm_pw.at(memory_t::device),
+                                   ctx_.augmentation_op(iat).sym_weight().at(memory_t::device),
+                                   rho_aug__.at(memory_t::device, 0, iv),
                                    1);
             }
             acc::sync_stream(1);

--- a/src/Density/generate_rho_aug.hpp
+++ b/src/Density/generate_rho_aug.hpp
@@ -152,8 +152,8 @@ inline void Density::generate_rho_aug(mdarray<double_complex, 2>& rho_aug__)
 #endif
     }
 
-    if (pu == GPU) {
-        rho_aug__.copy<memory_t::device, memory_t::host>();
+    if (pu == device_t::GPU) {
+        rho_aug__.copy_to(memory_t::host);
     }
 
     if (ctx_.control().print_checksum_) {

--- a/src/Density/generate_valence.hpp
+++ b/src/Density/generate_valence.hpp
@@ -106,7 +106,7 @@ inline void Density::generate_valence(K_point_set const& ks__)
     }
 
     if (density_matrix_.size()) {
-        ctx_.comm().allreduce(density_matrix_.at<device_t::CPU>(), static_cast<int>(density_matrix_.size()));
+        ctx_.comm().allreduce(density_matrix_.at(memory_t::host), static_cast<int>(density_matrix_.size()));
     }
 
     ctx_.fft_coarse().prepare(ctx_.gvec_coarse_partition());

--- a/src/Geometry/force.hpp
+++ b/src/Geometry/force.hpp
@@ -305,11 +305,11 @@ class Force
 
                 /* apw-apw block of the overlap matrix */
                 linalg<CPU>::gemm(0, 1, kp__->num_gkvec_row(), kp__->num_gkvec_col(), type.mt_aw_basis_size(),
-                                  alm_row.at<CPU>(), alm_row.ld(), alm_col.at<CPU>(), alm_col.ld(), o.at<CPU>(), o.ld());
+                                  alm_row.at(memory_t::host), alm_row.ld(), alm_col.at(memory_t::host), alm_col.ld(), o.at(memory_t::host), o.ld());
 
                 /* apw-apw block of the Hamiltonian matrix */
                 linalg<CPU>::gemm(0, 1, kp__->num_gkvec_row(), kp__->num_gkvec_col(), type.mt_aw_basis_size(),
-                                  alm_row.at<CPU>(), alm_row.ld(), halm_col.at<CPU>(), halm_col.ld(), h.at<CPU>(), h.ld());
+                                  alm_row.at(memory_t::host), alm_row.ld(), halm_col.at(memory_t::host), halm_col.ld(), h.at(memory_t::host), h.ld());
 
                 int iat = type.id();
 
@@ -797,7 +797,7 @@ class Force
             hamiltonian_.dismiss();
 
             /* global reduction */
-            kset_.comm().allreduce(forces_hubbard_.at<CPU>(), 3 * ctx_.unit_cell().num_atoms());
+            kset_.comm().allreduce(forces_hubbard_.at(memory_t::host), 3 * ctx_.unit_cell().num_atoms());
 
             return forces_hubbard_;
         }

--- a/src/Hamiltonian/apply.hpp
+++ b/src/Hamiltonian/apply.hpp
@@ -429,15 +429,15 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
 
         if (hphi__ != nullptr) {
             kp__->comm().allreduce(halm_phi.at<CPU>(), num_mt_aw * n__);
-            if (ctx_.processing_unit() == GPU) {
-                halm_phi.copy<memory_t::host, memory_t::device>();
+            if (ctx_.processing_unit() == device_t::GPU) {
+                halm_phi.copy_to(memory_t::device);
             }
         }
 
         if (ophi__ != nullptr) {
             kp__->comm().allreduce(alm_phi.at<CPU>(), num_mt_aw * n__);
-            if (ctx_.processing_unit() == GPU) {
-                alm_phi.copy<memory_t::host, memory_t::device>();
+            if (ctx_.processing_unit() == device_t::GPU) {
+                alm_phi.copy_to(memory_t::device);
             }
         }
     };
@@ -527,8 +527,8 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
             }
         } // ia
 
-        if (ctx_.processing_unit() == GPU) {
-            phi_lo_block.copy<memory_t::host, memory_t::device>();
+        if (ctx_.processing_unit() == device_t::GPU) {
+            phi_lo_block.copy_to(memory_t::device);
         }
     };
 

--- a/src/Hamiltonian/apply.hpp
+++ b/src/Hamiltonian/apply.hpp
@@ -320,21 +320,21 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
                     mdarray<double_complex, 2> halm_tmp;
                     switch (ctx_.processing_unit()) {
                         case CPU: {
-                            alm_tmp = mdarray<double_complex, 2>(alm_block.at<CPU>(0, offsets_aw[ialoc]),
+                            alm_tmp = mdarray<double_complex, 2>(alm_block.at(memory_t::host, 0, offsets_aw[ialoc]),
                                                                  ngv, type.mt_aw_basis_size());
                             if (hphi__ != nullptr) {
-                                halm_tmp = mdarray<double_complex, 2>(halm_block.at<CPU>(0, offsets_aw[ialoc]),
+                                halm_tmp = mdarray<double_complex, 2>(halm_block.at(memory_t::host, 0, offsets_aw[ialoc]),
                                                                       ngv, type.mt_aw_basis_size());
                             }
                             break;
                         }
                         case GPU: {
-                            alm_tmp = mdarray<double_complex, 2>(alm_block.at<CPU>(0, offsets_aw[ialoc]),
-                                                                 alm_block.at<GPU>(0, offsets_aw[ialoc]),
+                            alm_tmp = mdarray<double_complex, 2>(alm_block.at(memory_t::host, 0, offsets_aw[ialoc]),
+                                                                 alm_block.at(memory_t::device, 0, offsets_aw[ialoc]),
                                                                  ngv, type.mt_aw_basis_size());
                             if (hphi__ != nullptr) {
-                                halm_tmp = mdarray<double_complex, 2>(halm_block.at<CPU>(0, offsets_aw[ialoc]),
-                                                                      halm_block.at<GPU>(0, offsets_aw[ialoc]),
+                                halm_tmp = mdarray<double_complex, 2>(halm_block.at(memory_t::host, 0, offsets_aw[ialoc]),
+                                                                      halm_block.at(memory_t::device, 0, offsets_aw[ialoc]),
                                                                       ngv, type.mt_aw_basis_size());
                             }
                             break;
@@ -381,21 +381,21 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
             case CPU: {
                 if (ophi__ != nullptr) {
                     /* create resulting array with proper dimensions from the already allocated chunk of memory */
-                    alm_phi = matrix<double_complex>(alm_phi_buf.at<CPU>(), num_mt_aw, n__);
+                    alm_phi = matrix<double_complex>(alm_phi_buf.at(memory_t::host), num_mt_aw, n__);
                     /* alm_phi(lm, i) = A(G, lm)^{T} * C(G, i), remember that Alm was conjugated */
                     linalg<CPU>::gemm(2, 0, num_mt_aw, n__, ngv,
-                                      alm_block.at<CPU>(), alm_block.ld(),
-                                      phi__.pw_coeffs(0).prime().at<CPU>(0, N__), phi__.pw_coeffs(0).prime().ld(),
-                                      alm_phi.at<CPU>(), alm_phi.ld());
+                                      alm_block.at(memory_t::host), alm_block.ld(),
+                                      phi__.pw_coeffs(0).prime().at(memory_t::host, 0, N__), phi__.pw_coeffs(0).prime().ld(),
+                                      alm_phi.at(memory_t::host), alm_phi.ld());
                 }
                 if (hphi__ != nullptr) {
                     /* create resulting array with proper dimensions from the already allocated chunk of memory */
-                    halm_phi = matrix<double_complex>(halm_phi_buf.at<CPU>(), num_mt_aw, n__);
+                    halm_phi = matrix<double_complex>(halm_phi_buf.at(memory_t::host), num_mt_aw, n__);
                     /* halm_phi(lm, i) = H_{mt}A(G, lm)^{T} * C(G, i) */
                     linalg<CPU>::gemm(2, 0, num_mt_aw, n__, ngv,
-                                      halm_block.at<CPU>(), halm_block.ld(),
-                                      phi__.pw_coeffs(0).prime().at<CPU>(0, N__), phi__.pw_coeffs(0).prime().ld(),
-                                      halm_phi.at<CPU>(), halm_phi.ld());
+                                      halm_block.at(memory_t::host), halm_block.ld(),
+                                      phi__.pw_coeffs(0).prime().at(memory_t::host, 0, N__), phi__.pw_coeffs(0).prime().ld(),
+                                      halm_phi.at(memory_t::host), halm_phi.ld());
                 }
                 break;
             }
@@ -403,22 +403,22 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
 #if defined(__GPU)
                 if (ophi__ != nullptr) {
                     /* create resulting array with proper dimensions from the already allocated chunk of memory */
-                    alm_phi = matrix<double_complex>(alm_phi_buf.at<CPU>(), alm_phi_buf.at<GPU>(), num_mt_aw, n__);
+                    alm_phi = matrix<double_complex>(alm_phi_buf.at(memory_t::host, ), alm_phi_buf.at(memory_t::device, ), num_mt_aw, n__);
                     /* alm_phi(lm, i) = A(G, lm)^{T} * C(G, i) */
                     linalg<GPU>::gemm(2, 0, num_mt_aw, n__, ngv,
-                                      alm_block.at<GPU>(), alm_block.ld(),
-                                      phi__.pw_coeffs(0).prime().at<GPU>(0, N__), phi__.pw_coeffs(0).prime().ld(),
-                                      alm_phi.at<GPU>(), alm_phi.ld());
+                                      alm_block.at(memory_t::device, ), alm_block.ld(),
+                                      phi__.pw_coeffs(0).prime().at(memory_t::device, 0, N__), phi__.pw_coeffs(0).prime().ld(),
+                                      alm_phi.at(memory_t::device, ), alm_phi.ld());
                     alm_phi.copy<memory_t::device, memory_t::host>();
                 }
                 if (hphi__ != nullptr) {
                     /* create resulting array with proper dimensions from the already allocated chunk of memory */
-                    halm_phi = matrix<double_complex>(halm_phi_buf.at<CPU>(), halm_phi_buf.at<GPU>(), num_mt_aw, n__);
+                    halm_phi = matrix<double_complex>(halm_phi_buf.at(memory_t::host, ), halm_phi_buf.at(memory_t::device, ), num_mt_aw, n__);
                     /* halm_phi(lm, i) = H_{mt}A(G, lm)^{T} * C(G, i) */
                     linalg<GPU>::gemm(2, 0, num_mt_aw, n__, ngv,
-                                      halm_block.at<GPU>(), halm_block.ld(),
-                                      phi__.pw_coeffs(0).prime().at<GPU>(0, N__), phi__.pw_coeffs(0).prime().ld(),
-                                      halm_phi.at<GPU>(), halm_phi.ld());
+                                      halm_block.at(memory_t::device, ), halm_block.ld(),
+                                      phi__.pw_coeffs(0).prime().at(memory_t::device, 0, N__), phi__.pw_coeffs(0).prime().ld(),
+                                      halm_phi.at(memory_t::device, ), halm_phi.ld());
 
                     halm_phi.copy<memory_t::device, memory_t::host>();
                 }
@@ -428,14 +428,14 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
         }
 
         if (hphi__ != nullptr) {
-            kp__->comm().allreduce(halm_phi.at<CPU>(), num_mt_aw * n__);
+            kp__->comm().allreduce(halm_phi.at(memory_t::host), num_mt_aw * n__);
             if (ctx_.processing_unit() == device_t::GPU) {
                 halm_phi.copy_to(memory_t::device);
             }
         }
 
         if (ophi__ != nullptr) {
-            kp__->comm().allreduce(alm_phi.at<CPU>(), num_mt_aw * n__);
+            kp__->comm().allreduce(alm_phi.at(memory_t::host), num_mt_aw * n__);
             if (ctx_.processing_unit() == device_t::GPU) {
                 alm_phi.copy_to(memory_t::device);
             }
@@ -452,20 +452,20 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
                     /* APW-APW contribution to overlap */
                     linalg<CPU>::gemm(0, 0, ngv, n__, num_mt_aw,
                                       linalg_const<double_complex>::one(),
-                                      alm_block.at<CPU>(), alm_block.ld(),
-                                      alm_phi.at<CPU>(), alm_phi.ld(),
+                                      alm_block.at(memory_t::host), alm_block.ld(),
+                                      alm_phi.at(memory_t::host), alm_phi.ld(),
                                       linalg_const<double_complex>::one(),
-                                      ophi__->pw_coeffs(0).prime().at<CPU>(0, N__), ophi__->pw_coeffs(0).prime().ld());
+                                      ophi__->pw_coeffs(0).prime().at(memory_t::host, 0, N__), ophi__->pw_coeffs(0).prime().ld());
 
                 }
                 if (hphi__ != nullptr) {
                     /* APW-APW contribution to Hamiltonian */
                     linalg<CPU>::gemm(0, 0, ngv, n__, num_mt_aw,
                                       linalg_const<double_complex>::one(),
-                                      alm_block.at<CPU>(), alm_block.ld(),
-                                      halm_phi.at<CPU>(), halm_phi.ld(),
+                                      alm_block.at(memory_t::host), alm_block.ld(),
+                                      halm_phi.at(memory_t::host), halm_phi.ld(),
                                       linalg_const<double_complex>::one(),
-                                      hphi__->pw_coeffs(0).prime().at<CPU>(0, N__), hphi__->pw_coeffs(0).prime().ld());
+                                      hphi__->pw_coeffs(0).prime().at(memory_t::host, 0, N__), hphi__->pw_coeffs(0).prime().ld());
                 }
                 break;
             }
@@ -475,20 +475,20 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
                     /* APW-APW contribution to overlap */
                     linalg<GPU>::gemm(0, 0, ngv, n__, num_mt_aw,
                                       &linalg_const<double_complex>::one(),
-                                      alm_block.at<GPU>(), alm_block.ld(),
-                                      alm_phi.at<GPU>(), alm_phi.ld(),
+                                      alm_block.at(memory_t::device, ), alm_block.ld(),
+                                      alm_phi.at(memory_t::device, ), alm_phi.ld(),
                                       &linalg_const<double_complex>::one(),
-                                      ophi__->pw_coeffs(0).prime().at<GPU>(0, N__), ophi__->pw_coeffs(0).prime().ld());
+                                      ophi__->pw_coeffs(0).prime().at(memory_t::device, 0, N__), ophi__->pw_coeffs(0).prime().ld());
 
                 }
                 if (hphi__ != nullptr) {
                     /* APW-APW contribution to Hamiltonian */
                     linalg<GPU>::gemm(0, 0, ngv, n__, num_mt_aw,
                                       &linalg_const<double_complex>::one(),
-                                      alm_block.at<GPU>(), alm_block.ld(),
-                                      halm_phi.at<GPU>(), halm_phi.ld(),
+                                      alm_block.at(memory_t::device, ), alm_block.ld(),
+                                      halm_phi.at(memory_t::device, ), halm_phi.ld(),
                                       &linalg_const<double_complex>::one(),
-                                      hphi__->pw_coeffs(0).prime().at<GPU>(0, N__), hphi__->pw_coeffs(0).prime().ld());
+                                      hphi__->pw_coeffs(0).prime().at(memory_t::device, 0, N__), hphi__->pw_coeffs(0).prime().ld());
                 }
 #endif
                 break;
@@ -513,12 +513,12 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
                 #pragma omp parallel for schedule(static)
                 for (int i = 0; i < n__; i++) {
                     std::memcpy(&phi_lo_ia(0, i),
-                                phi__.mt_coeffs(0).prime().at<CPU>(phi__.offset_mt_coeffs(ia_location.local_index), N__ + i),
+                                phi__.mt_coeffs(0).prime().at(memory_t::host, phi__.offset_mt_coeffs(ia_location.local_index), N__ + i),
                                 type.mt_lo_basis_size() * sizeof(double_complex));
                 }
             }
             /* broadcast from a rank */
-            kp__->comm().bcast(phi_lo_ia.at<CPU>(), static_cast<int>(phi_lo_ia.size()), ia_location.rank);
+            kp__->comm().bcast(phi_lo_ia.at(memory_t::host), static_cast<int>(phi_lo_ia.size()), ia_location.rank);
             /* wrtite into a proper position in a block */
             #pragma omp parallel for schedule(static)
             for (int i = 0; i < n__; i++) {
@@ -563,9 +563,9 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
                 switch (ctx_.processing_unit()) {
                     case CPU: {
                         linalg<CPU>::gemm(0, 0, ngv, nlo, naw,
-                                          alm_block.at<CPU>(0, offsets_aw[ialoc]), alm_block.ld(),
-                                          hmt.at<CPU>(), hmt.ld(),
-                                          halm_block.at<CPU>(0, offsets_lo[ialoc]), halm_block.ld());
+                                          alm_block.at(memory_t::host, 0, offsets_aw[ialoc]), alm_block.ld(),
+                                          hmt.at(memory_t::host), hmt.ld(),
+                                          halm_block.at(memory_t::host, 0, offsets_lo[ialoc]), halm_block.ld());
                         break;
                     }
                     case GPU: {
@@ -573,9 +573,9 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
                         hmt.allocate(memory_t::device);
                         hmt.copy<memory_t::host, memory_t::device>();
                         linalg<GPU>::gemm(0, 0, ngv, nlo, naw,
-                                          alm_block.at<GPU>(0, offsets_aw[ialoc]), alm_block.ld(),
-                                          hmt.at<GPU>(), hmt.ld(),
-                                          halm_block.at<GPU>(0, offsets_lo[ialoc]), halm_block.ld());
+                                          alm_block.at(memory_t::device, 0, offsets_aw[ialoc]), alm_block.ld(),
+                                          hmt.at(memory_t::device), hmt.ld(),
+                                          halm_block.at(memory_t::device, 0, offsets_lo[ialoc]), halm_block.ld());
 #endif
                         break;
 
@@ -586,10 +586,10 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
                 case CPU: {
                     linalg<CPU>::gemm(0, 0, ngv, n__, num_mt_lo,
                                       linalg_const<double_complex>::one(),
-                                      halm_block.at<CPU>(), halm_block.ld(),
-                                      phi_lo_block.at<CPU>(), phi_lo_block.ld(),
+                                      halm_block.at(memory_t::host), halm_block.ld(),
+                                      phi_lo_block.at(memory_t::host), phi_lo_block.ld(),
                                       linalg_const<double_complex>::one(),
-                                      hphi__->pw_coeffs(0).prime().at<CPU>(0, N__), hphi__->pw_coeffs(0).prime().ld());
+                                      hphi__->pw_coeffs(0).prime().at(memory_t::host, 0, N__), hphi__->pw_coeffs(0).prime().ld());
                     break;
 
                 }
@@ -597,10 +597,10 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
 #if defined(__GPU)
                     linalg<GPU>::gemm(0, 0, ngv, n__, num_mt_lo,
                                       &linalg_const<double_complex>::one(),
-                                      halm_block.at<GPU>(), halm_block.ld(),
-                                      phi_lo_block.at<GPU>(), phi_lo_block.ld(),
+                                      halm_block.at(memory_t::device), halm_block.ld(),
+                                      phi_lo_block.at(memory_t::device), phi_lo_block.ld(),
                                       &linalg_const<double_complex>::one(),
-                                      hphi__->pw_coeffs(0).prime().at<GPU>(0, N__), hphi__->pw_coeffs(0).prime().ld());
+                                      hphi__->pw_coeffs(0).prime().at(memory_t::device, 0, N__), hphi__->pw_coeffs(0).prime().ld());
 #endif
                     break;
                 }
@@ -638,10 +638,10 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
                 case CPU: {
                     linalg<CPU>::gemm(0, 0, ngv, n__, num_mt_lo,
                                       linalg_const<double_complex>::one(),
-                                      halm_block.at<CPU>(), halm_block.ld(),
-                                      phi_lo_block.at<CPU>(), phi_lo_block.ld(),
+                                      halm_block.at(memory_t::host), halm_block.ld(),
+                                      phi_lo_block.at(memory_t::host), phi_lo_block.ld(),
                                       linalg_const<double_complex>::one(),
-                                      ophi__->pw_coeffs(0).prime().at<CPU>(0, N__), ophi__->pw_coeffs(0).prime().ld());
+                                      ophi__->pw_coeffs(0).prime().at(memory_t::host, 0, N__), ophi__->pw_coeffs(0).prime().ld());
                     break;
 
                 }
@@ -650,10 +650,10 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
                     halm_block.copy_to(memory_t::device, 0, ngv * num_mt_lo);
                     linalg<GPU>::gemm(0, 0, ngv, n__, num_mt_lo,
                                       &linalg_const<double_complex>::one(),
-                                      halm_block.at<GPU>(), halm_block.ld(),
-                                      phi_lo_block.at<GPU>(), phi_lo_block.ld(),
+                                      halm_block.at(memory_t::device, ), halm_block.ld(),
+                                      phi_lo_block.at(memory_t::device, ), phi_lo_block.ld(),
                                       &linalg_const<double_complex>::one(),
-                                      ophi__->pw_coeffs(0).prime().at<GPU>(0, N__), ophi__->pw_coeffs(0).prime().ld());
+                                      ophi__->pw_coeffs(0).prime().at(memory_t::device, 0, N__), ophi__->pw_coeffs(0).prime().ld());
 #endif
                     break;
                 }
@@ -852,12 +852,12 @@ inline void Hamiltonian::apply_magnetic_field(K_point*                     kp__,
         /* compute bwf = B_z*|wf_j> */
         linalg<CPU>::hemm(0, 0, mt_basis_size, ctx_.num_fv_states(),
                           linalg_const<double_complex>::one(),
-                          zm.at<CPU>(),
+                          zm.at(memory_t::host),
                           zm.ld(),
-                          fv_states__.mt_coeffs(0).prime().at<CPU>(offset, 0),
+                          fv_states__.mt_coeffs(0).prime().at(memory_t::host, offset, 0),
                           fv_states__.mt_coeffs(0).prime().ld(),
                           linalg_const<double_complex>::zero(),
-                          hpsi__[0].mt_coeffs(0).prime().at<CPU>(offset, 0),
+                          hpsi__[0].mt_coeffs(0).prime().at(memory_t::host, offset, 0),
                           hpsi__[0].mt_coeffs(0).prime().ld());
 
         /* compute bwf = (B_x - iB_y)|wf_j> */
@@ -876,11 +876,11 @@ inline void Hamiltonian::apply_magnetic_field(K_point*                     kp__,
             }
 
             linalg<CPU>::gemm(0, 0, mt_basis_size, ctx_.num_fv_states(), mt_basis_size,
-                              zm.at<CPU>(),
+                              zm.at(memory_t::host),
                               zm.ld(),
-                              fv_states__.mt_coeffs(0).prime().at<CPU>(offset, 0),
+                              fv_states__.mt_coeffs(0).prime().at(memory_t::host, offset, 0),
                               fv_states__.mt_coeffs(0).prime().ld(),
-                              hpsi__[2].mt_coeffs(0).prime().at<CPU>(offset, 0),
+                              hpsi__[2].mt_coeffs(0).prime().at(memory_t::host, offset, 0),
                               hpsi__[2].mt_coeffs(0).prime().ld());
         }
     }

--- a/src/Hamiltonian/apply.hpp
+++ b/src/Hamiltonian/apply.hpp
@@ -350,14 +350,14 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
                         }
                     }
 #if defined(__GPU)
-                    if (ctx_.processing_unit() == GPU) {
+                    if (ctx_.processing_unit() == device_t::GPU) {
                         alm_tmp.copy_to(memory_t::device, stream_id(tid));
                     }
 #endif
                     if (hphi__ != nullptr) {
                         apply_hmt_to_apw<spin_block_t::nm>(atom, ngv, alm_tmp, halm_tmp);
 #if defined(__GPU)
-                        if (ctx_.processing_unit() == GPU) {
+                        if (ctx_.processing_unit() == device_t::GPU) {
                             halm_tmp.copy_to(memory_t::device, stream_id(tid));
                         }
 #endif
@@ -365,8 +365,8 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
                 }
             }
 #if defined(__GPU)
-            if (ctx_.processing_unit() == GPU) {
-                acc::sync_stream(tid);
+            if (ctx_.processing_unit() == device_t::GPU) {
+                acc::sync_stream(stream_id(tid));
             }
 #endif
         }

--- a/src/Hamiltonian/apply.hpp
+++ b/src/Hamiltonian/apply.hpp
@@ -403,24 +403,24 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
 #if defined(__GPU)
                 if (ophi__ != nullptr) {
                     /* create resulting array with proper dimensions from the already allocated chunk of memory */
-                    alm_phi = matrix<double_complex>(alm_phi_buf.at(memory_t::host, ), alm_phi_buf.at(memory_t::device, ), num_mt_aw, n__);
+                    alm_phi = matrix<double_complex>(alm_phi_buf.at(memory_t::host), alm_phi_buf.at(memory_t::device), num_mt_aw, n__);
                     /* alm_phi(lm, i) = A(G, lm)^{T} * C(G, i) */
                     linalg<GPU>::gemm(2, 0, num_mt_aw, n__, ngv,
-                                      alm_block.at(memory_t::device, ), alm_block.ld(),
+                                      alm_block.at(memory_t::device), alm_block.ld(),
                                       phi__.pw_coeffs(0).prime().at(memory_t::device, 0, N__), phi__.pw_coeffs(0).prime().ld(),
-                                      alm_phi.at(memory_t::device, ), alm_phi.ld());
-                    alm_phi.copy<memory_t::device, memory_t::host>();
+                                      alm_phi.at(memory_t::device), alm_phi.ld());
+                    alm_phi.copy_to(memory_t::host);
                 }
                 if (hphi__ != nullptr) {
                     /* create resulting array with proper dimensions from the already allocated chunk of memory */
-                    halm_phi = matrix<double_complex>(halm_phi_buf.at(memory_t::host, ), halm_phi_buf.at(memory_t::device, ), num_mt_aw, n__);
+                    halm_phi = matrix<double_complex>(halm_phi_buf.at(memory_t::host), halm_phi_buf.at(memory_t::device), num_mt_aw, n__);
                     /* halm_phi(lm, i) = H_{mt}A(G, lm)^{T} * C(G, i) */
                     linalg<GPU>::gemm(2, 0, num_mt_aw, n__, ngv,
-                                      halm_block.at(memory_t::device, ), halm_block.ld(),
+                                      halm_block.at(memory_t::device), halm_block.ld(),
                                       phi__.pw_coeffs(0).prime().at(memory_t::device, 0, N__), phi__.pw_coeffs(0).prime().ld(),
-                                      halm_phi.at(memory_t::device, ), halm_phi.ld());
+                                      halm_phi.at(memory_t::device), halm_phi.ld());
 
-                    halm_phi.copy<memory_t::device, memory_t::host>();
+                    halm_phi.copy_to(memory_t::host);
                 }
 #endif
                 break;
@@ -475,8 +475,8 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
                     /* APW-APW contribution to overlap */
                     linalg<GPU>::gemm(0, 0, ngv, n__, num_mt_aw,
                                       &linalg_const<double_complex>::one(),
-                                      alm_block.at(memory_t::device, ), alm_block.ld(),
-                                      alm_phi.at(memory_t::device, ), alm_phi.ld(),
+                                      alm_block.at(memory_t::device), alm_block.ld(),
+                                      alm_phi.at(memory_t::device), alm_phi.ld(),
                                       &linalg_const<double_complex>::one(),
                                       ophi__->pw_coeffs(0).prime().at(memory_t::device, 0, N__), ophi__->pw_coeffs(0).prime().ld());
 
@@ -485,8 +485,8 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
                     /* APW-APW contribution to Hamiltonian */
                     linalg<GPU>::gemm(0, 0, ngv, n__, num_mt_aw,
                                       &linalg_const<double_complex>::one(),
-                                      alm_block.at(memory_t::device, ), alm_block.ld(),
-                                      halm_phi.at(memory_t::device, ), halm_phi.ld(),
+                                      alm_block.at(memory_t::device), alm_block.ld(),
+                                      halm_phi.at(memory_t::device), halm_phi.ld(),
                                       &linalg_const<double_complex>::one(),
                                       hphi__->pw_coeffs(0).prime().at(memory_t::device, 0, N__), hphi__->pw_coeffs(0).prime().ld());
                 }
@@ -571,7 +571,7 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
                     case GPU: {
 #if defined(__GPU)
                         hmt.allocate(memory_t::device);
-                        hmt.copy<memory_t::host, memory_t::device>();
+                        hmt.copy_to(memory_t::device);
                         linalg<GPU>::gemm(0, 0, ngv, nlo, naw,
                                           alm_block.at(memory_t::device, 0, offsets_aw[ialoc]), alm_block.ld(),
                                           hmt.at(memory_t::device), hmt.ld(),
@@ -650,8 +650,8 @@ inline void Hamiltonian::apply_fv_h_o(K_point*        kp__,
                     halm_block.copy_to(memory_t::device, 0, ngv * num_mt_lo);
                     linalg<GPU>::gemm(0, 0, ngv, n__, num_mt_lo,
                                       &linalg_const<double_complex>::one(),
-                                      halm_block.at(memory_t::device, ), halm_block.ld(),
-                                      phi_lo_block.at(memory_t::device, ), phi_lo_block.ld(),
+                                      halm_block.at(memory_t::device), halm_block.ld(),
+                                      phi_lo_block.at(memory_t::device), phi_lo_block.ld(),
                                       &linalg_const<double_complex>::one(),
                                       ophi__->pw_coeffs(0).prime().at(memory_t::device, 0, N__), ophi__->pw_coeffs(0).prime().ld());
 #endif

--- a/src/Hamiltonian/get_h_o_diag.hpp
+++ b/src/Hamiltonian/get_h_o_diag.hpp
@@ -77,9 +77,8 @@ Hamiltonian::get_h_diag(K_point* kp__,
             nlo++;
         }
     }
-    if (ctx_.processing_unit() == GPU) {
-        h_diag.allocate(memory_t::device);
-        h_diag.copy<memory_t::host, memory_t::device>();
+    if (ctx_.processing_unit() == device_t::GPU) {
+        h_diag.allocate(memory_t::device).copy_to(memory_t::device);
     }
     return std::move(h_diag);
 }
@@ -119,9 +118,8 @@ Hamiltonian::get_o_diag(K_point* kp__,
             }
         }
     }
-    if (ctx_.processing_unit() == GPU) {
-        o_diag.allocate(memory_t::device);
-        o_diag.copy<memory_t::host, memory_t::device>();
+    if (ctx_.processing_unit() == device_t::GPU) {
+        o_diag.allocate(memory_t::device).copy_to(memory_t::device);
     }
     return std::move(o_diag);
 }
@@ -181,9 +179,8 @@ Hamiltonian::get_h_diag(K_point* kp__) const
             }
         }
     }
-    if (ctx_.processing_unit() == GPU) {
-        h_diag.allocate(memory_t::device);
-        h_diag.copy<memory_t::host, memory_t::device>();
+    if (ctx_.processing_unit() == device_t::GPU) {
+        h_diag.allocate(memory_t::device).copy_to(memory_t::device);
     }
     return std::move(h_diag);
 }
@@ -242,9 +239,8 @@ Hamiltonian::get_o_diag(K_point* kp__) const
             }
         }
     }
-    if (ctx_.processing_unit() == GPU) {
-        o_diag.allocate(memory_t::device);
-        o_diag.copy<memory_t::host, memory_t::device>();
+    if (ctx_.processing_unit() == device_t::GPU) {
+        o_diag.allocate(memory_t::device).copy_to(memory_t::device);
     }
     return std::move(o_diag);
 }

--- a/src/Hamiltonian/local_operator.hpp
+++ b/src/Hamiltonian/local_operator.hpp
@@ -691,7 +691,7 @@ class Local_operator
                 /* save phi_u(r) */
                 switch (fft_coarse_.pu()) {
                     case device_t::CPU: {
-                        fft_coarse_.output(buf_rg_.at<CPU>());
+                        fft_coarse_.output(buf_rg_.at(memory_t::host));
                         break;
                     }
                     case device_t::GPU: {
@@ -712,7 +712,7 @@ class Local_operator
                 /* copy to FFT buffer */
                 switch (fft_coarse_.pu()) {
                     case device_t::CPU: {
-                        fft_coarse_.input(buf_rg_.at<CPU>());
+                        fft_coarse_.input(buf_rg_.at(memory_t::host));
                         break;
                     }
                     case device_t::GPU: {
@@ -734,7 +734,7 @@ class Local_operator
                 /* save phi_d(r) */
                 switch (fft_coarse_.pu()) {
                     case device_t::CPU: {
-                        fft_coarse_.output(buf_rg_.at<CPU>());
+                        fft_coarse_.output(buf_rg_.at(memory_t::host));
                         break;
                     }
                     case device_t::GPU: {
@@ -755,7 +755,7 @@ class Local_operator
                 /* copy to FFT buffer */
                 switch (fft_coarse_.pu()) {
                     case CPU: {
-                        fft_coarse_.input(buf_rg_.at<CPU>());
+                        fft_coarse_.input(buf_rg_.at(memory_t::host));
                         break;
                     }
                     case GPU: {
@@ -845,12 +845,12 @@ class Local_operator
             switch (fft_coarse_.pu()) {
                 case CPU: {
                     /* phi(G) -> phi(r) */
-                    fft_coarse_.transform<1>(phi__.pw_coeffs(0).extra().at<CPU>(0, j));
+                    fft_coarse_.transform<1>(phi__.pw_coeffs(0).extra().at(memory_t::host, 0, j));
 
                     if (ophi__ != nullptr) {
                         /* save phi(r) */
                         if (hphi__ != nullptr) {
-                            fft_coarse_.output(buf_rg_.at<CPU>());
+                            fft_coarse_.output(buf_rg_.at(memory_t::host));
                         }
                         #pragma omp parallel for schedule(static)
                         for (int ir = 0; ir < fft_coarse_.local_size(); ir++) {
@@ -858,10 +858,10 @@ class Local_operator
                             fft_coarse_.buffer(ir) *= theta_.f_rg(ir);
                         }
                         /* phi(r) * Theta(r) -> ophi(G) */
-                        fft_coarse_.transform<-1>(ophi__->pw_coeffs(0).extra().at<CPU>(0, j));
+                        fft_coarse_.transform<-1>(ophi__->pw_coeffs(0).extra().at(memory_t::host, 0, j));
                         /* load phi(r) back */
                         if (hphi__ != nullptr) {
-                            fft_coarse_.input(buf_rg_.at<CPU>());
+                            fft_coarse_.input(buf_rg_.at(memory_t::host));
                         }
                     }
                     if (hphi__ != nullptr) {
@@ -872,14 +872,14 @@ class Local_operator
                             fft_coarse_.buffer(ir) *= veff_vec_[0].f_rg(ir);
                         }
                         /* phi(r) * Theta(r) * V(r) -> hphi(G) */
-                        fft_coarse_.transform<-1>(hphi__->pw_coeffs(0).extra().at<CPU>(0, j));
+                        fft_coarse_.transform<-1>(hphi__->pw_coeffs(0).extra().at(memory_t::host, 0, j));
                     }
                     break;
                 }
                 case GPU: {
 #if defined(__GPU)
                     /* phi(G) -> phi(r) */
-                    fft_coarse_.transform<1>(phi__.pw_coeffs(0).extra().at<CPU>(0, j));
+                    fft_coarse_.transform<1>(phi__.pw_coeffs(0).extra().at(memory_t::host, 0, j));
 
                     if (ophi__ != nullptr) {
                         /* save phi(r) */
@@ -890,7 +890,7 @@ class Local_operator
                         scale_matrix_rows_gpu(fft_coarse_.local_size(), 1, fft_coarse_.buffer().at<GPU>(),
                                               theta_.f_rg().at<GPU>());
                         /* phi(r) * Theta(r) -> ophi(G) */
-                        fft_coarse_.transform<-1>(ophi__->pw_coeffs(0).extra().at<CPU>(0, j));
+                        fft_coarse_.transform<-1>(ophi__->pw_coeffs(0).extra().at(memory_t::host, 0, j));
                         /* load phi(r) back */
                         if (hphi__ != nullptr) {
                             acc::copy(fft_coarse_.buffer().at<GPU>(), buf_rg_.at<GPU>(), fft_coarse_.local_size());
@@ -901,7 +901,7 @@ class Local_operator
                         scale_matrix_rows_gpu(fft_coarse_.local_size(), 1, fft_coarse_.buffer().at<GPU>(),
                                               veff_vec_[0].f_rg().at<GPU>());
                         /* phi(r) * Theta(r) * V(r) -> hphi(G) */
-                        fft_coarse_.transform<-1>(hphi__->pw_coeffs(0).extra().at<CPU>(0, j));
+                        fft_coarse_.transform<-1>(hphi__->pw_coeffs(0).extra().at(memory_t::host, 0, j));
                     }
 #endif
                     break;
@@ -1013,10 +1013,10 @@ class Local_operator
             switch (fft_coarse_.pu()) {
                 case CPU: {
                     /* phi(G) -> phi(r) */
-                    fft_coarse_.transform<1>(phi__.pw_coeffs(0).extra().at<CPU>(0, j));
+                    fft_coarse_.transform<1>(phi__.pw_coeffs(0).extra().at(memory_t::host, 0, j));
                     /* save phi(r) */
                     if (bphi__.size() == 3) {
-                        fft_coarse_.output(buf_rg_.at<CPU>());
+                        fft_coarse_.output(buf_rg_.at(memory_t::host));
                     }
                     #pragma omp parallel for schedule(static)
                     for (int ir = 0; ir < fft_coarse_.local_size(); ir++) {
@@ -1024,7 +1024,7 @@ class Local_operator
                         fft_coarse_.buffer(ir) *= veff_vec_[1].f_rg(ir);
                     }
                     /* phi(r) * Bz(r) -> bphi[0](G) */
-                    fft_coarse_.transform<-1>(bphi__[0].pw_coeffs(0).extra().at<CPU>(0, j));
+                    fft_coarse_.transform<-1>(bphi__[0].pw_coeffs(0).extra().at(memory_t::host, 0, j));
                     /* non-collinear case */
                     if (bphi__.size() == 3) {
                         #pragma omp parallel for schedule(static)
@@ -1033,18 +1033,18 @@ class Local_operator
                             fft_coarse_.buffer(ir) = buf_rg_[ir] * double_complex(veff_vec_[2].f_rg(ir), -veff_vec_[3].f_rg(ir));
                         }
                         /* phi(r) * (Bx(r)-iBy(r)) -> bphi[2](G) */
-                        fft_coarse_.transform<-1>(bphi__[2].pw_coeffs(0).extra().at<CPU>(0, j));
+                        fft_coarse_.transform<-1>(bphi__[2].pw_coeffs(0).extra().at(memory_t::host, 0, j));
                     }
                     break;
                 }
                 case GPU: {
 #if defined(__GPU)
                     /* phi(G) -> phi(r) */
-                    fft_coarse_.transform<1>(phi__.pw_coeffs(0).extra().at<CPU>(0, j));
+                    fft_coarse_.transform<1>(phi__.pw_coeffs(0).extra().at(memory_t::host, 0, j));
                     /* multiply by Bz */
                     scale_matrix_rows_gpu(fft_coarse_.local_size(), 1, fft_coarse_.buffer().at<GPU>(), veff_vec_[1].f_rg().at<GPU>());
                     /* phi(r) * Bz(r) -> bphi[0](G) */
-                    fft_coarse_.transform<-1>(bphi__[0].pw_coeffs(0).extra().at<CPU>(0, j));
+                    fft_coarse_.transform<-1>(bphi__[0].pw_coeffs(0).extra().at(memory_t::host, 0, j));
 #else
                     TERMINATE_NO_GPU
 #endif

--- a/src/Hamiltonian/local_operator.hpp
+++ b/src/Hamiltonian/local_operator.hpp
@@ -102,8 +102,7 @@ class Local_operator
 
         if (fft_coarse_.pu() == GPU) {
             for (int j = 0; j < ctx_.num_mag_dims() + 1; j++) {
-                veff_vec_[j].f_rg().allocate(memory_t::device);
-                veff_vec_[j].f_rg().copy<memory_t::host, memory_t::device>();
+                veff_vec_[j].f_rg().allocate(memory_t::device).copy_to(memory_t::device);
             }
             buf_rg_.allocate(memory_t::device);
         }
@@ -171,11 +170,9 @@ class Local_operator
 
             if (fft_coarse_.pu() == GPU) {
                 for (int j = 0; j < ctx_.num_mag_dims() + 1; j++) {
-                    veff_vec_[j].f_rg().allocate(memory_t::device);
-                    veff_vec_[j].f_rg().copy<memory_t::host, memory_t::device>();
+                    veff_vec_[j].f_rg().allocate(memory_t::device).copy_to(memory_t::device);
                 }
-                theta_.f_rg().allocate(memory_t::device);
-                theta_.f_rg().copy<memory_t::host, memory_t::device>();
+                theta_.f_rg().allocate(memory_t::device).copy_to(memory_t::device);
                 buf_rg_.allocate(memory_t::device);
             }
 
@@ -220,8 +217,7 @@ class Local_operator
             /* copy veff to device */
             if (fft_coarse_.pu() == GPU) {
                 for (int j = 0; j < ctx_.num_mag_dims() + 1; j++) {
-                    veff_vec_[j].f_rg().allocate(memory_t::device);
-                    veff_vec_[j].f_rg().copy<memory_t::host, memory_t::device>();
+                    veff_vec_[j].f_rg().allocate(memory_t::device).copy_to(memory_t::device);
                 }
                 if (ctx_.num_mag_dims() == 3) {
                     buf_rg_.allocate(memory_t::device);
@@ -268,8 +264,7 @@ class Local_operator
         }
 
         if (fft_coarse_.pu() == device_t::GPU) {
-            pw_ekin_.allocate(memory_t::device);
-            pw_ekin_.copy<memory_t::host, memory_t::device>();
+            pw_ekin_.allocate(memory_t::device).copy_to(memory_t::device);
             vphi_.allocate(memory_t::device);
         }
     }

--- a/src/Hamiltonian/local_operator.hpp
+++ b/src/Hamiltonian/local_operator.hpp
@@ -382,7 +382,7 @@ class Local_operator
             case device_t::GPU: {
                 vptr.allocate(memory_t::device);
                 for (int j = 0; j < ctx_.num_mag_dims() + 1; j++) {
-                    vptr[j] = veff_vec_[j].f_rg().at<GPU>();
+                    vptr[j] = veff_vec_[j].f_rg().at(memory_t::device);
                 }
                 vptr.copy_to(memory_t::device);
                 break;
@@ -530,7 +530,7 @@ class Local_operator
                 }
                 case device_t::GPU: {
 #ifdef __GPU
-                    mul_by_veff_gpu(ispn_block, fft_coarse_.local_size(), vptr.at<GPU>(), buf.at<GPU>());
+                    mul_by_veff_gpu(ispn_block, fft_coarse_.local_size(), vptr.at(memory_t::device), buf.at(memory_t::device));
 #endif
                     break;
                 }
@@ -607,23 +607,23 @@ class Local_operator
                     if (gamma) {
                         add_pw_ekin_gpu(gkvec_p_->gvec_count_fft(),
                                         alpha,
-                                        pw_ekin_.at<GPU>(),
-                                        phi1[ispn].at<GPU>(0, 0),
-                                        vphi_.at<GPU>(0, 0),
-                                        hphi1[ispn].at<GPU>(0, 0));
+                                        pw_ekin_.at(memory_t::device),
+                                        phi1[ispn].at(memory_t::device, 0, 0),
+                                        vphi_.at(memory_t::device, 0, 0),
+                                        hphi1[ispn].at(memory_t::device, 0, 0));
                         add_pw_ekin_gpu(gkvec_p_->gvec_count_fft(),
                                         alpha,
-                                        pw_ekin_.at<GPU>(),
-                                        phi1[ispn].at<GPU>(0, 1),
-                                        vphi_.at<GPU>(0, 1),
-                                        hphi1[ispn].at<GPU>(0, 1));
+                                        pw_ekin_.at(memory_t::device),
+                                        phi1[ispn].at(memory_t::device, 0, 1),
+                                        vphi_.at(memory_t::device, 0, 1),
+                                        hphi1[ispn].at(memory_t::device, 0, 1));
                     } else {
                         add_pw_ekin_gpu(gkvec_p_->gvec_count_fft(),
                                         alpha,
-                                        pw_ekin_.at<GPU>(),
-                                        phi1[ispn].at<GPU>(0, 0),
-                                        vphi_.at<GPU>(0, 0),
-                                        hphi1[ispn].at<GPU>(0, 0));
+                                        pw_ekin_.at(memory_t::device),
+                                        phi1[ispn].at(memory_t::device, 0, 0),
+                                        vphi_.at(memory_t::device, 0, 0),
+                                        hphi1[ispn].at(memory_t::device, 0, 0));
                     }
 #endif
                     break;
@@ -696,7 +696,7 @@ class Local_operator
                     }
                     case device_t::GPU: {
 #ifdef __GPU
-                        acc::copy(buf_rg_.at<GPU>(), fft_coarse_.buffer().at<GPU>(), fft_coarse_.local_size());
+                        acc::copy(buf_rg_.at(memory_t::device), fft_coarse_.buffer().at(memory_t::device), fft_coarse_.local_size());
 #endif
                         break;
                     }
@@ -717,7 +717,7 @@ class Local_operator
                     }
                     case device_t::GPU: {
 #ifdef __GPU
-                        acc::copy(fft_coarse_.buffer().at<GPU>(), buf_rg_.at<GPU>(), fft_coarse_.local_size());
+                        acc::copy(fft_coarse_.buffer().at(memory_t::device), buf_rg_.at(memory_t::device), fft_coarse_.local_size());
 #endif
                         break;
                     }
@@ -739,7 +739,7 @@ class Local_operator
                     }
                     case device_t::GPU: {
 #ifdef __GPU
-                        acc::copy(buf_rg_.at<GPU>(), fft_coarse_.buffer().at<GPU>(), fft_coarse_.local_size());
+                        acc::copy(buf_rg_.at(memory_t::device), fft_coarse_.buffer().at(memory_t::device), fft_coarse_.local_size());
 #endif
                         break;
                     }
@@ -760,7 +760,7 @@ class Local_operator
                     }
                     case GPU: {
 #ifdef __GPU
-                        acc::copy(fft_coarse_.buffer().at<GPU>(), buf_rg_.at<GPU>(), fft_coarse_.local_size());
+                        acc::copy(fft_coarse_.buffer().at(memory_t::device), buf_rg_.at(memory_t::device), fft_coarse_.local_size());
 #endif
                         break;
                     }
@@ -884,22 +884,22 @@ class Local_operator
                     if (ophi__ != nullptr) {
                         /* save phi(r) */
                         if (hphi__ != nullptr) {
-                            acc::copy(buf_rg_.at<GPU>(), fft_coarse_.buffer().at<GPU>(), fft_coarse_.local_size());
+                            acc::copy(buf_rg_.at(memory_t::device), fft_coarse_.buffer().at(memory_t::device), fft_coarse_.local_size());
                         }
                         /* multiply by step function */
-                        scale_matrix_rows_gpu(fft_coarse_.local_size(), 1, fft_coarse_.buffer().at<GPU>(),
-                                              theta_.f_rg().at<GPU>());
+                        scale_matrix_rows_gpu(fft_coarse_.local_size(), 1, fft_coarse_.buffer().at(memory_t::device),
+                                              theta_.f_rg().at(memory_t::device));
                         /* phi(r) * Theta(r) -> ophi(G) */
                         fft_coarse_.transform<-1>(ophi__->pw_coeffs(0).extra().at(memory_t::host, 0, j));
                         /* load phi(r) back */
                         if (hphi__ != nullptr) {
-                            acc::copy(fft_coarse_.buffer().at<GPU>(), buf_rg_.at<GPU>(), fft_coarse_.local_size());
+                            acc::copy(fft_coarse_.buffer().at(memory_t::device), buf_rg_.at(memory_t::device), fft_coarse_.local_size());
                         }
                     }
                     if (hphi__ != nullptr) {
                         /* multiply by effective potential */
-                        scale_matrix_rows_gpu(fft_coarse_.local_size(), 1, fft_coarse_.buffer().at<GPU>(),
-                                              veff_vec_[0].f_rg().at<GPU>());
+                        scale_matrix_rows_gpu(fft_coarse_.local_size(), 1, fft_coarse_.buffer().at(memory_t::device),
+                                              veff_vec_[0].f_rg().at(memory_t::device));
                         /* phi(r) * Theta(r) * V(r) -> hphi(G) */
                         fft_coarse_.transform<-1>(hphi__->pw_coeffs(0).extra().at(memory_t::host, 0, j));
                     }
@@ -934,7 +934,7 @@ class Local_operator
                         case GPU: {
 #if defined(__GPU)
                             /* multiply by step function */
-                            scale_matrix_rows_gpu(fft_coarse_.local_size(), 1, fft_coarse_.buffer().at<GPU>(), theta_.f_rg().at<GPU>());
+                            scale_matrix_rows_gpu(fft_coarse_.local_size(), 1, fft_coarse_.buffer().at(memory_t::device), theta_.f_rg().at(memory_t::device));
 #endif
                             break;
                         }
@@ -1042,7 +1042,7 @@ class Local_operator
                     /* phi(G) -> phi(r) */
                     fft_coarse_.transform<1>(phi__.pw_coeffs(0).extra().at(memory_t::host, 0, j));
                     /* multiply by Bz */
-                    scale_matrix_rows_gpu(fft_coarse_.local_size(), 1, fft_coarse_.buffer().at<GPU>(), veff_vec_[1].f_rg().at<GPU>());
+                    scale_matrix_rows_gpu(fft_coarse_.local_size(), 1, fft_coarse_.buffer().at(memory_t::device), veff_vec_[1].f_rg().at(memory_t::device));
                     /* phi(r) * Bz(r) -> bphi[0](G) */
                     fft_coarse_.transform<-1>(bphi__[0].pw_coeffs(0).extra().at(memory_t::host, 0, j));
 #else

--- a/src/Hamiltonian/non_local_operator.hpp
+++ b/src/Hamiltonian/non_local_operator.hpp
@@ -72,7 +72,7 @@ class Non_local_operator
             switch (pu_) {
                 case device_t::GPU: {
                     packed_mtrx_offset_.allocate(memory_t::device);
-                    packed_mtrx_offset_.template copy<memory_t::host, memory_t::device>();
+                    packed_mtrx_offset_.copy_to(memory_t::device);
                     break;
                 }
                 case device_t::CPU: break;
@@ -487,8 +487,7 @@ class D_operator : public Non_local_operator<T>
             }
 
             if (this->pu_ == GPU) {
-                this->op_.allocate(memory_t::device);
-                this->op_.template copy<memory_t::host, memory_t::device>();
+                this->op_.allocate(memory_t::device).copy_to(memory_t::device);
             }
         }
 
@@ -575,8 +574,7 @@ class Q_operator : public Non_local_operator<T>
             }
 
             if (this->pu_ == device_t::GPU) {
-                this->op_.allocate(memory_t::device);
-                this->op_.template copy<memory_t::host, memory_t::device>();
+                this->op_.allocate(memory_t::device).copy_to(memory_t::device);
             }
         }
 
@@ -618,7 +616,7 @@ class P_operator : public Non_local_operator<T>
             }
             if (this->pu_ == GPU) {
                 this->op_.allocate(memory_t::device);
-                this->op_.template copy<memory_t::host, memory_t::device>();
+                this->op_.copy_to(memory_t::device);
             }
         }
 };

--- a/src/Hamiltonian/non_local_operator.hpp
+++ b/src/Hamiltonian/non_local_operator.hpp
@@ -170,8 +170,8 @@ inline void Non_local_operator<double_complex>::apply(int chunk__,
 
         //switch (pu_) {
         //    case CPU: {
-        //        linalg<CPU>::gemm(0, 0, nbf, n__, nbf, op_.at<CPU>(packed_mtrx_offset_(ia), ispn_block__), nbf,
-        //                          beta_phi__.at<CPU>(offs, 0), nbeta, work_.at<CPU>(offs), nbeta);
+        //        linalg<CPU>::gemm(0, 0, nbf, n__, nbf, op_.at(memory_t::host, packed_mtrx_offset_(ia), ispn_block__), nbf,
+        //                          beta_phi__.at(memory_t::host, offs, 0), nbeta, work_.at(memory_t::host, offs), nbeta);
 
         //        break;
         //    }
@@ -220,9 +220,9 @@ inline void Non_local_operator<double_complex>::apply(int chunk__,
     ///* compute <G+k|beta> * O * <beta|phi> and add to op_phi */
     //switch (pu_) {
     //    case CPU: {
-    //        linalg<CPU>::gemm(0, 0, num_gkvec_loc, n__, nbeta, linalg_const<double_complex>::one(), beta_gk.template at<CPU>(),
-    //                          num_gkvec_loc, work_.at<CPU>(), nbeta, linalg_const<double_complex>::one(),
-    //                          op_phi__.pw_coeffs(jspn).prime().at<CPU>(0, idx0__),
+    //        linalg<CPU>::gemm(0, 0, num_gkvec_loc, n__, nbeta, linalg_const<double_complex>::one(), beta_gk.template at(memory_t::host),
+    //                          num_gkvec_loc, work_.at(memory_t::host), nbeta, linalg_const<double_complex>::one(),
+    //                          op_phi__.pw_coeffs(jspn).prime().at(memory_t::host, 0, idx0__),
     //                          op_phi__.pw_coeffs(jspn).prime().ld());
     //        break;
     //    }
@@ -232,8 +232,8 @@ inline void Non_local_operator<double_complex>::apply(int chunk__,
     //        #pragma omp parallel
     //        acc::sync_stream(omp_get_thread_num());
 
-    //        linalg<GPU>::gemm(0, 0, num_gkvec_loc, n__, nbeta, &linalg_const<double_complex>::one(), beta_gk.template at<GPU>(),
-    //                          beta_gk.ld(), work_.at<GPU>(), nbeta, &linalg_const<double_complex>::one(),
+    //        linalg<GPU>::gemm(0, 0, num_gkvec_loc, n__, nbeta, &linalg_const<double_complex>::one(), beta_gk.template at(memory_t::device),
+    //                          beta_gk.ld(), work_.at(memory_t::device), nbeta, &linalg_const<double_complex>::one(),
     //                          op_phi__.pw_coeffs(jspn).prime().at<GPU>(0, idx0__),
     //                          op_phi__.pw_coeffs(jspn).prime().ld());
     //        acc::sync_stream(-1);
@@ -275,22 +275,22 @@ inline void Non_local_operator<double_complex>::apply_one_atom(int chunk__,
     case CPU: {
         linalg<CPU>::gemm(0, 0, nbf,
                           n__, nbf,
-                          op_.at<CPU>(packed_mtrx_offset_(ia), ispn_block__),
+                          op_.at(memory_t::host, packed_mtrx_offset_(ia), ispn_block__),
                           nbf,
-                          beta_phi__.at<CPU>(offs, 0),
+                          beta_phi__.at(memory_t::host, offs, 0),
                           nbeta,
-                          work_.at<CPU>(),
+                          work_.at(memory_t::host),
                           nbf);
         /* compute <G+k|beta> * O * <beta|phi> and add to op_phi */
         linalg<CPU>::gemm(0, 0,
                           num_gkvec_loc,
                           n__, nbf,
                           linalg_const<double_complex>::one(),
-                          beta_gk.template at<CPU>(0, offs),
+                          beta_gk.template at(memory_t::host, 0, offs),
                           num_gkvec_loc,
-                          work_.at<CPU>(), nbf,
+                          work_.at(memory_t::host), nbf,
                           linalg_const<double_complex>::one(),
-                          op_phi__.pw_coeffs(jspn).prime().at<CPU>(0, idx0__),
+                          op_phi__.pw_coeffs(jspn).prime().at(memory_t::host, 0, idx0__),
                           op_phi__.pw_coeffs(jspn).prime().ld());
 
         break;
@@ -303,14 +303,14 @@ inline void Non_local_operator<double_complex>::apply_one_atom(int chunk__,
                           nbf,
                           beta_phi__.at<GPU>(offs, 0),
                           nbeta,
-                          work_.at<GPU>(),
+                          work_.at(memory_t::device),
                           nbf, -1);
         linalg<GPU>::gemm(0, 0,
                           num_gkvec_loc,
                           n__, nbf,
                           &linalg_const<double_complex>::one(),
                           beta_gk.template at<GPU>(0, offs),
-                          beta_gk.ld(), work_.at<GPU>(), nbf,
+                          beta_gk.ld(), work_.at(memory_t::device), nbf,
                           &linalg_const<double_complex>::one(),
                           op_phi__.pw_coeffs(jspn).prime().at<GPU>(0, idx0__),
                           op_phi__.pw_coeffs(jspn).prime().ld());
@@ -359,8 +359,8 @@ inline void Non_local_operator<double>::apply(int chunk__,
 
         switch (pu_) {
             case CPU: {
-                linalg<CPU>::gemm(0, 0, nbf, n__, nbf, op_.at<CPU>(packed_mtrx_offset_(ia), ispn_block__), nbf,
-                                  beta_phi__.at<CPU>(offs, 0), nbeta, work_.at<CPU>(offs), nbeta);
+                linalg<CPU>::gemm(0, 0, nbf, n__, nbf, op_.at(memory_t::host, packed_mtrx_offset_(ia), ispn_block__), nbf,
+                                  beta_phi__.at(memory_t::host, offs, 0), nbeta, work_.at(memory_t::host, offs), nbeta);
                 break;
             }
             case GPU: {
@@ -376,9 +376,9 @@ inline void Non_local_operator<double>::apply(int chunk__,
     /* compute <G+k|beta> * O * <beta|phi> and add to op_phi */
     switch (pu_) {
         case CPU: {
-            linalg<CPU>::gemm(0, 0, 2 * num_gkvec_loc, n__, nbeta, 1.0, reinterpret_cast<double*>(beta_gk.template at<CPU>()),
-                              2 * num_gkvec_loc, work_.at<CPU>(), nbeta, 1.0,
-                              reinterpret_cast<double*>(op_phi__.pw_coeffs(jspn).prime().at<CPU>(0, idx0__)),
+            linalg<CPU>::gemm(0, 0, 2 * num_gkvec_loc, n__, nbeta, 1.0, reinterpret_cast<double*>(beta_gk.template at(memory_t::host)),
+                              2 * num_gkvec_loc, work_.at(memory_t::host), nbeta, 1.0,
+                              reinterpret_cast<double*>(op_phi__.pw_coeffs(jspn).prime().at(memory_t::host, 0, idx0__)),
                               2 * op_phi__.pw_coeffs(jspn).prime().ld());
             break;
         }
@@ -389,7 +389,7 @@ inline void Non_local_operator<double>::apply(int chunk__,
             acc::sync_stream(omp_get_thread_num());
 
             linalg<GPU>::gemm(0, 0, 2 * num_gkvec_loc, n__, nbeta, &linalg_const<double>::one(),
-                              reinterpret_cast<double*>(beta_gk.template at<GPU>()), 2 * num_gkvec_loc, work_.at<GPU>(), nbeta,
+                              reinterpret_cast<double*>(beta_gk.template at(memory_t::device)), 2 * num_gkvec_loc, work_.at(memory_t::device), nbeta,
                               &linalg_const<double>::one(),
                               reinterpret_cast<double*>(op_phi__.pw_coeffs(jspn).prime().at<GPU>(0, idx0__)),
                               2 * num_gkvec_loc);

--- a/src/Hamiltonian/non_local_operator.hpp
+++ b/src/Hamiltonian/non_local_operator.hpp
@@ -286,7 +286,7 @@ inline void Non_local_operator<double_complex>::apply_one_atom(int chunk__,
                           num_gkvec_loc,
                           n__, nbf,
                           linalg_const<double_complex>::one(),
-                          beta_gk.template at(memory_t::host, 0, offs),
+                          beta_gk.at(memory_t::host, 0, offs),
                           num_gkvec_loc,
                           work_.at(memory_t::host), nbf,
                           linalg_const<double_complex>::one(),
@@ -299,9 +299,9 @@ inline void Non_local_operator<double_complex>::apply_one_atom(int chunk__,
         #ifdef __GPU
         linalg<GPU>::gemm(0, 0, nbf,
                           n__, nbf,
-                          op_.at<GPU>(packed_mtrx_offset_(ia), ispn_block__),
+                          op_.at(memory_t::device, packed_mtrx_offset_(ia), ispn_block__),
                           nbf,
-                          beta_phi__.at<GPU>(offs, 0),
+                          beta_phi__.at(memory_t::device, offs, 0),
                           nbeta,
                           work_.at(memory_t::device),
                           nbf, -1);
@@ -309,10 +309,10 @@ inline void Non_local_operator<double_complex>::apply_one_atom(int chunk__,
                           num_gkvec_loc,
                           n__, nbf,
                           &linalg_const<double_complex>::one(),
-                          beta_gk.template at<GPU>(0, offs),
+                          beta_gk.at(memory_t::device, 0, offs),
                           beta_gk.ld(), work_.at(memory_t::device), nbf,
                           &linalg_const<double_complex>::one(),
-                          op_phi__.pw_coeffs(jspn).prime().at<GPU>(0, idx0__),
+                          op_phi__.pw_coeffs(jspn).prime().at(memory_t::device, 0, idx0__),
                           op_phi__.pw_coeffs(jspn).prime().ld());
         acc::sync_stream(-1);
         #endif
@@ -365,8 +365,8 @@ inline void Non_local_operator<double>::apply(int chunk__,
             }
             case GPU: {
                 #ifdef __GPU
-                linalg<GPU>::gemm(0, 0, nbf, n__, nbf, op_.at<GPU>(packed_mtrx_offset_(ia), ispn_block__), nbf,
-                                  beta_phi__.at<GPU>(offs, 0), nbeta, work_.at<GPU>(offs), nbeta, omp_get_thread_num());
+                linalg<GPU>::gemm(0, 0, nbf, n__, nbf, op_.at(memory_t::device, packed_mtrx_offset_(ia), ispn_block__), nbf,
+                                  beta_phi__.at(memory_t::device, offs, 0), nbeta, work_.at(memory_t::device, offs), nbeta, omp_get_thread_num());
                 break;
                 #endif
             }
@@ -376,7 +376,7 @@ inline void Non_local_operator<double>::apply(int chunk__,
     /* compute <G+k|beta> * O * <beta|phi> and add to op_phi */
     switch (pu_) {
         case CPU: {
-            linalg<CPU>::gemm(0, 0, 2 * num_gkvec_loc, n__, nbeta, 1.0, reinterpret_cast<double*>(beta_gk.template at(memory_t::host)),
+            linalg<CPU>::gemm(0, 0, 2 * num_gkvec_loc, n__, nbeta, 1.0, reinterpret_cast<double*>(beta_gk.at(memory_t::host)),
                               2 * num_gkvec_loc, work_.at(memory_t::host), nbeta, 1.0,
                               reinterpret_cast<double*>(op_phi__.pw_coeffs(jspn).prime().at(memory_t::host, 0, idx0__)),
                               2 * op_phi__.pw_coeffs(jspn).prime().ld());
@@ -391,7 +391,7 @@ inline void Non_local_operator<double>::apply(int chunk__,
             linalg<GPU>::gemm(0, 0, 2 * num_gkvec_loc, n__, nbeta, &linalg_const<double>::one(),
                               reinterpret_cast<double*>(beta_gk.template at(memory_t::device)), 2 * num_gkvec_loc, work_.at(memory_t::device), nbeta,
                               &linalg_const<double>::one(),
-                              reinterpret_cast<double*>(op_phi__.pw_coeffs(jspn).prime().at<GPU>(0, idx0__)),
+                              reinterpret_cast<double*>(op_phi__.pw_coeffs(jspn).prime().at(memory_t::device, 0, idx0__)),
                               2 * num_gkvec_loc);
             acc::sync_stream(-1);
             #endif

--- a/src/Hamiltonian/set_lapw_h_o.hpp
+++ b/src/Hamiltonian/set_lapw_h_o.hpp
@@ -45,7 +45,7 @@ inline void Hamiltonian::set_fv_h_o<CPU, electronic_structure_method_t::full_pot
     if (ctx_.valence_relativity() == relativity_t::iora) {
         oalm_col = mdarray<double_complex, 2>(kp__->num_gkvec_col(), max_mt_aw);
     } else {
-        oalm_col = mdarray<double_complex, 2>(alm_col.at<CPU>(), kp__->num_gkvec_col(), max_mt_aw);
+        oalm_col = mdarray<double_complex, 2>(alm_col.at(memory_t::host), kp__->num_gkvec_col(), max_mt_aw);
     }
 
     utils::timer t1("sirius::Hamiltonian::set_fv_h_o|zgemm");
@@ -76,14 +76,14 @@ inline void Hamiltonian::set_fv_h_o<CPU, electronic_structure_method_t::full_pot
                     auto& type = atom.type();
                     int naw = type.mt_aw_basis_size();
 
-                    mdarray<double_complex, 2> alm_row_tmp(alm_row.at<CPU>(0, offsets[ialoc]), kp__->num_gkvec_row(), naw);
-                    mdarray<double_complex, 2> alm_col_tmp(alm_col.at<CPU>(0, offsets[ialoc]), kp__->num_gkvec_col(), naw);
-                    mdarray<double_complex, 2> halm_col_tmp(halm_col.at<CPU>(0, offsets[ialoc]), kp__->num_gkvec_col(), naw);
+                    mdarray<double_complex, 2> alm_row_tmp(alm_row.at(memory_t::host, 0, offsets[ialoc]), kp__->num_gkvec_row(), naw);
+                    mdarray<double_complex, 2> alm_col_tmp(alm_col.at(memory_t::host, 0, offsets[ialoc]), kp__->num_gkvec_col(), naw);
+                    mdarray<double_complex, 2> halm_col_tmp(halm_col.at(memory_t::host, 0, offsets[ialoc]), kp__->num_gkvec_col(), naw);
                     mdarray<double_complex, 2> oalm_col_tmp;
                     if (ctx_.valence_relativity() == relativity_t::iora) {
-                        oalm_col_tmp = mdarray<double_complex, 2>(oalm_col.at<CPU>(0, offsets[ialoc]), kp__->num_gkvec_col(), naw);
+                        oalm_col_tmp = mdarray<double_complex, 2>(oalm_col.at(memory_t::host, 0, offsets[ialoc]), kp__->num_gkvec_col(), naw);
                     } else {
-                        oalm_col_tmp = mdarray<double_complex, 2>(alm_col.at<CPU>(0, offsets[ialoc]), kp__->num_gkvec_col(), naw);
+                        oalm_col_tmp = mdarray<double_complex, 2>(alm_col.at(memory_t::host, 0, offsets[ialoc]), kp__->num_gkvec_col(), naw);
                     }
 
                     kp__->alm_coeffs_row().generate(ia, alm_row_tmp);
@@ -115,17 +115,17 @@ inline void Hamiltonian::set_fv_h_o<CPU, electronic_structure_method_t::full_pot
         }
         linalg<CPU>::gemm(0, 1, kp__->num_gkvec_row(), kp__->num_gkvec_col(), num_mt_aw,
                           linalg_const<double_complex>::one(),
-                          alm_row.at<CPU>(), alm_row.ld(),
-                          oalm_col.at<CPU>(), oalm_col.ld(),
+                          alm_row.at(memory_t::host), alm_row.ld(),
+                          oalm_col.at(memory_t::host), oalm_col.ld(),
                           linalg_const<double_complex>::one(),
-                          o__.at<CPU>(), o__.ld());
+                          o__.at(memory_t::host), o__.ld());
 
         linalg<CPU>::gemm(0, 1, kp__->num_gkvec_row(), kp__->num_gkvec_col(), num_mt_aw,
                           linalg_const<double_complex>::one(),
-                          alm_row.at<CPU>(), alm_row.ld(),
-                          halm_col.at<CPU>(), halm_col.ld(),
+                          alm_row.at(memory_t::host), alm_row.ld(),
+                          halm_col.at(memory_t::host), halm_col.ld(),
                           linalg_const<double_complex>::one(),
-                          h__.at<CPU>(), h__.ld());
+                          h__.at(memory_t::host), h__.ld());
     }
     double tval = t1.stop();
     if (kp__->comm().rank() == 0 && ctx_.control().print_performance_) {
@@ -200,16 +200,16 @@ inline void Hamiltonian::set_fv_h_o<GPU, electronic_structure_method_t::full_pot
                     auto& atom = unit_cell_.atom(ia);
                     auto& type = atom.type();
 
-                    mdarray<double_complex, 2> alm_row_tmp(alm_row.at<CPU>(0, offsets[ialoc], s),
-                                                           alm_row.at<GPU>(0, offsets[ialoc], s),
+                    mdarray<double_complex, 2> alm_row_tmp(alm_row.at(memory_t::host, 0, offsets[ialoc], s),
+                                                           alm_row.at(memory_t::device, 0, offsets[ialoc], s),
                                                            kp__->num_gkvec_row(), type.mt_aw_basis_size());
 
-                    mdarray<double_complex, 2> alm_col_tmp(alm_col.at<CPU>(0, offsets[ialoc], s),
-                                                           alm_col.at<GPU>(0, offsets[ialoc], s),
+                    mdarray<double_complex, 2> alm_col_tmp(alm_col.at(memory_t::host, 0, offsets[ialoc], s),
+                                                           alm_col.at(memory_t::device, 0, offsets[ialoc], s),
                                                            kp__->num_gkvec_col(), type.mt_aw_basis_size());
 
-                    mdarray<double_complex, 2> halm_col_tmp(halm_col.at<CPU>(0, offsets[ialoc], s),
-                                                            halm_col.at<GPU>(0, offsets[ialoc], s),
+                    mdarray<double_complex, 2> halm_col_tmp(halm_col.at(memory_t::host, 0, offsets[ialoc], s),
+                                                            halm_col.at(memory_t::device, 0, offsets[ialoc], s),
                                                             kp__->num_gkvec_col(), type.mt_aw_basis_size());
 
                     kp__->alm_coeffs_row().generate(ia, alm_row_tmp);
@@ -234,16 +234,16 @@ inline void Hamiltonian::set_fv_h_o<GPU, electronic_structure_method_t::full_pot
         }
         acc::sync_stream(omp_get_max_threads());
         linalg<GPU>::gemm(0, 1, kp__->num_gkvec_row(), kp__->num_gkvec_col(), num_mt_aw, &linalg_const<double_complex>::one(),
-                          alm_row.at<GPU>(0, 0, s), alm_row.ld(), alm_col.at<GPU>(0, 0, s), alm_col.ld(), &linalg_const<double_complex>::one(),
-                          o__.at<GPU>(), o__.ld(), omp_get_max_threads());
+                          alm_row.at(memory_t::device, 0, 0, s), alm_row.ld(), alm_col.at(memory_t::device, 0, 0, s), alm_col.ld(), &linalg_const<double_complex>::one(),
+                          o__.at(memory_t::device), o__.ld(), omp_get_max_threads());
 
         linalg<GPU>::gemm(0, 1, kp__->num_gkvec_row(), kp__->num_gkvec_col(), num_mt_aw, &linalg_const<double_complex>::one(),
-                          alm_row.at<GPU>(0, 0, s), alm_row.ld(), halm_col.at<GPU>(0, 0, s), halm_col.ld(), &linalg_const<double_complex>::one(),
-                          h__.at<GPU>(), h__.ld(), omp_get_max_threads());
+                          alm_row.at(memory_t::device, 0, 0, s), alm_row.ld(), halm_col.at(memory_t::device, 0, 0, s), halm_col.ld(), &linalg_const<double_complex>::one(),
+                          h__.at(memory_t::device), h__.ld(), omp_get_max_threads());
     }
 
-    acc::copyout(h__.at<CPU>(), h__.ld(), h__.at<GPU>(), h__.ld(), kp__->num_gkvec_row(), kp__->num_gkvec_col());
-    acc::copyout(o__.at<CPU>(), o__.ld(), o__.at<GPU>(), o__.ld(), kp__->num_gkvec_row(), kp__->num_gkvec_col());
+    acc::copyout(h__.at(memory_t::host), h__.ld(), h__.at(memory_t::device), h__.ld(), kp__->num_gkvec_row(), kp__->num_gkvec_col());
+    acc::copyout(o__.at(memory_t::host), o__.ld(), o__.at(memory_t::device), o__.ld(), kp__->num_gkvec_row(), kp__->num_gkvec_col());
 
     double tval = t1.stop();
     //if (kp__->comm().rank() == 0 && ctx_.control().print_performance_) {

--- a/src/Hamiltonian/set_lapw_h_o.hpp
+++ b/src/Hamiltonian/set_lapw_h_o.hpp
@@ -230,9 +230,9 @@ inline void Hamiltonian::set_fv_h_o<GPU, electronic_structure_method_t::full_pot
                     set_fv_h_o_apw_lo(kp__, type, atom, ia, alm_row_tmp, alm_col_tmp, h__, o__);
                 }
             }
-            acc::sync_stream(tid);
+            acc::sync_stream(stream_id(tid));
         }
-        acc::sync_stream(omp_get_max_threads());
+        acc::sync_stream(stream_id(omp_get_max_threads()));
         linalg<GPU>::gemm(0, 1, kp__->num_gkvec_row(), kp__->num_gkvec_col(), num_mt_aw, &linalg_const<double_complex>::one(),
                           alm_row.at(memory_t::device, 0, 0, s), alm_row.ld(), alm_col.at(memory_t::device, 0, 0, s), alm_col.ld(), &linalg_const<double_complex>::one(),
                           o__.at(memory_t::device), o__.ld(), omp_get_max_threads());

--- a/src/Hubbard/hubbard_generate_atomic_orbitals.hpp
+++ b/src/Hubbard/hubbard_generate_atomic_orbitals.hpp
@@ -154,11 +154,9 @@ void Hubbard::orthogonalize_atomic_orbitals(K_point& kp, Wave_functions& sphi)
             // }
         }
 
-        #ifdef __GPU
-        if (ctx_.processing_unit()) {
-            S.copy<memory_t::device, memory_t::host>();
+        if (ctx_.processing_unit() == device_t::GPU) {
+            S.copy_to(memory_t::host);
         }
-        #endif
 
         // diagonalize the all stuff
 
@@ -197,11 +195,9 @@ void Hubbard::orthogonalize_atomic_orbitals(K_point& kp, Wave_functions& sphi)
             }
         }
 
-        #ifdef __GPU
-        if (ctx_.processing_unit()) {
-            S.copy<memory_t::host, memory_t::device>();
+        if (ctx_.processing_unit() == device_t::GPU) {
+            S.copy_to(memory_t::device);
         }
-        #endif
 
         // only need to do that when in the ultra soft case
         if (augment) {

--- a/src/Hubbard/hubbard_occupancies_derivatives.hpp
+++ b/src/Hubbard/hubbard_occupancies_derivatives.hpp
@@ -194,10 +194,9 @@ void Hubbard::compute_occupancies_derivatives(K_point&                    kp,
                                 dir);
         } // direction x, y, z
 
-        // use a memcpy here
-        memcpy(dn__.template at<CPU>(0, 0, 0, 0, 0, atom_id),
-               dn_tmp.template at<CPU>(),
-               sizeof(double_complex) * dn_tmp.size());
+        /* use a memcpy here */
+        std::memcpy(dn__.at(memory_t::host, 0, 0, 0, 0, 0, atom_id), dn_tmp.at(memory_t::host),
+                    sizeof(double_complex) * dn_tmp.size());
     } // atom_id
 
     #if defined(__GPU)

--- a/src/Hubbard/hubbard_occupancies_derivatives.hpp
+++ b/src/Hubbard/hubbard_occupancies_derivatives.hpp
@@ -480,12 +480,11 @@ void Hubbard::compute_occupancies(K_point&                    kp,
               0, this->number_of_hubbard_orbitals(), dphi_s_psi, 0, ispn * this->number_of_hubbard_orbitals());
     }
 
-    #if defined(__GPU)
-    if (ctx_.processing_unit() == GPU) {
-        dphi_s_psi.copy<memory_t::device, memory_t::host>();
-        phi_s_psi.copy<memory_t::device, memory_t::host>();
+    if (ctx_.processing_unit() == device_t::GPU) {
+        dphi_s_psi.copy_to(memory_t::host);
+        phi_s_psi.copy_to(memory_t::host);
     }
-    #endif
+
     /* include the occupancy directly in dphi_s_psi */
 
     for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
@@ -495,11 +494,9 @@ void Hubbard::compute_occupancies(K_point&                    kp,
             }
         }
     }
-    #if defined(__GPU)
-    if (ctx_.processing_unit() == GPU) {
-        dphi_s_psi.copy<memory_t::host, memory_t::device>();
+    if (ctx_.processing_unit() == device_t::GPU) {
+        dphi_s_psi.copy_to(memory_t::device);
     }
-    #endif
 
     dm.zero(memory_t::host);
     dm.zero(memory_t::device);
@@ -552,7 +549,7 @@ void Hubbard::compute_occupancies(K_point&                    kp,
                               &linalg_const<double_complex>::one(),
                               dm);
 
-            dm.copy<memory_t::device, memory_t::host>();
+            dm.copy_to(memory_t::host);
 #endif
             break;
         }

--- a/src/Hubbard/hubbard_occupancy.hpp
+++ b/src/Hubbard/hubbard_occupancy.hpp
@@ -124,7 +124,7 @@ void Hubbard::hubbard_compute_occupation_numbers(K_point_set& kset_)
                 kp->hubbard_wave_functions().pw_coeffs(ispn).deallocate_on_device();
             }
 
-            dm.copy<memory_t::device, memory_t::host>();
+            dm.copy_to(memory_t::host);
         }
         #endif
 

--- a/src/K_point/generate_spinor_wave_functions.hpp
+++ b/src/K_point/generate_spinor_wave_functions.hpp
@@ -41,11 +41,9 @@ inline void K_point::generate_spinor_wave_functions()
         if (ctx_.processing_unit() == device_t::GPU) {
             fv_states().allocate_on_device(0);
             fv_states().copy_to_device(0, 0, nfv);
-            sv_eigen_vectors_[0].allocate(memory_t::device);
-            sv_eigen_vectors_[0].copy<memory_t::host, memory_t::device>();
+            sv_eigen_vectors_[0].allocate(memory_t::device).copy_to(memory_t::device);
             if (ctx_.num_mag_dims() == 1) {
-                sv_eigen_vectors_[1].allocate(memory_t::device);
-                sv_eigen_vectors_[1].copy<memory_t::host, memory_t::device>();
+                sv_eigen_vectors_[1].allocate(memory_t::device).copy_to(memory_t::device);
             }
             if (is_device_memory(ctx_.preferred_memory_t())) {
                 for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {

--- a/src/K_point/k_point.hpp
+++ b/src/K_point/k_point.hpp
@@ -1267,7 +1267,7 @@ inline void K_point::get_fv_eigen_vectors(mdarray<double_complex, 2>& fv_evec)
     //        fv_evec(j, i) = fv_eigen_vectors_(jloc, iloc);
     //    }
     //}
-    //comm_.allreduce(fv_evec.at<CPU>(), (int)fv_evec.size());
+    //comm_.allreduce(fv_evec.at(memory_t::host), (int)fv_evec.size());
 }
 
 inline void K_point::get_sv_eigen_vectors(mdarray<double_complex, 2>& sv_evec)
@@ -1300,7 +1300,7 @@ inline void K_point::get_sv_eigen_vectors(mdarray<double_complex, 2>& sv_evec)
         }
     }
 
-    comm_.allreduce(sv_evec.at<CPU>(), (int)sv_evec.size());
+    comm_.allreduce(sv_evec.at(memory_t::host), (int)sv_evec.size());
 }
 
 #include "initialize.hpp"

--- a/src/K_point/k_point_set.hpp
+++ b/src/K_point/k_point_set.hpp
@@ -416,7 +416,7 @@ inline void K_point_set::sync_band_energies()
             }
         }
     }
-    comm().allgather(band_energies.at<CPU>(),
+    comm().allgather(band_energies.at(memory_t::host),
                      ctx_.num_bands() * ctx_.num_spin_dims() * spl_num_kpoints_.global_offset(),
                      ctx_.num_bands() * ctx_.num_spin_dims() * spl_num_kpoints_.local_size());
 

--- a/src/Kernels/generate_dm_pw.cu
+++ b/src/Kernels/generate_dm_pw.cu
@@ -88,6 +88,6 @@ extern "C" void generate_dm_pw_gpu(int num_atoms__,
                   &beta,
                   dm_pw__, nbf__ * (nbf__ + 1) / 2,
                   stream_id__);
-   acc::sync_stream(stream_id__);
+   acc::sync_stream(stream_id(stream_id__));
 }
 

--- a/src/Potential/generate_d_operator_matrix.hpp
+++ b/src/Potential/generate_d_operator_matrix.hpp
@@ -143,7 +143,7 @@ inline void Potential::generate_D_operator_matrix()
                 }
             }
 
-            comm_.allreduce(d_tmp.at<CPU>(), static_cast<int>(d_tmp.size()));
+            comm_.allreduce(d_tmp.at(memory_t::host), static_cast<int>(d_tmp.size()));
 
             if (ctx_.control().print_checksum_ && ctx_.comm().rank() == 0) {
                 for (int i = 0; i < atom_type.num_atoms(); i++) {

--- a/src/Potential/generate_d_operator_matrix.hpp
+++ b/src/Potential/generate_d_operator_matrix.hpp
@@ -52,7 +52,7 @@ inline void Potential::generate_D_operator_matrix()
 #ifdef __GPU
         /* start copy of Q(G) for the next atom type */
         if (ctx_.processing_unit() == GPU) {
-            acc::sync_stream(0);
+            acc::sync_stream(stream_id(0));
             if (iat + 1 != unit_cell_.num_atom_types() && ctx_.unit_cell().atom_type(iat + 1).augment() &&
                 ctx_.unit_cell().atom_type(iat + 1).num_atoms() > 0) {
                 ctx_.augmentation_op(iat + 1).prepare(stream_id(0));

--- a/src/Potential/generate_pw_coefs.hpp
+++ b/src/Potential/generate_pw_coefs.hpp
@@ -39,8 +39,8 @@ inline void Potential::generate_pw_coefs()
                 double M = 1 - sq_alpha_half * effective_potential().f_rg(ir);
                 ctx_.fft().buffer(ir) = ctx_.theta(ir) / std::pow(M, 2);
             }
-            if (ctx_.fft().pu() == GPU) {
-                ctx_.fft().buffer().copy<memory_t::host, memory_t::device>();
+            if (ctx_.fft().pu() == device_t::GPU) {
+                ctx_.fft().buffer().copy_to(memory_t::device);
             }
             ctx_.fft().transform<-1>(&fpw_fft[0]);
             ctx_.gvec_partition().gather_pw_global(&fpw_fft[0], &rm2_inv_pw_[0]);
@@ -50,8 +50,8 @@ inline void Potential::generate_pw_coefs()
                 double M = 1 - sq_alpha_half * effective_potential().f_rg(ir);
                 ctx_.fft().buffer(ir) = ctx_.theta(ir) / M;
             }
-            if (ctx_.fft().pu() == GPU) {
-                ctx_.fft().buffer().copy<memory_t::host, memory_t::device>();
+            if (ctx_.fft().pu() == device_t::GPU) {
+                ctx_.fft().buffer().copy_to(memory_t::device);
             }
             ctx_.fft().transform<-1>(&fpw_fft[0]);
             ctx_.gvec_partition().gather_pw_global(&fpw_fft[0], &rm_inv_pw_[0]);
@@ -60,8 +60,8 @@ inline void Potential::generate_pw_coefs()
             for (int ir = 0; ir < ctx_.fft().local_size(); ir++) {
                 ctx_.fft().buffer(ir) = effective_potential().f_rg(ir) * ctx_.theta(ir);
             }
-            if (ctx_.fft().pu() == GPU) {
-                ctx_.fft().buffer().copy<memory_t::host, memory_t::device>();
+            if (ctx_.fft().pu() == device_t::GPU) {
+                ctx_.fft().buffer().copy_to(memory_t::device);
             }
             ctx_.fft().transform<-1>(&fpw_fft[0]);
             ctx_.gvec_partition().gather_pw_global(&fpw_fft[0], &veff_pw_[0]);

--- a/src/Potential/poisson.hpp
+++ b/src/Potential/poisson.hpp
@@ -87,12 +87,12 @@ inline void Potential::poisson_add_pseudo_pw(mdarray<double_complex, 2>& qmt__,
             }
             case GPU: {
 #if defined(__GPU)
-                qa.copy<memory_t::host, memory_t::device>();
+                qa.copy_to(memory_t::device);
                 linalg<GPU>::gemm(0, 2, ctx_.lmmax_rho(), ctx_.gvec().count(), unit_cell_.atom_type(iat).num_atoms(),
-                                  qa.at<GPU>(), qa.ld(),
-                                  pf.at<GPU>(), pf.ld(),
-                                  qapf.at<GPU>(), qapf.ld());
-                qapf.copy<memory_t::device, memory_t::host>();
+                                  qa.at(memory_t::device), qa.ld(),
+                                  pf.at(memory_t::device), pf.ld(),
+                                  qapf.at(memory_t::device), qapf.ld());
+                qapf.copy_to(memory_t::host);
 #endif
                 break;
             }

--- a/src/Potential/poisson.hpp
+++ b/src/Potential/poisson.hpp
@@ -259,7 +259,7 @@ inline void Potential::poisson(Periodic_function<double> const& rho)
             vh_el_(ia) = y00 * hartree_potential_->f_mt<index_domain_t::local>(0, 0, ialoc);
 #endif
         }
-        ctx_.comm().allgather(vh_el_.at<CPU>(), unit_cell_.spl_num_atoms().global_offset(),
+        ctx_.comm().allgather(vh_el_.at(memory_t::host), unit_cell_.spl_num_atoms().global_offset(),
                               unit_cell_.spl_num_atoms().local_size());
     }
 

--- a/src/Potential/potential.hpp
+++ b/src/Potential/potential.hpp
@@ -1096,7 +1096,7 @@ class Potential : public Field4D
 
     inline void set_veff_pw(double_complex const* veff_pw__)
     {
-        std::copy(veff_pw__, veff_pw__ + ctx_.gvec().num_gvec(), veff_pw_.at<CPU>());
+        std::copy(veff_pw__, veff_pw__ + ctx_.gvec().num_gvec(), veff_pw_.at(memory_t::host));
     }
 
     double_complex const& rm_inv_pw(int ig__) const
@@ -1106,7 +1106,7 @@ class Potential : public Field4D
 
     inline void set_rm_inv_pw(double_complex const* rm_inv_pw__)
     {
-        std::copy(rm_inv_pw__, rm_inv_pw__ + ctx_.gvec().num_gvec(), rm_inv_pw_.at<CPU>());
+        std::copy(rm_inv_pw__, rm_inv_pw__ + ctx_.gvec().num_gvec(), rm_inv_pw_.at(memory_t::host));
     }
 
     double_complex const& rm2_inv_pw(int ig__) const
@@ -1116,7 +1116,7 @@ class Potential : public Field4D
 
     inline void set_rm2_inv_pw(double_complex const* rm2_inv_pw__)
     {
-        std::copy(rm2_inv_pw__, rm2_inv_pw__ + ctx_.gvec().num_gvec(), rm2_inv_pw_.at<CPU>());
+        std::copy(rm2_inv_pw__, rm2_inv_pw__ + ctx_.gvec().num_gvec(), rm2_inv_pw_.at(memory_t::host));
     }
 
     /// Integral of \f$ \rho({\bf r}) V^{XC}({\bf r}) \f$.

--- a/src/SDDK/GPU/cuda.hpp
+++ b/src/SDDK/GPU/cuda.hpp
@@ -205,9 +205,9 @@ inline void destroy_streams()
 }
 
 /// Synchronize a single stream.
-inline void sync_stream(int stream_id__)
+inline void sync_stream(stream_id sid__)
 {
-    CALL_CUDA(cudaStreamSynchronize, (stream(stream_id(stream_id__))));
+    CALL_CUDA(cudaStreamSynchronize, (stream(sid__)));
 }
 
 /// Copy memory inside a device.
@@ -228,9 +228,9 @@ inline void copyin(T* target__, T const* source__, size_t n__)
 
 /// Asynchronous copy from host to device.
 template <typename T>
-inline void copyin(T* target__, T const* source__, size_t n__, int stream_id__)
+inline void copyin(T* target__, T const* source__, size_t n__, stream_id sid__)
 {
-    CALL_CUDA(cudaMemcpyAsync, (target__, source__, n__ * sizeof(T), cudaMemcpyHostToDevice, stream(stream_id(stream_id__))));
+    CALL_CUDA(cudaMemcpyAsync, (target__, source__, n__ * sizeof(T), cudaMemcpyHostToDevice, stream(sid__)));
 }
 
 /// 2D copy to the device.
@@ -242,10 +242,10 @@ inline void copyin(T* target__, int ld1__, T const* source__, int ld2__, int nro
 
 /// Asynchronous 2D copy to the device.
 template <typename T>
-inline void copyin(T* target__, int ld1__, T const* source__, int ld2__, int nrow__, int ncol__, int stream_id__)
+inline void copyin(T* target__, int ld1__, T const* source__, int ld2__, int nrow__, int ncol__, stream_id sid__)
 {
     CALL_CUDA(cudaMemcpy2DAsync, (target__, ld1__ * sizeof(T), source__, ld2__ * sizeof(T), nrow__ * sizeof(T), ncol__,
-                                  cudaMemcpyHostToDevice, stream(stream_id(stream_id__))));
+                                  cudaMemcpyHostToDevice, stream(sid__)));
 }
 
 /// Copy memory from device to host.
@@ -257,9 +257,9 @@ inline void copyout(T* target__, T const* source__, size_t n__)
 
 /// Asynchronous copy from device to host.
 template <typename T>
-inline void copyout(T* target__, T const* source__, size_t n__, int stream_id__)
+inline void copyout(T* target__, T const* source__, size_t n__, stream_id sid__)
 {
-    CALL_CUDA(cudaMemcpyAsync, (target__, source__, n__ * sizeof(T), cudaMemcpyDeviceToHost, stream(stream_id(stream_id__))));
+    CALL_CUDA(cudaMemcpyAsync, (target__, source__, n__ * sizeof(T), cudaMemcpyDeviceToHost, stream(sid__)));
 }
 
 /// 2D copy from device to host.
@@ -271,10 +271,10 @@ inline void copyout(T* target__, int ld1__, T const* source__, int ld2__, int nr
 
 /// Asynchronous 2D copy from device to host.
 template <typename T>
-inline void copyout(T* target__, int ld1__, T const* source__, int ld2__, int nrow__, int ncol__, int stream_id__)
+inline void copyout(T* target__, int ld1__, T const* source__, int ld2__, int nrow__, int ncol__, stream_id sid__)
 {
     CALL_CUDA(cudaMemcpy2D, (target__, ld1__ * sizeof(T), source__, ld2__ * sizeof(T), nrow__ * sizeof(T), ncol__,
-                             cudaMemcpyDeviceToHost, stream(stream_id(stream_id__))));
+                             cudaMemcpyDeviceToHost, stream(sid__)));
 }
 
 /// Zero the device memory.

--- a/src/SDDK/dmatrix.hpp
+++ b/src/SDDK/dmatrix.hpp
@@ -314,7 +314,7 @@ class dmatrix : public matrix<T>
                 }
             }
         }
-        blacs_grid_->comm().allreduce(d.template at<CPU>(), n__);
+        blacs_grid_->comm().allreduce(d.template at(memory_t::host), n__);
         return std::move(d);
     }
 
@@ -376,7 +376,7 @@ class dmatrix : public matrix<T>
                 }
             }
         }
-        this->comm().allreduce(full_mtrx.template at<CPU>(), static_cast<int>(full_mtrx.size()));
+        this->comm().allreduce(full_mtrx.template at(memory_t::host), static_cast<int>(full_mtrx.size()));
 
         if (this->blacs_grid().comm().rank() == 0) {
             HDF5_tree h5(name__, hdf5_access_t::truncate);
@@ -408,7 +408,7 @@ inline void dmatrix<double_complex>::serialize(std::string name__, int n__) cons
             full_mtrx(irow(i), icol(j)) = (*this)(i, j);
         }
     }
-    blacs_grid_->comm().allreduce(full_mtrx.at<CPU>(), static_cast<int>(full_mtrx.size()));
+    blacs_grid_->comm().allreduce(full_mtrx.at(memory_t::host), static_cast<int>(full_mtrx.size()));
 
     //json dict;
     //dict["mtrx_re"] = json::array();
@@ -457,7 +457,7 @@ inline void dmatrix<double>::serialize(std::string name__, int n__) const
             full_mtrx(irow(i), icol(j)) = (*this)(i, j);
         }
     }
-    blacs_grid_->comm().allreduce(full_mtrx.at<CPU>(), static_cast<int>(full_mtrx.size()));
+    blacs_grid_->comm().allreduce(full_mtrx.at(memory_t::host), static_cast<int>(full_mtrx.size()));
 
     //json dict;
     //dict["mtrx"] = json::array();

--- a/src/SDDK/fft3d.hpp
+++ b/src/SDDK/fft3d.hpp
@@ -306,7 +306,7 @@ class FFT3D : public FFT3D_grid
                     TERMINATE("wrong direction");
                 }
             }
-            acc::sync_stream(cufft_stream_id);
+            acc::sync_stream(stream_id(cufft_stream_id));
 #endif
         }
 
@@ -528,7 +528,7 @@ class FFT3D : public FFT3D_grid
                         break;
                     }
                 }
-                acc::sync_stream(cufft_stream_id);
+                acc::sync_stream(stream_id(cufft_stream_id));
 #endif
                 break;
             }
@@ -621,7 +621,7 @@ class FFT3D : public FFT3D_grid
                     break;
                 }
             }
-            acc::sync_stream(cufft_stream_id);
+            acc::sync_stream(stream_id(cufft_stream_id));
         }
 #endif
 

--- a/src/SDDK/fft3d.hpp
+++ b/src/SDDK/fft3d.hpp
@@ -839,12 +839,12 @@ class FFT3D : public FFT3D_grid
     {
         switch (pu_) {
             case CPU: {
-                std::memcpy(data__, fft_buffer_.at<CPU>(), local_size() * sizeof(double_complex));
+                std::memcpy(data__, fft_buffer_.at(memory_t::host), local_size() * sizeof(double_complex));
                 break;
             }
             case GPU: {
 #ifdef __GPU
-                acc::copyout(data__, fft_buffer_.at<GPU>(), local_size());
+                acc::copyout(data__, fft_buffer_.at(memory_t::device), local_size());
 #endif
                 break;
             }

--- a/src/SDDK/fft3d.hpp
+++ b/src/SDDK/fft3d.hpp
@@ -816,8 +816,8 @@ class FFT3D : public FFT3D_grid
         for (int i = 0; i < local_size(); i++) {
             fft_buffer_[i] = data__[i];
         }
-        if (pu_ == GPU) {
-            fft_buffer_.copy<memory_t::host, memory_t::device>();
+        if (pu_ == device_t::GPU) {
+            fft_buffer_.copy_to(memory_t::device);
         }
     }
 
@@ -825,8 +825,8 @@ class FFT3D : public FFT3D_grid
     /** \param [out] data CPU pointer to the real-space data. */
     inline void output(double* data__)
     {
-        if (pu_ == GPU) {
-            fft_buffer_.copy<memory_t::device, memory_t::host>();
+        if (pu_ == device_t::GPU) {
+            fft_buffer_.copy_to(memory_t::host);
         }
         for (int i = 0; i < local_size(); i++) {
             data__[i] = fft_buffer_[i].real();

--- a/src/SDDK/gvec.hpp
+++ b/src/SDDK/gvec.hpp
@@ -376,7 +376,7 @@ class Gvec
             gvec_shell_(tmp[ig].second) = num_gvec_shells_ - 1;
         }
         gvec_shell_len_ = mdarray<double, 1>(num_gvec_shells_);
-        std::copy(tmp_len.begin(), tmp_len.end(), gvec_shell_len_.at<CPU>());
+        std::copy(tmp_len.begin(), tmp_len.end(), gvec_shell_len_.at(memory_t::host));
     }
 
     /// Compute the Cartesian coordinates.
@@ -409,7 +409,7 @@ class Gvec
         distribute_z_columns();
 
         gvec_index_by_xy_ = mdarray<int, 3>(2, fft_grid.limits(0), fft_grid.limits(1), memory_t::host, "Gvec.gvec_index_by_xy_");
-        std::fill(gvec_index_by_xy_.at<CPU>(), gvec_index_by_xy_.at<CPU>() + gvec_index_by_xy_.size(), -1);
+        std::fill(gvec_index_by_xy_.at(memory_t::host), gvec_index_by_xy_.at(memory_t::host) + gvec_index_by_xy_.size(), -1);
 
         /* build the full G-vector index and reverse mapping */
         gvec_full_index_ = mdarray<uint32_t, 1>(num_gvec_);

--- a/src/SDDK/hdf5_tree.hpp
+++ b/src/SDDK/hdf5_tree.hpp
@@ -334,27 +334,18 @@ class HDF5_tree
         for (int i = 0; i < N; i++) {
             dims[i + 1] = (int)data.size(i);
         }
-        write(name, (T*)data.template at(memory_t::host), dims);
+        write(name, (T*)data.at(memory_t::host), dims);
     }
 
     /// Write a multidimensional array by name.
     template <typename T, int N>
     void write(std::string const& name__, mdarray<T, N> const& data__)
     {
-        //if (typeid(T) == typeid(std::complex<double>)) {
-        //    std::vector<int> dims(N + 1);
-        //    dims[0] = 2;
-        //    for (int i = 0; i < N; i++) {
-        //        dims[i + 1] = (int)data.size(i);
-        //    }
-        //    write(name, (double*)data.template at(memory_t::host), dims);
-        //} else {
         std::vector<int> dims(N);
         for (int i = 0; i < N; i++) {
             dims[i] = static_cast<int>(data__.size(i));
         }
-        write(name__, data__.template at(memory_t::host), dims);
-        //}
+        write(name__, data__.at(memory_t::host), dims);
     }
 
     /// Write a multidimensional array by integer index.
@@ -406,7 +397,7 @@ class HDF5_tree
         for (int i = 0; i < N; i++) {
             dims[i + 1] = (int)data.size(i);
         }
-        read(name, (double*)data.template at(memory_t::host), dims);
+        read(name, (double*)data.at(memory_t::host), dims);
     }
 
     template <typename T, int N>
@@ -416,7 +407,7 @@ class HDF5_tree
         for (int i = 0; i < N; i++) {
             dims[i] = (int)data.size(i);
         }
-        read(name, data.template at(memory_t::host), dims);
+        read(name, data.at(memory_t::host), dims);
     }
 
     template <typename T, int N>

--- a/src/SDDK/hdf5_tree.hpp
+++ b/src/SDDK/hdf5_tree.hpp
@@ -334,7 +334,7 @@ class HDF5_tree
         for (int i = 0; i < N; i++) {
             dims[i + 1] = (int)data.size(i);
         }
-        write(name, (T*)data.template at<CPU>(), dims);
+        write(name, (T*)data.template at(memory_t::host), dims);
     }
 
     /// Write a multidimensional array by name.
@@ -347,13 +347,13 @@ class HDF5_tree
         //    for (int i = 0; i < N; i++) {
         //        dims[i + 1] = (int)data.size(i);
         //    }
-        //    write(name, (double*)data.template at<CPU>(), dims);
+        //    write(name, (double*)data.template at(memory_t::host), dims);
         //} else {
         std::vector<int> dims(N);
         for (int i = 0; i < N; i++) {
             dims[i] = static_cast<int>(data__.size(i));
         }
-        write(name__, data__.template at<CPU>(), dims);
+        write(name__, data__.template at(memory_t::host), dims);
         //}
     }
 
@@ -406,7 +406,7 @@ class HDF5_tree
         for (int i = 0; i < N; i++) {
             dims[i + 1] = (int)data.size(i);
         }
-        read(name, (double*)data.template at<CPU>(), dims);
+        read(name, (double*)data.template at(memory_t::host), dims);
     }
 
     template <typename T, int N>
@@ -416,7 +416,7 @@ class HDF5_tree
         for (int i = 0; i < N; i++) {
             dims[i] = (int)data.size(i);
         }
-        read(name, data.template at<CPU>(), dims);
+        read(name, data.template at(memory_t::host), dims);
     }
 
     template <typename T, int N>

--- a/src/SDDK/linalg.hpp
+++ b/src/SDDK/linalg.hpp
@@ -235,14 +235,14 @@ class linalg<GPU>: public linalg_base
         static void gemm(int transa, int transb, ftn_int m, ftn_int n, ftn_int k, matrix<T> const& A, matrix<T> const& B,
                          matrix<T>& C, int stream_id = -1)
         {
-            gemm(transa, transb, m, n, k, A.template at<GPU>(), A.ld(), B.template at<GPU>(), B.ld(), C.template at<GPU>(), C.ld(), stream_id);
+            gemm(transa, transb, m, n, k, A.at(memory_t::device), A.ld(), B.at(memory_t::device), B.ld(), C.at(memory_t::device), C.ld(), stream_id);
         }
 
         template <typename T>
         static void gemm(int transa, int transb, ftn_int m, ftn_int n, ftn_int k, const T *alpha, matrix<T> const& A, matrix<T> const& B, const T *beta,
                          matrix<T>& C, int stream_id = -1)
         {
-            gemm(transa, transb, m, n, k, alpha, A.template at<GPU>(), A.ld(), B.template at<GPU>(), B.ld(), beta, C.template at<GPU>(), C.ld(), stream_id);
+            gemm(transa, transb, m, n, k, alpha, A.at(memory_t::device), A.ld(), B.at(memory_t::device), B.ld(), beta, C.at(memory_t::device), C.ld(), stream_id);
         }
 
         /// Cholesky factorization
@@ -873,11 +873,11 @@ inline void linalg<CPU>::geqrf<ftn_double_complex>(ftn_int m, ftn_int n, dmatrix
     ftn_double_complex z;
     ftn_int info;
     ftn_int lda = A.ld();
-    FORTRAN(zgeqrf)(&m, &n, A.at<CPU>(ia, ja), &lda, &z, &z, &lwork, &info);
+    FORTRAN(zgeqrf)(&m, &n, A.at(memory_t::host, ia, ja), &lda, &z, &z, &lwork, &info);
     lwork = static_cast<int>(z.real() + 1);
     std::vector<ftn_double_complex> work(lwork);
     std::vector<ftn_double_complex> tau(std::max(m, n));
-    FORTRAN(zgeqrf)(&m, &n, A.at<CPU>(ia, ja), &lda, tau.data(), work.data(), &lwork, &info);
+    FORTRAN(zgeqrf)(&m, &n, A.at(memory_t::host, ia, ja), &lda, tau.data(), work.data(), &lwork, &info);
 }
 
 template <>
@@ -887,11 +887,11 @@ inline void linalg<CPU>::geqrf<ftn_double>(ftn_int m, ftn_int n, dmatrix<ftn_dou
     ftn_double z;
     ftn_int info;
     ftn_int lda = A.ld();
-    FORTRAN(dgeqrf)(&m, &n, A.at<CPU>(ia, ja), &lda, &z, &z, &lwork, &info);
+    FORTRAN(dgeqrf)(&m, &n, A.at(memory_t::host, ia, ja), &lda, &z, &z, &lwork, &info);
     lwork = static_cast<int>(z + 1);
     std::vector<ftn_double> work(lwork);
     std::vector<ftn_double> tau(std::max(m, n));
-    FORTRAN(dgeqrf)(&m, &n, A.at<CPU>(ia, ja), &lda, tau.data(), work.data(), &lwork, &info);
+    FORTRAN(dgeqrf)(&m, &n, A.at(memory_t::host, ia, ja), &lda, tau.data(), work.data(), &lwork, &info);
 }
 
 template<>
@@ -902,7 +902,8 @@ inline void linalg<CPU>::gemm<ftn_double_complex>(int transa, int transb, ftn_in
                                                   ftn_double_complex beta,
                                                   dmatrix<ftn_double_complex>& C, ftn_int ic, ftn_int jc)
 {
-    gemm(transa, transb, m, n, k, alpha, A.at<CPU>(ia, ja), A.ld(), B.at<CPU>(ib, jb), B.ld(), beta, C.at<CPU>(ic, jc), C.ld());
+    gemm(transa, transb, m, n, k, alpha, A.at(memory_t::host, ia, ja), A.ld(), B.at(memory_t::host, ib, jb), B.ld(),
+         beta, C.at(memory_t::host, ic, jc), C.ld());
 }
 
 template<>
@@ -922,7 +923,8 @@ inline void linalg<CPU>::gemm<ftn_double>(int transa, int transb, ftn_int m, ftn
                                           ftn_double beta,
                                           dmatrix<ftn_double>& C, ftn_int ic, ftn_int jc)
 {
-    gemm(transa, transb, m, n, k, alpha, A.at<CPU>(ia, ja), A.ld(), B.at<CPU>(ib, jb), B.ld(), beta, C.at<CPU>(ic, jc), C.ld());
+    gemm(transa, transb, m, n, k, alpha, A.at(memory_t::host, ia, ja), A.ld(), B.at(memory_t::host, ib, jb), B.ld(),
+         beta, C.at(memory_t::host, ic, jc), C.ld());
 }
 
 template<>

--- a/src/SDDK/linalg.hpp
+++ b/src/SDDK/linalg.hpp
@@ -75,7 +75,7 @@ class linalg<CPU>: public linalg_base
         static void hemm(int side, int uplo, ftn_int m, ftn_int n, T alpha, matrix<T>& A,
                          matrix<T>& B, T beta, matrix<T>& C)
         {
-            hemm(side, uplo, m, n, alpha, A.template at<CPU>(), A.ld(), B.template at<CPU>(), B.ld(), beta, C.template at<CPU>(), C.ld());
+            hemm(side, uplo, m, n, alpha, A.at(memory_t::host), A.ld(), B.at(memory_t::host), B.ld(), beta, C.at(memory_t::host), C.ld());
         }
 
         /// General matrix-matrix multiplication.
@@ -99,7 +99,7 @@ class linalg<CPU>: public linalg_base
         static void gemm(int transa, int transb, ftn_int m, ftn_int n, ftn_int k, T alpha, matrix<T> const& A, matrix<T> const& B,
                          T beta, matrix<T>& C)
         {
-            gemm(transa, transb, m, n, k, alpha, A.template at<CPU>(), A.ld(), B.template at<CPU>(), B.ld(), beta, C.template at<CPU>(), C.ld());
+            gemm(transa, transb, m, n, k, alpha, A.at(memory_t::host), A.ld(), B.at(memory_t::host), B.ld(), beta, C.at(memory_t::host), C.ld());
         }
 
         /// Compute C = op(A) * op(B) operation with matrix objects.
@@ -107,7 +107,7 @@ class linalg<CPU>: public linalg_base
         static void gemm(int transa, int transb, ftn_int m, ftn_int n, ftn_int k, matrix<T> const& A, matrix<T> const& B,
                          matrix<T>& C)
         {
-            gemm(transa, transb, m, n, k, A.template at<CPU>(), A.ld(), B.template at<CPU>(), B.ld(), C.template at<CPU>(), C.ld());
+            gemm(transa, transb, m, n, k, A.at(memory_t::host), A.ld(), B.at(memory_t::host), B.ld(), C.at(memory_t::host), C.ld());
         }
 
         /// Compute C = alpha * op(A) * op(B) + beta * op(C), generic interface
@@ -433,14 +433,14 @@ template <>
 inline void linalg<CPU>::geinv<ftn_double>(ftn_int n, matrix<ftn_double>& A)
 {
     std::vector<int> ipiv(n);
-    int info = getrf(n, n, A.at<CPU>(), A.ld(), &ipiv[0]);
+    int info = getrf(n, n, A.at(memory_t::host), A.ld(), &ipiv[0]);
     if (info)
     {
         printf("getrf returned %i\n", info);
         exit(-1);
     }
 
-    info = getri(n, A.at<CPU>(), A.ld(), &ipiv[0]);
+    info = getri(n, A.at(memory_t::host), A.ld(), &ipiv[0]);
     if (info)
     {
         printf("getri returned %i\n", info);
@@ -453,14 +453,14 @@ template <>
 inline void linalg<CPU>::geinv<ftn_double_complex>(ftn_int n, matrix<ftn_double_complex>& A)
 {
     std::vector<int> ipiv(n);
-    int info = getrf(n, n, A.at<CPU>(), A.ld(), &ipiv[0]);
+    int info = getrf(n, n, A.at(memory_t::host), A.ld(), &ipiv[0]);
     if (info)
     {
         printf("getrf returned %i\n", info);
         exit(-1);
     }
 
-    info = getri(n, A.at<CPU>(), A.ld(), &ipiv[0]);
+    info = getri(n, A.at(memory_t::host), A.ld(), &ipiv[0]);
     if (info)
     {
         printf("getri returned %i\n", info);
@@ -494,13 +494,13 @@ template <>
 inline void linalg<CPU>::heinv<ftn_double_complex>(ftn_int n, matrix<ftn_double_complex>& A)
 {
     std::vector<int> ipiv(n);
-    int info = hetrf(n, A.at<CPU>(), A.ld(), &ipiv[0]);
+    int info = hetrf(n, A.at(memory_t::host), A.ld(), &ipiv[0]);
     if (info) {
         printf("hetrf returned %i\n", info);
         exit(-1);
     }
 
-    info = hetri(n, A.at<CPU>(), A.ld(), &ipiv[0]);
+    info = hetri(n, A.at(memory_t::host), A.ld(), &ipiv[0]);
     if (info) {
         printf("hetri returned %i\n", info);
         exit(-1);
@@ -532,14 +532,14 @@ template <>
 inline void linalg<CPU>::syinv<ftn_double>(ftn_int n, matrix<ftn_double>& A)
 {
     std::vector<int> ipiv(n);
-    int info = sytrf(n, A.at<CPU>(), A.ld(), &ipiv[0]);
+    int info = sytrf(n, A.at(memory_t::host), A.ld(), &ipiv[0]);
     if (info)
     {
         printf("sytrf returned %i\n", info);
         exit(-1);
     }
 
-    info = sytri(n, A.at<CPU>(), A.ld(), &ipiv[0]);
+    info = sytri(n, A.at(memory_t::host), A.ld(), &ipiv[0]);
     if (info)
     {
         printf("sytri returned %i\n", info);
@@ -638,7 +638,7 @@ inline ftn_int linalg<CPU>::getrf<ftn_double_complex>(ftn_int m, ftn_int n, dmat
     ftn_int info;
     ia++;
     ja++;
-    FORTRAN(pzgetrf)(&m, &n, A.at<CPU>(), &ia, &ja, const_cast<int*>(A.descriptor()), ipiv, &info);
+    FORTRAN(pzgetrf)(&m, &n, A.at(memory_t::host), &ia, &ja, const_cast<int*>(A.descriptor()), ipiv, &info);
     return info;
 }
 
@@ -655,13 +655,13 @@ inline ftn_int linalg<CPU>::getri<ftn_double_complex>(ftn_int n, dmatrix<ftn_dou
     ftn_double_complex z;
     i = -1;
     /* query work sizes */
-    FORTRAN(pzgetri)(&n, A.at<CPU>(), &ia, &ja, const_cast<int*>(A.descriptor()), &ipiv[0], &z, &i, &liwork, &i, &info);
+    FORTRAN(pzgetri)(&n, A.at(memory_t::host), &ia, &ja, const_cast<int*>(A.descriptor()), &ipiv[0], &z, &i, &liwork, &i, &info);
 
     lwork = (int)real(z) + 1;
     std::vector<ftn_double_complex> work(lwork);
     std::vector<ftn_int> iwork(liwork);
 
-    FORTRAN(pzgetri)(&n, A.at<CPU>(), &ia, &ja, const_cast<int*>(A.descriptor()), &ipiv[0], &work[0], &lwork, &iwork[0], &liwork, &info);
+    FORTRAN(pzgetri)(&n, A.at(memory_t::host), &ia, &ja, const_cast<int*>(A.descriptor()), &ipiv[0], &work[0], &lwork, &iwork[0], &liwork, &info);
 
     return info;
 }
@@ -671,15 +671,13 @@ inline void linalg<CPU>::geinv<ftn_double_complex>(ftn_int n, dmatrix<ftn_double
 {
     std::vector<ftn_int> ipiv(A.num_rows_local() + A.bs_row());
     ftn_int info = getrf(n, n, A, 0, 0, &ipiv[0]);
-    if (info)
-    {
+    if (info) {
         printf("getrf returned %i\n", info);
         exit(-1);
     }
 
     info = getri(n, A, 0, 0, &ipiv[0]);
-    if (info)
-    {
+    if (info) {
         printf("getri returned %i\n", info);
         exit(-1);
     }
@@ -695,7 +693,7 @@ inline void linalg<CPU>::tranc<ftn_double_complex>(ftn_int m, ftn_int n, dmatrix
     ftn_double_complex one = 1;
     ftn_double_complex zero = 0;
 
-    pztranc(m, n, one, A.at<CPU>(), ia, ja, A.descriptor(), zero, C.at<CPU>(), ic, jc, C.descriptor());
+    pztranc(m, n, one, A.at(memory_t::host), ia, ja, A.descriptor(), zero, C.at(memory_t::host), ic, jc, C.descriptor());
 }
 
 template <>
@@ -708,7 +706,7 @@ inline void linalg<CPU>::tranu<ftn_double_complex>(ftn_int m, ftn_int n, dmatrix
     ftn_double_complex one = 1;
     ftn_double_complex zero = 0;
 
-    pztranu(m, n, one, A.at<CPU>(), ia, ja, A.descriptor(), zero, C.at<CPU>(), ic, jc, C.descriptor());
+    pztranu(m, n, one, A.at(memory_t::host), ia, ja, A.descriptor(), zero, C.at(memory_t::host), ic, jc, C.descriptor());
 }
 
 template <>
@@ -721,7 +719,7 @@ inline void linalg<CPU>::tranc<ftn_double>(ftn_int m, ftn_int n, dmatrix<ftn_dou
     ftn_double one = 1;
     ftn_double zero = 0;
 
-    pdtran(m, n, one, A.at<CPU>(), ia, ja, A.descriptor(), zero, C.at<CPU>(), ic, jc, C.descriptor());
+    pdtran(m, n, one, A.at(memory_t::host), ia, ja, A.descriptor(), zero, C.at(memory_t::host), ic, jc, C.descriptor());
 }
 
 template <>
@@ -730,7 +728,7 @@ inline void linalg<CPU>::gemr2d(ftn_int m, ftn_int n, dmatrix<ftn_double_complex
 {
     ia++; ja++;
     ib++; jb++;
-    FORTRAN(pzgemr2d)(&m, &n, A.at<CPU>(), &ia, &ja, A.descriptor(), B.at<CPU>(), &ib, &jb, B.descriptor(), &gcontext);
+    FORTRAN(pzgemr2d)(&m, &n, A.at(memory_t::host), &ia, &ja, A.descriptor(), B.at(memory_t::host), &ib, &jb, B.descriptor(), &gcontext);
 }
 
 template<>
@@ -748,8 +746,8 @@ inline void linalg<CPU>::gemm<ftn_double>(int transa, int transb, ftn_int m, ftn
     ia++; ja++;
     ib++; jb++;
     ic++; jc++;
-    FORTRAN(pdgemm)(trans[transa], trans[transb], &m, &n, &k, &alpha, A.at<CPU>(), &ia, &ja, A.descriptor(),
-                    B.at<CPU>(), &ib, &jb, B.descriptor(), &beta, C.at<CPU>(), &ic, &jc, C.descriptor(),
+    FORTRAN(pdgemm)(trans[transa], trans[transb], &m, &n, &k, &alpha, A.at(memory_t::host), &ia, &ja, A.descriptor(),
+                    B.at(memory_t::host), &ib, &jb, B.descriptor(), &beta, C.at(memory_t::host), &ic, &jc, C.descriptor(),
                     (ftn_len)1, (ftn_len)1);
 }
 
@@ -770,8 +768,8 @@ inline void linalg<CPU>::gemm<ftn_double_complex>(int transa, int transb, ftn_in
     ia++; ja++;
     ib++; jb++;
     ic++; jc++;
-    FORTRAN(pzgemm)(trans[transa], trans[transb], &m, &n, &k, &alpha, A.at<CPU>(), &ia, &ja, A.descriptor(),
-                    B.at<CPU>(), &ib, &jb, B.descriptor(), &beta, C.at<CPU>(), &ic, &jc, C.descriptor(),
+    FORTRAN(pzgemm)(trans[transa], trans[transb], &m, &n, &k, &alpha, A.at(memory_t::host), &ia, &ja, A.descriptor(),
+                    B.at(memory_t::host), &ib, &jb, B.descriptor(), &beta, C.at(memory_t::host), &ic, &jc, C.descriptor(),
                     (ftn_len)1, (ftn_len)1);
 }
 
@@ -781,7 +779,7 @@ inline ftn_int linalg<CPU>::potrf<ftn_double>(ftn_int n, dmatrix<ftn_double>& A)
     ftn_int ia{1};
     ftn_int ja{1};
     ftn_int info;
-    FORTRAN(pdpotrf)("U", &n, A.at<CPU>(), &ia, &ja, const_cast<int*>(A.descriptor()), &info, (ftn_len)1);
+    FORTRAN(pdpotrf)("U", &n, A.at(memory_t::host), &ia, &ja, const_cast<int*>(A.descriptor()), &info, (ftn_len)1);
     return info;
 }
 
@@ -791,7 +789,7 @@ inline ftn_int linalg<CPU>::potrf<ftn_double_complex>(ftn_int n, dmatrix<ftn_dou
     ftn_int ia{1};
     ftn_int ja{1};
     ftn_int info;
-    FORTRAN(pzpotrf)("U", &n, A.at<CPU>(), &ia, &ja, const_cast<int*>(A.descriptor()), &info, (ftn_len)1);
+    FORTRAN(pzpotrf)("U", &n, A.at(memory_t::host), &ia, &ja, const_cast<int*>(A.descriptor()), &info, (ftn_len)1);
     return info;
 }
 
@@ -801,7 +799,7 @@ inline ftn_int linalg<CPU>::trtri<ftn_double>(ftn_int n, dmatrix<ftn_double>& A)
     ftn_int ia{1};
     ftn_int ja{1};
     ftn_int info;
-    FORTRAN(pdtrtri)("U", "N", &n, A.at<CPU>(), &ia, &ja, const_cast<int*>(A.descriptor()), &info, (ftn_len)1, (ftn_len)1);
+    FORTRAN(pdtrtri)("U", "N", &n, A.at(memory_t::host), &ia, &ja, const_cast<int*>(A.descriptor()), &info, (ftn_len)1, (ftn_len)1);
     return info;
 }
 
@@ -811,7 +809,7 @@ inline ftn_int linalg<CPU>::trtri<ftn_double_complex>(ftn_int n, dmatrix<ftn_dou
     ftn_int ia{1};
     ftn_int ja{1};
     ftn_int info;
-    FORTRAN(pztrtri)("U", "N", &n, A.at<CPU>(), &ia, &ja, const_cast<int*>(A.descriptor()), &info, (ftn_len)1, (ftn_len)1);
+    FORTRAN(pztrtri)("U", "N", &n, A.at(memory_t::host), &ia, &ja, const_cast<int*>(A.descriptor()), &info, (ftn_len)1, (ftn_len)1);
     return info;
 }
 
@@ -822,11 +820,11 @@ inline void linalg<CPU>::geqrf<ftn_double_complex>(ftn_int m, ftn_int n, dmatrix
     ftn_int lwork = -1;
     ftn_double_complex z;
     ftn_int info;
-    FORTRAN(pzgeqrf)(&m, &n, A.at<CPU>(), &ia, &ja, const_cast<int*>(A.descriptor()), &z, &z, &lwork, &info);
+    FORTRAN(pzgeqrf)(&m, &n, A.at(memory_t::host), &ia, &ja, const_cast<int*>(A.descriptor()), &z, &z, &lwork, &info);
     lwork = static_cast<int>(z.real() + 1);
     std::vector<ftn_double_complex> work(lwork);
     std::vector<ftn_double_complex> tau(std::max(m, n));
-    FORTRAN(pzgeqrf)(&m, &n, A.at<CPU>(), &ia, &ja, const_cast<int*>(A.descriptor()), tau.data(), work.data(), &lwork, &info);
+    FORTRAN(pzgeqrf)(&m, &n, A.at(memory_t::host), &ia, &ja, const_cast<int*>(A.descriptor()), tau.data(), work.data(), &lwork, &info);
 }
 
 template <>
@@ -836,36 +834,36 @@ inline void linalg<CPU>::geqrf<ftn_double>(ftn_int m, ftn_int n, dmatrix<ftn_dou
     ftn_int lwork = -1;
     ftn_double z;
     ftn_int info;
-    FORTRAN(pdgeqrf)(&m, &n, A.at<CPU>(), &ia, &ja, const_cast<int*>(A.descriptor()), &z, &z, &lwork, &info);
+    FORTRAN(pdgeqrf)(&m, &n, A.at(memory_t::host), &ia, &ja, const_cast<int*>(A.descriptor()), &z, &z, &lwork, &info);
     lwork = static_cast<int>(z + 1);
     std::vector<ftn_double> work(lwork);
     std::vector<ftn_double> tau(std::max(m, n));
-    FORTRAN(pdgeqrf)(&m, &n, A.at<CPU>(), &ia, &ja, const_cast<int*>(A.descriptor()), tau.data(), work.data(), &lwork, &info);
+    FORTRAN(pdgeqrf)(&m, &n, A.at(memory_t::host), &ia, &ja, const_cast<int*>(A.descriptor()), tau.data(), work.data(), &lwork, &info);
 }
 
 #else
 template<>
 inline ftn_int linalg<CPU>::potrf<ftn_double>(ftn_int n, dmatrix<ftn_double>& A)
 {
-    return linalg<CPU>::potrf<ftn_double>(n, A.at<CPU>(), A.ld());
+    return linalg<CPU>::potrf<ftn_double>(n, A.at(memory_t::host), A.ld());
 }
 
 template<>
 inline ftn_int linalg<CPU>::potrf<ftn_double_complex>(ftn_int n, dmatrix<ftn_double_complex>& A)
 {
-    return linalg<CPU>::potrf<ftn_double_complex>(n, A.at<CPU>(), A.ld());
+    return linalg<CPU>::potrf<ftn_double_complex>(n, A.at(memory_t::host), A.ld());
 }
 
 template<>
 inline ftn_int linalg<CPU>::trtri<ftn_double>(ftn_int n, dmatrix<ftn_double>& A)
 {
-    return linalg<CPU>::trtri<ftn_double>(n, A.at<CPU>(), A.ld());
+    return linalg<CPU>::trtri<ftn_double>(n, A.at(memory_t::host), A.ld());
 }
 
 template<>
 inline ftn_int linalg<CPU>::trtri<ftn_double_complex>(ftn_int n, dmatrix<ftn_double_complex>& A)
 {
-    return linalg<CPU>::trtri<ftn_double_complex>(n, A.at<CPU>(), A.ld());
+    return linalg<CPU>::trtri<ftn_double_complex>(n, A.at(memory_t::host), A.ld());
 }
 
 template <>
@@ -913,7 +911,7 @@ inline void linalg<CPU>::gemm<ftn_double_complex>(int transa, int transb, ftn_in
                                                   dmatrix<ftn_double_complex>& A, dmatrix<ftn_double_complex>& B,
                                                   ftn_double_complex beta, dmatrix<ftn_double_complex>& C)
 {
-    gemm(transa, transb, m, n, k, alpha, A.at<CPU>(), A.ld(), B.at<CPU>(), B.ld(), beta, C.at<CPU>(), C.ld());
+    gemm(transa, transb, m, n, k, alpha, A.at(memory_t::host), A.ld(), B.at(memory_t::host), B.ld(), beta, C.at(memory_t::host), C.ld());
 }
 
 template<>
@@ -933,7 +931,7 @@ inline void linalg<CPU>::gemm<ftn_double>(int transa, int transb, ftn_int m, ftn
                                           dmatrix<ftn_double>& A, dmatrix<ftn_double>& B,
                                           ftn_double beta, dmatrix<ftn_double>& C)
 {
-    gemm(transa, transb, m, n, k, alpha, A.at<CPU>(), A.ld(), B.at<CPU>(), B.ld(), beta, C.at<CPU>(), C.ld());
+    gemm(transa, transb, m, n, k, alpha, A.at(memory_t::host), A.ld(), B.at(memory_t::host), B.ld(), beta, C.at(memory_t::host), C.ld());
 }
 #endif
 

--- a/src/SDDK/matrix_storage.hpp
+++ b/src/SDDK/matrix_storage.hpp
@@ -440,7 +440,7 @@ class matrix_storage<T, matrix_storage_t::slab>
             }
             case memory_t::device: {
 #ifdef __GPU
-                scale_matrix_elements_gpu(reinterpret_cast<cuDoubleComplex*>(prime().template at<GPU>(0, i0__)),
+                scale_matrix_elements_gpu(reinterpret_cast<cuDoubleComplex*>(prime().at(memory_t::device, 0, i0__)),
                                           prime().ld(), num_rows_loc(), n__, beta__);
 #endif
                 break;
@@ -471,7 +471,7 @@ class matrix_storage<T, matrix_storage_t::slab>
     void copy_to_device(int i0__, int n__)
     {
         if (num_rows_loc()) {
-            acc::copyin(prime_.template at<GPU>(0, i0__), prime_.template at<CPU>(0, i0__), n__ * num_rows_loc());
+            acc::copyin(prime_.at(memory_t::device, 0, i0__), prime_.at(memory_t::host, 0, i0__), n__ * num_rows_loc());
         }
     }
 
@@ -479,7 +479,7 @@ class matrix_storage<T, matrix_storage_t::slab>
     void copy_to_host(int i0__, int n__)
     {
         if (num_rows_loc()) {
-            acc::copyout(prime_.template at<CPU>(0, i0__), prime_.template at<GPU>(0, i0__), n__ * num_rows_loc());
+            acc::copyout(prime_.at(memory_t::host, 0, i0__), prime_.at(memory_t::device, 0, i0__), n__ * num_rows_loc());
         }
     }
 #endif
@@ -505,7 +505,7 @@ class matrix_storage<T, matrix_storage_t::slab>
                 cs1.zero(memory_t::device);
 #ifdef __GPU
                 add_checksum_gpu(prime().at(memory_t::device, 0, i0__), num_rows_loc(), n__, cs1.at(memory_t::device));
-                cs1.copy<memory_t::device, memory_t::host>();
+                cs1.copy_to(memory_t::host);
                 cs = cs1.checksum();
 #endif
                 break;

--- a/src/SDDK/memory.hpp
+++ b/src/SDDK/memory.hpp
@@ -1380,7 +1380,7 @@ class mdarray
                 acc::copyin(&raw_ptr_device_[idx0__], &raw_ptr_[idx0__], n__);
             } else {
                 /* asynchronous (non-blocking) copy */
-                acc::copyin(&raw_ptr_device_[idx0__], &raw_ptr_[idx0__], n__, sid.id());
+                acc::copyin(&raw_ptr_device_[idx0__], &raw_ptr_[idx0__], n__, sid);
             }
         }
         /* copy back from device to host */
@@ -1390,7 +1390,7 @@ class mdarray
                 acc::copyout(&raw_ptr_[idx0__], &raw_ptr_device_[idx0__], n__);
             } else {
                 /* asynchronous (non-blocking) copy */
-                acc::copyout(&raw_ptr_[idx0__], &raw_ptr_device_[idx0__], n__, sid.id());
+                acc::copyout(&raw_ptr_[idx0__], &raw_ptr_device_[idx0__], n__, sid);
             }
         }
 #endif

--- a/src/SDDK/memory.hpp
+++ b/src/SDDK/memory.hpp
@@ -790,35 +790,6 @@ class mdarray
         return const_cast<T*>(static_cast<mdarray<T, N> const&>(*this).at_idx(mem__, idx__));
     }
 
-    /// TODO: remove in future
-    template <device_t pu>
-    inline T const* at_idx(index_type const idx__) const
-    {
-        switch (pu) {
-            case CPU: {
-                mdarray_assert(raw_ptr_ != nullptr);
-                return &raw_ptr_[idx__];
-            }
-            case GPU: {
-#ifdef __GPU
-                mdarray_assert(raw_ptr_device_ != nullptr);
-                return &raw_ptr_device_[idx__];
-#else
-                printf("error at line %i of file %s: not compiled with GPU support\n", __LINE__, __FILE__);
-                exit(0);
-#endif
-            }
-        }
-        return nullptr;
-    }
-
-    /// TODO: remove in future
-    template <device_t pu>
-    inline T* at_idx(index_type const idx__)
-    {
-        return const_cast<T*>(static_cast<mdarray<T, N> const&>(*this).template at_idx<pu>(idx__));
-    }
-
     inline void call_constructor()
     {
         /* call constructor on non-trivial data */
@@ -1238,30 +1209,6 @@ class mdarray
         return const_cast<T&>(static_cast<mdarray<T, N> const&>(*this)[idx__]);
     }
 
-    template <device_t pu>
-    inline T* at() // TODO: remove this
-    {
-        return at_idx<pu>(0);
-    }
-
-    template <device_t pu>
-    inline T const* at() const // TODO: remove this
-    {
-        return at_idx<pu>(0);
-    }
-
-    template <device_t pu, typename... Args>
-    inline T* at(Args... args) // TODO: remove this
-    {
-        return at_idx<pu>(idx(args...));
-    }
-
-    template <device_t pu, typename... Args>
-    inline T const* at(Args... args) const // TODO: remove this
-    {
-        return at_idx<pu>(idx(args...));
-    }
-
     template <typename... Args>
     inline T const* at(memory_t mem__, Args... args) const
     {
@@ -1286,11 +1233,11 @@ class mdarray
         return const_cast<T*>(static_cast<mdarray<T, N> const&>(*this).at(mem__));
     }
 
-    template <device_t pu>
-    typename std::enable_if<pu == device_t::CPU, T*>::type data() // TODO: remove this?
-    {
-        return raw_ptr_;
-    }
+    //template <device_t pu>
+    //typename std::enable_if<pu == device_t::CPU, T*>::type data() // TODO: remove this?
+    //{
+    //    return raw_ptr_;
+    //}
 
     /// Return total size (number of elements) of the array.
     inline size_t size() const

--- a/src/SDDK/memory.hpp
+++ b/src/SDDK/memory.hpp
@@ -1145,11 +1145,11 @@ class mdarray
     }
 
     /// Allocate memory for array.
-    inline void allocate(memory_t memory__)
+    inline mdarray<T, N>& allocate(memory_t memory__)
     {
         /* do nothing for zero-sized array */
         if (!this->size()) {
-            return;
+            return *this;
         }
 
         /* host allocation */
@@ -1165,14 +1165,15 @@ class mdarray
             raw_ptr_device_    = unique_ptr_device_.get();
         }
 #endif
+        return *this;
     }
 
     /// Allocate memory from the pool.
-    inline void allocate(memory_pool& mp__)
+    inline mdarray<T, N>& allocate(memory_pool& mp__)
     {
         /* do nothing for zero-sized array */
         if (!this->size()) {
-            return;
+            return *this;
         }
         /* host allocation */
         if (is_host_memory(mp__.memory_type())) {
@@ -1187,6 +1188,7 @@ class mdarray
             raw_ptr_device_    = unique_ptr_device_.get();
         }
 #endif
+        return *this;
     }
 
     /// Deallocate host or device memory.
@@ -1390,45 +1392,6 @@ class mdarray
             }
         }
         std::memcpy(dest__.raw_ptr_, raw_ptr_, size() * sizeof(T));
-    }
-
-    /// Copy n elements starting from idx0.
-    template <memory_t from__, memory_t to__>
-    inline void copy(size_t idx0__, size_t n__, int stream_id__ = -1) // TODO: remove this
-    {
-#ifdef __GPU
-        mdarray_assert(raw_ptr_ != nullptr);
-        mdarray_assert(raw_ptr_device_ != nullptr);
-        mdarray_assert(idx0__ + n__ <= size());
-
-        if (is_host_memory(from__) && is_device_memory(to__)) {
-            if (stream_id__ == -1) {
-                acc::copyin(&raw_ptr_device_[idx0__], &raw_ptr_[idx0__], n__);
-            } else {
-                acc::copyin(&raw_ptr_device_[idx0__], &raw_ptr_[idx0__], n__, stream_id__);
-            }
-        }
-
-        if (is_device_memory(from__) && is_host_memory(to__)) {
-            if (stream_id__ == -1) {
-                acc::copyout(&raw_ptr_[idx0__], &raw_ptr_device_[idx0__], n__);
-            } else {
-                acc::copyout(&raw_ptr_[idx0__], &raw_ptr_device_[idx0__], n__, stream_id__);
-            }
-        }
-#endif
-    }
-
-    template <memory_t from__, memory_t to__>
-    inline void async_copy(size_t n__, int stream_id__)
-    {
-        copy<from__, to__>(0, n__, stream_id__);
-    }
-
-    template <memory_t from__, memory_t to__>
-    inline void copy()
-    {
-        copy<from__, to__>(0, size());
     }
 
     /// Zero n elements starting from idx0.

--- a/src/SDDK/wave_functions.hpp
+++ b/src/SDDK/wave_functions.hpp
@@ -338,26 +338,27 @@ class Wave_functions
         switch (pu__) {
             case CPU: {
                 /* copy PW part */
-                std::copy(src__.pw_coeffs(ispn__).prime().at<CPU>(0, i0__),
-                          src__.pw_coeffs(ispn__).prime().at<CPU>(0, i0__) + ngv * n__,
-                          pw_coeffs(jspn__).prime().at<CPU>(0, j0__));
+                std::copy(src__.pw_coeffs(ispn__).prime().at(memory_t::host, 0, i0__),
+                          src__.pw_coeffs(ispn__).prime().at(memory_t::host, 0, i0__) + ngv * n__,
+                          pw_coeffs(jspn__).prime().at(memory_t::host, 0, j0__));
                 /* copy MT part */
                 if (has_mt()) {
-                    std::copy(src__.mt_coeffs(ispn__).prime().at<CPU>(0, i0__),
-                              src__.mt_coeffs(ispn__).prime().at<CPU>(0, i0__) + nmt * n__,
-                              mt_coeffs(jspn__).prime().at<CPU>(0, j0__));
+                    std::copy(src__.mt_coeffs(ispn__).prime().at(memory_t::host, 0, i0__),
+                              src__.mt_coeffs(ispn__).prime().at(memory_t::host, 0, i0__) + nmt * n__,
+                              mt_coeffs(jspn__).prime().at(memory_t::host, 0, j0__));
                 }
                 break;
             }
             case GPU: {
 #ifdef __GPU
                 /* copy PW part */
-                acc::copy(pw_coeffs(jspn__).prime().at<GPU>(0, j0__), src__.pw_coeffs(ispn__).prime().at<GPU>(0, i0__),
+                acc::copy(pw_coeffs(jspn__).prime().at(memory_t::device, 0, j0__),
+                          src__.pw_coeffs(ispn__).prime().at(memory_t::device, 0, i0__),
                           ngv * n__);
                 /* copy MT part */
                 if (has_mt()) {
-                    acc::copy(mt_coeffs(jspn__).prime().at<GPU>(0, j0__),
-                              src__.mt_coeffs(ispn__).prime().at<GPU>(0, i0__), nmt * n__);
+                    acc::copy(mt_coeffs(jspn__).prime().at(memory_t::device, 0, j0__),
+                              src__.mt_coeffs(ispn__).prime().at(memory_t::device, 0, i0__), nmt * n__);
                 }
 #endif
                 break;

--- a/src/SDDK/wave_functions.hpp
+++ b/src/SDDK/wave_functions.hpp
@@ -173,9 +173,9 @@ class Wave_functions
             }
         }
         if (pu__ == device_t::GPU) {
-            s.copy<memory_t::device, memory_t::host>();
+            s.copy_to(memory_t::host);
         }
-        comm_.allreduce(s.at<CPU>(), n__);
+        comm_.allreduce(s.at(memory_t::host), n__);
         return std::move(s);
     }
 

--- a/src/SDDK/wave_functions.hpp
+++ b/src/SDDK/wave_functions.hpp
@@ -161,11 +161,11 @@ class Wave_functions
                 }
                 case device_t::GPU: {
 #ifdef __GPU
-                    add_square_sum_gpu(pw_coeffs(is).prime().at<GPU>(), pw_coeffs(is).num_rows_loc(), n__,
-                                       gkvecp_.gvec().reduced(), comm_.rank(), s.at<GPU>());
+                    add_square_sum_gpu(pw_coeffs(is).prime().at(memory_t::device), pw_coeffs(is).num_rows_loc(), n__,
+                                       gkvecp_.gvec().reduced(), comm_.rank(), s.at(memory_t::device));
                     if (has_mt()) {
-                        add_square_sum_gpu(mt_coeffs(is).prime().at<GPU>(), mt_coeffs(is).num_rows_loc(), n__, 0,
-                                           comm_.rank(), s.at<GPU>());
+                        add_square_sum_gpu(mt_coeffs(is).prime().at(memory_t::device), mt_coeffs(is).num_rows_loc(), n__, 0,
+                                           comm_.rank(), s.at(memory_t::device));
                     }
 #endif
                     break;

--- a/src/SDDK/wf_inner.hpp
+++ b/src/SDDK/wf_inner.hpp
@@ -222,7 +222,7 @@ inline void inner(device_t        pu__,
         T* buf = (pu__ == CPU) ? tmp.template at<CPU>(0, 0) : tmp.template at<GPU>(0, 0);
         local_inner(i0__, m__, j0__, n__, buf, m__, -1);
         if (pu__ == GPU) {
-            tmp.template copy<memory_t::device, memory_t::host>();
+            tmp.copy_to(memory_t::host);
         }
         comm.allreduce(&tmp[0], static_cast<int>(tmp.size()));
         for (int j = 0; j < n__; j++) {

--- a/src/SDDK/wf_inner.hpp
+++ b/src/SDDK/wf_inner.hpp
@@ -111,15 +111,15 @@ inline void inner(device_t        pu__,
                     case CPU: {
                         linalg<CPU>::gemm(2, 0, m__, n__, bra__.pw_coeffs(s).num_rows_loc(),
                                           *reinterpret_cast<double_complex*>(&alpha),
-                                          bra__.pw_coeffs(s).prime().at<CPU>(0, i0__), bra__.pw_coeffs(s).prime().ld(),
-                                          ket__.pw_coeffs(s).prime().at<CPU>(0, j0__), ket__.pw_coeffs(s).prime().ld(),
+                                          bra__.pw_coeffs(s).prime().at(memory_t::host, 0, i0__), bra__.pw_coeffs(s).prime().ld(),
+                                          ket__.pw_coeffs(s).prime().at(memory_t::host, 0, j0__), ket__.pw_coeffs(s).prime().ld(),
                                           *reinterpret_cast<double_complex*>(&beta),
                                           reinterpret_cast<double_complex*>(buf__), ld__);
                         if (bra__.has_mt()) {
                             linalg<CPU>::gemm(2, 0, m__, n__, bra__.mt_coeffs(s).num_rows_loc(),
                                               *reinterpret_cast<double_complex*>(&alpha),
-                                              bra__.mt_coeffs(s).prime().at<CPU>(0, i0__), bra__.mt_coeffs(s).prime().ld(),
-                                              ket__.mt_coeffs(s).prime().at<CPU>(0, j0__), ket__.mt_coeffs(s).prime().ld(),
+                                              bra__.mt_coeffs(s).prime().at(memory_t::host, 0, i0__), bra__.mt_coeffs(s).prime().ld(),
+                                              ket__.mt_coeffs(s).prime().at(memory_t::host, 0, j0__), ket__.mt_coeffs(s).prime().ld(),
                                               linalg_const<double_complex>::one(),
                                               reinterpret_cast<double_complex*>(buf__), ld__);
                         }
@@ -129,16 +129,16 @@ inline void inner(device_t        pu__,
                         #ifdef __GPU
                         linalg<GPU>::gemm(2, 0, m__, n__, bra__.pw_coeffs(s).num_rows_loc(),
                                           reinterpret_cast<double_complex*>(&alpha),
-                                          bra__.pw_coeffs(s).prime().at<GPU>(0, i0__), bra__.pw_coeffs(s).prime().ld(),
-                                          ket__.pw_coeffs(s).prime().at<GPU>(0, j0__), ket__.pw_coeffs(s).prime().ld(),
+                                          bra__.pw_coeffs(s).prime().at(memory_t::device, 0, i0__), bra__.pw_coeffs(s).prime().ld(),
+                                          ket__.pw_coeffs(s).prime().at(memory_t::device, 0, j0__), ket__.pw_coeffs(s).prime().ld(),
                                           reinterpret_cast<double_complex*>(&beta),
                                           reinterpret_cast<double_complex*>(buf__), ld__,
                                           stream_id);
                         if (bra__.has_mt()) {
                             linalg<GPU>::gemm(2, 0, m__, n__, bra__.mt_coeffs(s).num_rows_loc(),
                                               reinterpret_cast<double_complex*>(&alpha),
-                                              bra__.mt_coeffs(s).prime().at<GPU>(0, i0__), bra__.mt_coeffs(s).prime().ld(),
-                                              ket__.mt_coeffs(s).prime().at<GPU>(0, j0__), ket__.mt_coeffs(s).prime().ld(),
+                                              bra__.mt_coeffs(s).prime().at(memory_t::device, 0, i0__), bra__.mt_coeffs(s).prime().ld(),
+                                              ket__.mt_coeffs(s).prime().at(memory_t::device, 0, j0__), ket__.mt_coeffs(s).prime().ld(),
                                               &linalg_const<double_complex>::one(),
                                               reinterpret_cast<double_complex*>(buf__), ld__,
                                               stream_id);
@@ -157,15 +157,15 @@ inline void inner(device_t        pu__,
                     case CPU: {
                         linalg<CPU>::gemm(2, 0, m__, n__, 2 * bra__.pw_coeffs(s).num_rows_loc(),
                                           *reinterpret_cast<double*>(&alpha),
-                                          reinterpret_cast<double*>(bra__.pw_coeffs(s).prime().at<CPU>(0, i0__)), 2 * bra__.pw_coeffs(s).prime().ld(),
-                                          reinterpret_cast<double*>(ket__.pw_coeffs(s).prime().at<CPU>(0, j0__)), 2 * ket__.pw_coeffs(s).prime().ld(),
+                                          reinterpret_cast<double*>(bra__.pw_coeffs(s).prime().at(memory_t::host, 0, i0__)), 2 * bra__.pw_coeffs(s).prime().ld(),
+                                          reinterpret_cast<double*>(ket__.pw_coeffs(s).prime().at(memory_t::host, 0, j0__)), 2 * ket__.pw_coeffs(s).prime().ld(),
                                           *reinterpret_cast<double*>(&beta),
                                           reinterpret_cast<double*>(buf__), ld__);
                         /* subtract one extra G=0 contribution */
                         if (comm.rank() == 0) {
                             linalg<CPU>::ger(m__, n__, -1.0,
-                                             reinterpret_cast<double*>(bra__.pw_coeffs(s).prime().at<CPU>(0, i0__)), 2 * bra__.pw_coeffs(s).prime().ld(),
-                                             reinterpret_cast<double*>(ket__.pw_coeffs(s).prime().at<CPU>(0, j0__)), 2 * ket__.pw_coeffs(s).prime().ld(),
+                                             reinterpret_cast<double*>(bra__.pw_coeffs(s).prime().at(memory_t::host, 0, i0__)), 2 * bra__.pw_coeffs(s).prime().ld(),
+                                             reinterpret_cast<double*>(ket__.pw_coeffs(s).prime().at(memory_t::host, 0, j0__)), 2 * ket__.pw_coeffs(s).prime().ld(),
                                              reinterpret_cast<double*>(buf__), ld__); 
 
                         }
@@ -175,16 +175,16 @@ inline void inner(device_t        pu__,
                         #ifdef __GPU
                         linalg<GPU>::gemm(2, 0, m__, n__, 2 * bra__.pw_coeffs(s).num_rows_loc(),
                                           reinterpret_cast<double*>(&alpha),
-                                          reinterpret_cast<double*>(bra__.pw_coeffs(s).prime().at<GPU>(0, i0__)), 2 * bra__.pw_coeffs(s).prime().ld(),
-                                          reinterpret_cast<double*>(ket__.pw_coeffs(s).prime().at<GPU>(0, j0__)), 2 * ket__.pw_coeffs(s).prime().ld(),
+                                          reinterpret_cast<double*>(bra__.pw_coeffs(s).prime().at(memory_t::device, 0, i0__)), 2 * bra__.pw_coeffs(s).prime().ld(),
+                                          reinterpret_cast<double*>(ket__.pw_coeffs(s).prime().at(memory_t::device, 0, j0__)), 2 * ket__.pw_coeffs(s).prime().ld(),
                                           reinterpret_cast<double*>(&beta),
                                           reinterpret_cast<double*>(buf__), ld__,
                                           stream_id);
                         /* subtract one extra G=0 contribution */
                         if (comm.rank() == 0) {
                             linalg<GPU>::ger(m__, n__, &linalg_const<double>::m_one(),
-                                             reinterpret_cast<double*>(bra__.pw_coeffs(s).prime().at<GPU>(0, i0__)), 2 * bra__.pw_coeffs(s).prime().ld(),
-                                             reinterpret_cast<double*>(ket__.pw_coeffs(s).prime().at<GPU>(0, j0__)), 2 * ket__.pw_coeffs(s).prime().ld(),
+                                             reinterpret_cast<double*>(bra__.pw_coeffs(s).prime().at(memory_t::device, 0, i0__)), 2 * bra__.pw_coeffs(s).prime().ld(),
+                                             reinterpret_cast<double*>(ket__.pw_coeffs(s).prime().at(memory_t::device, 0, j0__)), 2 * ket__.pw_coeffs(s).prime().ld(),
                                              reinterpret_cast<double*>(buf__), ld__,
                                              stream_id);
                         }
@@ -199,12 +199,12 @@ inline void inner(device_t        pu__,
 
     /* single MPI rank */
     if (comm.size() == 1) {
-        T* buf = (pu__ == CPU) ? result__.template at<CPU>(irow0__, jcol0__) : result__.template at<GPU>(irow0__, jcol0__);
+        T* buf = (pu__ == CPU) ? result__.template at(memory_t::host, irow0__, jcol0__) : result__.template at(memory_t::device, irow0__, jcol0__);
         local_inner(i0__, m__, j0__, n__, buf, result__.ld(), -1);
         #ifdef __GPU
         if (pu__ == GPU) {
-            acc::copyout(result__.template at<CPU>(irow0__, jcol0__), result__.ld(),
-                         result__.template at<GPU>(irow0__, jcol0__), result__.ld(),
+            acc::copyout(result__.template at(memory_t::host, irow0__, jcol0__), result__.ld(),
+                         result__.template at(memory_t::device, irow0__, jcol0__), result__.ld(),
                          m__, n__);
         }
         #endif
@@ -219,7 +219,7 @@ inline void inner(device_t        pu__,
         if (pu__ == GPU) {
             tmp.allocate(memory_t::device);
         }
-        T* buf = (pu__ == CPU) ? tmp.template at<CPU>(0, 0) : tmp.template at<GPU>(0, 0);
+        T* buf = (pu__ == CPU) ? tmp.template at(memory_t::host, 0, 0) : tmp.template at(memory_t::device, 0, 0);
         local_inner(i0__, m__, j0__, n__, buf, m__, -1);
         if (pu__ == GPU) {
             tmp.copy_to(memory_t::host);
@@ -232,8 +232,8 @@ inline void inner(device_t        pu__,
         }
 #ifdef __GPU
         if (pu__ == GPU) {
-            acc::copyin(result__.template at<GPU>(irow0__, jcol0__), result__.ld(),
-                        result__.template at<CPU>(irow0__, jcol0__), result__.ld(),
+            acc::copyin(result__.template at(memory_t::device, irow0__, jcol0__), result__.ld(),
+                        result__.template at(memory_t::host, irow0__, jcol0__), result__.ld(),
                         m__, n__);
         }
 #endif
@@ -336,10 +336,10 @@ inline void inner(device_t        pu__,
                             state = buf_state[s % num_streams];
                         }
                         /* enqueue the gemm kernel */
-                        local_inner(i0__ + i0, nrow, j0__ + j0, ncol, c_tmp.template at<GPU>(0, s % num_streams), nrow, s % num_streams);
+                        local_inner(i0__ + i0, nrow, j0__ + j0, ncol, c_tmp.template at(memory_t::device, 0, s % num_streams), nrow, s % num_streams);
                         /* enqueue a copyout operation */
-                        acc::copyout(c_tmp.template at<CPU>(0, s % num_streams), 
-                                     c_tmp.template at<GPU>(0, s % num_streams),
+                        acc::copyout(c_tmp.template at(memory_t::host, 0, s % num_streams), 
+                                     c_tmp.template at(memory_t::device, 0, s % num_streams),
                                      nrow * ncol, s % num_streams);
 
                         /* lock the buffer */
@@ -355,7 +355,7 @@ inline void inner(device_t        pu__,
                         /* wait for the cuda stream to finish (both gemm and copyout) */
                         acc::sync_stream(s % num_streams);
                         /* sum over all MPI ranks */ 
-                        comm.allreduce(c_tmp.template at<CPU>(0, s % num_streams), nrow * ncol);
+                        comm.allreduce(c_tmp.template at(memory_t::host, 0, s % num_streams), nrow * ncol);
 
                         /* store panel: go over the elements of the window and add the elements 
                          * to the resulting array; the .add() method skips the elements that are 
@@ -413,10 +413,10 @@ inline void inner(device_t        pu__,
                 dims[s % 2][2] = nrow;
                 dims[s % 2][3] = ncol;
 
-                T* buf = (pu__ == CPU) ? c_tmp.template at<CPU>(0, s % 2) : c_tmp.template at<GPU>(0, s % 2);
+                T* buf = (pu__ == CPU) ? c_tmp.template at(memory_t::host, 0, s % 2) : c_tmp.template at(memory_t::device, 0, s % 2);
                 local_inner(i0__ + i0, nrow, j0__ + j0, ncol, buf, nrow, -1);
 
-                comm.iallreduce(c_tmp.template at<CPU>(0, s % 2), nrow * ncol, &req[s % 2]);
+                comm.iallreduce(c_tmp.template at(memory_t::host, 0, s % 2), nrow * ncol, &req[s % 2]);
 
                 s++;
             }
@@ -724,7 +724,7 @@ inline void inner(memory_t        mem__,
                             state = buf_state[s % num_streams];
                         }
                         /* enqueue the gemm kernel */
-                        //local_inner(i0__ + i0, nrow, j0__ + j0, ncol, c_tmp.template at<GPU>(0, s % num_streams),
+                        //local_inner(i0__ + i0, nrow, j0__ + j0, ncol, c_tmp.template at(memory_t::device, 0, s % num_streams),
                         //            nrow, stream_id(s % num_streams));
                         inner_local<T>(mem__, la__, ispn__, bra__, i0__ + i0, nrow, ket__, j0__ + j0, ncol, &beta,
                                        c_tmp.at(memory_t::device, 0, s % num_streams), nrow, stream_id(-1));
@@ -746,7 +746,7 @@ inline void inner(memory_t        mem__,
                         /* wait for the cuda stream to finish (both gemm and copyout) */
                         acc::sync_stream(s % num_streams);
                         /* sum over all MPI ranks */ 
-                        comm.allreduce(c_tmp.template at<CPU>(0, s % num_streams), nrow * ncol);
+                        comm.allreduce(c_tmp.template at(memory_t::host, 0, s % num_streams), nrow * ncol);
 
                         /* store panel: go over the elements of the window and add the elements 
                          * to the resulting array; the .add() method skips the elements that are 

--- a/src/SDDK/wf_ortho.hpp
+++ b/src/SDDK/wf_ortho.hpp
@@ -251,7 +251,7 @@ inline void orthogonalize(device_t                     pu__,
                                               e->mt_coeffs(s).prime().at(memory_t::device, 0, N__), e->mt_coeffs(s).prime().ld());
                         }
                         /* alpha should not go out of the scope, so wait */
-                        acc::sync_stream(-1);
+                        acc::sync_stream(stream_id(-1));
                     }
                     if (std::is_same<T, double>::value) {
                         double alpha{1};
@@ -265,10 +265,10 @@ inline void orthogonalize(device_t                     pu__,
                                               reinterpret_cast<double*>(o__.at(memory_t::device)), o__.ld(),
                                               reinterpret_cast<double*>(e->mt_coeffs(s).prime().at(memory_t::device, 0, N__)), 2 * e->mt_coeffs(s).prime().ld());
                         }
-                        acc::sync_stream(-1);
+                        acc::sync_stream(stream_id(-1));
                     }
                 }
-                acc::sync_stream(-1);
+                acc::sync_stream(stream_id(-1));
             }
 #endif
         }

--- a/src/SDDK/wf_ortho.hpp
+++ b/src/SDDK/wf_ortho.hpp
@@ -243,12 +243,12 @@ inline void orthogonalize(device_t                     pu__,
 
                         linalg<GPU>::trmm('R', 'U', 'N', e->pw_coeffs(s).num_rows_loc(), n__, &alpha,
                                           reinterpret_cast<double_complex*>(o__.at(memory_t::device)), o__.ld(),
-                                          e->pw_coeffs(s).prime().at<GPU>(0, N__), e->pw_coeffs(s).prime().ld());
+                                          e->pw_coeffs(s).prime().at(memory_t::device, 0, N__), e->pw_coeffs(s).prime().ld());
 
                         if (e->has_mt()) {
                             linalg<GPU>::trmm('R', 'U', 'N', e->mt_coeffs(s).num_rows_loc(), n__, &alpha,
                                               reinterpret_cast<double_complex*>(o__.at(memory_t::device)), o__.ld(),
-                                              e->mt_coeffs(s).prime().at<GPU>(0, N__), e->mt_coeffs(s).prime().ld());
+                                              e->mt_coeffs(s).prime().at(memory_t::device, 0, N__), e->mt_coeffs(s).prime().ld());
                         }
                         /* alpha should not go out of the scope, so wait */
                         acc::sync_stream(-1);
@@ -258,12 +258,12 @@ inline void orthogonalize(device_t                     pu__,
 
                         linalg<GPU>::trmm('R', 'U', 'N', 2 * e->pw_coeffs(s).num_rows_loc(), n__, &alpha,
                                           reinterpret_cast<double*>(o__.at(memory_t::device)), o__.ld(),
-                                          reinterpret_cast<double*>(e->pw_coeffs(s).prime().at<GPU>(0, N__)), 2 * e->pw_coeffs(s).prime().ld());
+                                          reinterpret_cast<double*>(e->pw_coeffs(s).prime().at(memory_t::device, 0, N__)), 2 * e->pw_coeffs(s).prime().ld());
 
                         if (e->has_mt()) {
                             linalg<GPU>::trmm('R', 'U', 'N', 2 * e->mt_coeffs(s).num_rows_loc(), n__, &alpha,
                                               reinterpret_cast<double*>(o__.at(memory_t::device)), o__.ld(),
-                                              reinterpret_cast<double*>(e->mt_coeffs(s).prime().at<GPU>(0, N__)), 2 * e->mt_coeffs(s).prime().ld());
+                                              reinterpret_cast<double*>(e->mt_coeffs(s).prime().at(memory_t::device, 0, N__)), 2 * e->mt_coeffs(s).prime().ld());
                         }
                         acc::sync_stream(-1);
                     }

--- a/src/SDDK/wf_ortho.hpp
+++ b/src/SDDK/wf_ortho.hpp
@@ -164,13 +164,13 @@ inline void orthogonalize(device_t                     pu__,
         if (use_magma) {
 #ifdef __GPU
             /* Cholesky factorization */
-            if (int info = linalg<GPU>::potrf(n__, o__.template at<GPU>(), o__.ld())) {
+            if (int info = linalg<GPU>::potrf(n__, o__.at(memory_t::device), o__.ld())) {
                 std::stringstream s;
                 s << "error in GPU factorization, info = " << info;
                 TERMINATE(s);
             }
             /* inversion of triangular matrix */
-            if (linalg<GPU>::trtri(n__, o__.template at<GPU>(), o__.ld())) {
+            if (linalg<GPU>::trtri(n__, o__.at(memory_t::device), o__.ld())) {
                 TERMINATE("error in inversion");
             }
 #endif
@@ -191,7 +191,7 @@ inline void orthogonalize(device_t                     pu__,
             }
             if (pu__ == GPU) {
 #ifdef __GPU
-                acc::copyin(o__.template at<GPU>(), o__.ld(), o__.template at<CPU>(), o__.ld(), n__, n__);
+                acc::copyin(o__.at(memory_t::device), o__.ld(), o__.at(memory_t::host), o__.ld(), n__, n__);
 #endif
             }
         }
@@ -211,25 +211,25 @@ inline void orthogonalize(device_t                     pu__,
                     /* wave functions are complex, transformation matrix is complex */
                     if (std::is_same<T, double_complex>::value) {
                         linalg<CPU>::trmm('R', 'U', 'N', e->pw_coeffs(s).num_rows_loc(), n__, double_complex(1, 0),
-                                          reinterpret_cast<double_complex*>(o__.template at<CPU>()), o__.ld(),
-                                          e->pw_coeffs(s).prime().at<CPU>(0, N__), e->pw_coeffs(s).prime().ld());
+                                          reinterpret_cast<double_complex*>(o__.at(memory_t::host)), o__.ld(),
+                                          e->pw_coeffs(s).prime().at(memory_t::host, 0, N__), e->pw_coeffs(s).prime().ld());
 
                         if (e->has_mt()) {
                             linalg<CPU>::trmm('R', 'U', 'N', e->mt_coeffs(s).num_rows_loc(), n__, double_complex(1, 0),
-                                              reinterpret_cast<double_complex*>(o__.template at<CPU>()), o__.ld(),
-                                              e->mt_coeffs(s).prime().at<CPU>(0, N__), e->mt_coeffs(s).prime().ld());
+                                              reinterpret_cast<double_complex*>(o__.at(memory_t::host)), o__.ld(),
+                                              e->mt_coeffs(s).prime().at(memory_t::host, 0, N__), e->mt_coeffs(s).prime().ld());
                         }
                     }
                     /* wave functions are real (psi(G) = psi^{*}(-G)), transformation matrix is real */
                     if (std::is_same<T, double>::value) {
                         linalg<CPU>::trmm('R', 'U', 'N', 2 * e->pw_coeffs(s).num_rows_loc(), n__, 1.0,
-                                          reinterpret_cast<double*>(o__.template at<CPU>()), o__.ld(),
-                                          reinterpret_cast<double*>(e->pw_coeffs(s).prime().at<CPU>(0, N__)), 2 * e->pw_coeffs(s).prime().ld());
+                                          reinterpret_cast<double*>(o__.at(memory_t::host)), o__.ld(),
+                                          reinterpret_cast<double*>(e->pw_coeffs(s).prime().at(memory_t::host, 0, N__)), 2 * e->pw_coeffs(s).prime().ld());
 
                         if (e->has_mt()) {
                             linalg<CPU>::trmm('R', 'U', 'N', 2 * e->mt_coeffs(s).num_rows_loc(), n__, 1.0,
-                                              reinterpret_cast<double*>(o__.template at<CPU>()), o__.ld(),
-                                              reinterpret_cast<double*>(e->mt_coeffs(s).prime().at<CPU>(0, N__)), 2 * e->mt_coeffs(s).prime().ld());
+                                              reinterpret_cast<double*>(o__.at(memory_t::host)), o__.ld(),
+                                              reinterpret_cast<double*>(e->mt_coeffs(s).prime().at(memory_t::host, 0, N__)), 2 * e->mt_coeffs(s).prime().ld());
                         }
                     }
                 }
@@ -242,12 +242,12 @@ inline void orthogonalize(device_t                     pu__,
                         double_complex alpha(1, 0);
 
                         linalg<GPU>::trmm('R', 'U', 'N', e->pw_coeffs(s).num_rows_loc(), n__, &alpha,
-                                          reinterpret_cast<double_complex*>(o__.template at<GPU>()), o__.ld(),
+                                          reinterpret_cast<double_complex*>(o__.at(memory_t::device)), o__.ld(),
                                           e->pw_coeffs(s).prime().at<GPU>(0, N__), e->pw_coeffs(s).prime().ld());
 
                         if (e->has_mt()) {
                             linalg<GPU>::trmm('R', 'U', 'N', e->mt_coeffs(s).num_rows_loc(), n__, &alpha,
-                                              reinterpret_cast<double_complex*>(o__.template at<GPU>()), o__.ld(),
+                                              reinterpret_cast<double_complex*>(o__.at(memory_t::device)), o__.ld(),
                                               e->mt_coeffs(s).prime().at<GPU>(0, N__), e->mt_coeffs(s).prime().ld());
                         }
                         /* alpha should not go out of the scope, so wait */
@@ -257,12 +257,12 @@ inline void orthogonalize(device_t                     pu__,
                         double alpha{1};
 
                         linalg<GPU>::trmm('R', 'U', 'N', 2 * e->pw_coeffs(s).num_rows_loc(), n__, &alpha,
-                                          reinterpret_cast<double*>(o__.template at<GPU>()), o__.ld(),
+                                          reinterpret_cast<double*>(o__.at(memory_t::device)), o__.ld(),
                                           reinterpret_cast<double*>(e->pw_coeffs(s).prime().at<GPU>(0, N__)), 2 * e->pw_coeffs(s).prime().ld());
 
                         if (e->has_mt()) {
                             linalg<GPU>::trmm('R', 'U', 'N', 2 * e->mt_coeffs(s).num_rows_loc(), n__, &alpha,
-                                              reinterpret_cast<double*>(o__.template at<GPU>()), o__.ld(),
+                                              reinterpret_cast<double*>(o__.at(memory_t::device)), o__.ld(),
                                               reinterpret_cast<double*>(e->mt_coeffs(s).prime().at<GPU>(0, N__)), 2 * e->mt_coeffs(s).prime().ld());
                         }
                         acc::sync_stream(-1);
@@ -498,13 +498,13 @@ inline void orthogonalize(memory_t                     mem__,
         if (use_magma) {
 #ifdef __GPU
             /* Cholesky factorization */
-            if (int info = linalg<GPU>::potrf(n__, o__.template at<GPU>(), o__.ld())) {
+            if (int info = linalg<GPU>::potrf(n__, o__.at(memory_t::device), o__.ld())) {
                 std::stringstream s;
                 s << "error in GPU factorization, info = " << info;
                 TERMINATE(s);
             }
             /* inversion of triangular matrix */
-            if (linalg<GPU>::trtri(n__, o__.template at<GPU>(), o__.ld())) {
+            if (linalg<GPU>::trtri(n__, o__.at(memory_t::device), o__.ld())) {
                 TERMINATE("error in inversion");
             }
 #endif

--- a/src/SDDK/wf_trans.hpp
+++ b/src/SDDK/wf_trans.hpp
@@ -104,18 +104,18 @@ inline void transform(device_t                     pu__,
                     /* transform plane-wave part */
                     linalg<CPU>::gemm(0, 0, wf_in__->pw_coeffs(in_s).num_rows_loc(), n__, m__,
                                       *reinterpret_cast<double_complex*>(alpha),
-                                      wf_in__->pw_coeffs(in_s).prime().at<CPU>(0, i0__), wf_in__->pw_coeffs(in_s).prime().ld(),
+                                      wf_in__->pw_coeffs(in_s).prime().at(memory_t::host, 0, i0__), wf_in__->pw_coeffs(in_s).prime().ld(),
                                       reinterpret_cast<double_complex*>(ptr__), ld__,
                                       linalg_const<double_complex>::one(),
-                                      wf_out__->pw_coeffs(s).prime().at<CPU>(0, j0__), wf_out__->pw_coeffs(s).prime().ld());
+                                      wf_out__->pw_coeffs(s).prime().at(memory_t::host, 0, j0__), wf_out__->pw_coeffs(s).prime().ld());
                     /* transform muffin-tin part */
                     if (wf_in__->has_mt()) {
                         linalg<CPU>::gemm(0, 0, wf_in__->mt_coeffs(in_s).num_rows_loc(), n__, m__,
                                           *reinterpret_cast<double_complex*>(alpha),
-                                          wf_in__->mt_coeffs(in_s).prime().at<CPU>(0, i0__), wf_in__->mt_coeffs(in_s).prime().ld(),
+                                          wf_in__->mt_coeffs(in_s).prime().at(memory_t::host, 0, i0__), wf_in__->mt_coeffs(in_s).prime().ld(),
                                           reinterpret_cast<double_complex*>(ptr__), ld__,
                                           linalg_const<double_complex>::one(),
-                                          wf_out__->mt_coeffs(s).prime().at<CPU>(0, j0__), wf_out__->mt_coeffs(s).prime().ld());
+                                          wf_out__->mt_coeffs(s).prime().at(memory_t::host, 0, j0__), wf_out__->mt_coeffs(s).prime().ld());
                     }
                 }
 
@@ -123,10 +123,10 @@ inline void transform(device_t                     pu__,
                     /* transform plane-wave part */
                     linalg<CPU>::gemm(0, 0, 2 * wf_in__->pw_coeffs(in_s).num_rows_loc(), n__, m__,
                                       *reinterpret_cast<double*>(alpha),
-                                      reinterpret_cast<double*>(wf_in__->pw_coeffs(in_s).prime().at<CPU>(0, i0__)), 2 * wf_in__->pw_coeffs(in_s).prime().ld(),
+                                      reinterpret_cast<double*>(wf_in__->pw_coeffs(in_s).prime().at(memory_t::host, 0, i0__)), 2 * wf_in__->pw_coeffs(in_s).prime().ld(),
                                       reinterpret_cast<double*>(ptr__), ld__,
                                       linalg_const<double>::one(),
-                                      reinterpret_cast<double*>(wf_out__->pw_coeffs(s).prime().at<CPU>(0, j0__)), 2 * wf_out__->pw_coeffs(s).prime().ld());
+                                      reinterpret_cast<double*>(wf_out__->pw_coeffs(s).prime().at(memory_t::host, 0, j0__)), 2 * wf_out__->pw_coeffs(s).prime().ld());
                     if (wf_in__->has_mt()) {
                         TERMINATE("not implemented");
                     }
@@ -138,20 +138,20 @@ inline void transform(device_t                     pu__,
                     /* transform plane-wave part */
                     linalg<GPU>::gemm(0, 0, wf_in__->pw_coeffs(in_s).num_rows_loc(), n__, m__,
                                       reinterpret_cast<double_complex*>(alpha),
-                                      wf_in__->pw_coeffs(in_s).prime().at<GPU>(0, i0__), wf_in__->pw_coeffs(in_s).prime().ld(),
+                                      wf_in__->pw_coeffs(in_s).prime().at(memory_t::device, 0, i0__), wf_in__->pw_coeffs(in_s).prime().ld(),
                                       reinterpret_cast<double_complex*>(ptr__), ld__,
                                       &linalg_const<double_complex>::one(),
-                                      wf_out__->pw_coeffs(s).prime().at<GPU>(0, j0__), wf_out__->pw_coeffs(s).prime().ld(),
+                                      wf_out__->pw_coeffs(s).prime().at(memory_t::device, 0, j0__), wf_out__->pw_coeffs(s).prime().ld(),
                                       stream_id__);
 
                     if (wf_in__->has_mt()) {
                         /* transform muffin-tin part */
                         linalg<GPU>::gemm(0, 0, wf_in__->mt_coeffs(in_s).num_rows_loc(), n__, m__,
                                           reinterpret_cast<double_complex*>(alpha),
-                                          wf_in__->mt_coeffs(in_s).prime().at<GPU>(0, i0__), wf_in__->mt_coeffs(in_s).prime().ld(),
+                                          wf_in__->mt_coeffs(in_s).prime().at(memory_t::device, 0, i0__), wf_in__->mt_coeffs(in_s).prime().ld(),
                                           reinterpret_cast<double_complex*>(ptr__), ld__,
                                           &linalg_const<double_complex>::one(),
-                                          wf_out__->mt_coeffs(s).prime().at<GPU>(0, j0__), wf_out__->mt_coeffs(s).prime().ld(),
+                                          wf_out__->mt_coeffs(s).prime().at(memory_t::device, 0, j0__), wf_out__->mt_coeffs(s).prime().ld(),
                                           stream_id__);
                     }
                 }
@@ -160,10 +160,10 @@ inline void transform(device_t                     pu__,
                     /* transform plane-wave part */
                     linalg<GPU>::gemm(0, 0, 2 * wf_in__->pw_coeffs(in_s).num_rows_loc(), n__, m__,
                                       reinterpret_cast<double*>(alpha),
-                                      reinterpret_cast<double*>(wf_in__->pw_coeffs(in_s).prime().at<GPU>(0, i0__)), 2 * wf_in__->pw_coeffs(in_s).prime().ld(),
+                                      reinterpret_cast<double*>(wf_in__->pw_coeffs(in_s).prime().at(memory_t::device, 0, i0__)), 2 * wf_in__->pw_coeffs(in_s).prime().ld(),
                                       reinterpret_cast<double*>(ptr__), ld__,
                                       &linalg_const<double>::one(),
-                                      reinterpret_cast<double*>(wf_out__->pw_coeffs(s).prime().at<GPU>(0, j0__)), 2 * wf_out__->pw_coeffs(s).prime().ld(),
+                                      reinterpret_cast<double*>(wf_out__->pw_coeffs(s).prime().at(memory_t::device, 0, j0__)), 2 * wf_out__->pw_coeffs(s).prime().ld(),
                                       stream_id__);
                     if (wf_in__->has_mt()) {
                         TERMINATE("not implemented");
@@ -194,18 +194,18 @@ inline void transform(device_t                     pu__,
     if (comm.size() == 1) {
         #ifdef __GPU
         if (pu__ == GPU) {
-            acc::copyin(mtrx__.template at<GPU>(irow0__, jcol0__), mtrx__.ld(),
-                        mtrx__.template at<CPU>(irow0__, jcol0__), mtrx__.ld(), m__, n__, 0);
+            acc::copyin(mtrx__.template at(memory_t::device, irow0__, jcol0__), mtrx__.ld(),
+                        mtrx__.template at(memory_t::host, irow0__, jcol0__), mtrx__.ld(), m__, n__, 0);
         }
         #endif
         T* ptr{nullptr};
         switch (pu__) {
             case CPU: {
-                ptr = mtrx__.template at<CPU>(irow0__, jcol0__);
+                ptr = mtrx__.template at(memory_t::host, irow0__, jcol0__);
                 break;
             }
             case GPU: {
-                ptr = mtrx__.template at<GPU>(irow0__, jcol0__);
+                ptr = mtrx__.template at(memory_t::device, irow0__, jcol0__);
                 break;
             }
         }
@@ -330,19 +330,19 @@ inline void transform(device_t                     pu__,
             }
             #ifdef __GPU
             if (pu__ == GPU) {
-                acc::copyin(submatrix.template at<GPU>(0, 0, s % num_streams), submatrix.ld(),
-                            submatrix.template at<CPU>(0, 0, s % num_streams), submatrix.ld(),
+                acc::copyin(submatrix.template at(memory_t::device, 0, 0, s % num_streams), submatrix.ld(),
+                            submatrix.template at(memory_t::host, 0, 0, s % num_streams), submatrix.ld(),
                             nrow, ncol, s % num_streams);
             }
             #endif
             T* ptr{nullptr};
             switch (pu__) {
                 case CPU: {
-                    ptr = submatrix.template at<CPU>(0, 0, s % num_streams);
+                    ptr = submatrix.template at(memory_t::host, 0, 0, s % num_streams);
                     break;
                 }
                 case GPU: {
-                    ptr = submatrix.template at<GPU>(0, 0, s % num_streams);
+                    ptr = submatrix.template at(memory_t::device, 0, 0, s % num_streams);
                     break;
                 }
             }
@@ -554,8 +554,8 @@ inline void transform(memory_t                     mem__,
     if (comm.size() == 1) {
 #ifdef __GPU
         if (is_device_memory(mem__)) {
-            acc::copyin(mtrx__.template at<GPU>(irow0__, jcol0__), mtrx__.ld(),
-                        mtrx__.template at<CPU>(irow0__, jcol0__), mtrx__.ld(), m__, n__, 0);
+            acc::copyin(mtrx__.template at(memory_t::device, irow0__, jcol0__), mtrx__.ld(),
+                        mtrx__.template at(memory_t::host, irow0__, jcol0__), mtrx__.ld(), m__, n__, 0);
         }
 #endif
         T* ptr = mtrx__.at(mem__, irow0__, jcol0__);

--- a/src/Unit_cell/atom.hpp
+++ b/src/Unit_cell/atom.hpp
@@ -234,7 +234,7 @@ class Atom
                 #pragma omp for
                 for (int i = 0; i < nrf; i++) {
                     rf_spline[i].interpolate();
-                    std::memcpy(rf_coef.at<CPU>(0, 0, i), rf_spline[i].coeffs().at<CPU>(), nmtp * 4 * sizeof(double));
+                    std::memcpy(rf_coef.at<CPU>(0, 0, i), rf_spline[i].coeffs().at(memory_t::host), nmtp * 4 * sizeof(double));
                     // cuda_async_copy_to_device(rf_coef.at<GPU>(0, 0, i), rf_coef.at<CPU>(0, 0, i), nmtp * 4 *
                     // sizeof(double), tid);
                 }
@@ -251,7 +251,7 @@ class Atom
                     for (int j = 0; j < num_mag_dims + 1; j++) {
                         int idx         = lm + lmmax * i + lmmax * nrf * j;
                         vrf_spline[idx] = rf_spline[i] * v_spline[lm + j * lmmax];
-                        std::memcpy(vrf_coef.at<CPU>(0, 0, idx), vrf_spline[idx].coeffs().at<CPU>(),
+                        std::memcpy(vrf_coef.at<CPU>(0, 0, idx), vrf_spline[idx].coeffs().at(memory_t::host),
                                     nmtp * 4 * sizeof(double));
                         // cuda_async_copy_to_device(vrf_coef.at<GPU>(0, 0, idx), vrf_coef.at<CPU>(0, 0, idx), nmtp * 4
                         // *sizeof(double), tid);
@@ -409,15 +409,15 @@ class Atom
 
     inline void sync_radial_integrals(Communicator const& comm__, int const rank__)
     {
-        comm__.bcast(h_radial_integrals_.at<CPU>(), (int)h_radial_integrals_.size(), rank__);
+        comm__.bcast(h_radial_integrals_.at(memory_t::host), (int)h_radial_integrals_.size(), rank__);
         if (type().parameters().num_mag_dims()) {
-            comm__.bcast(b_radial_integrals_.at<CPU>(), (int)b_radial_integrals_.size(), rank__);
+            comm__.bcast(b_radial_integrals_.at(memory_t::host), (int)b_radial_integrals_.size(), rank__);
         }
     }
 
     inline void sync_occupation_matrix(Communicator const& comm__, int const rank__)
     {
-        comm__.bcast(occupation_matrix_.at<CPU>(), (int)occupation_matrix_.size(), rank__);
+        comm__.bcast(occupation_matrix_.at(memory_t::host), (int)occupation_matrix_.size(), rank__);
     }
 
     inline int offset_aw() const
@@ -544,19 +544,19 @@ class Atom
 
     inline void set_occupation_matrix(const double_complex* source)
     {
-        std::memcpy(occupation_matrix_.at<CPU>(), source, 16 * 16 * 2 * 2 * sizeof(double_complex));
+        std::memcpy(occupation_matrix_.at(memory_t::host), source, 16 * 16 * 2 * 2 * sizeof(double_complex));
         apply_uj_correction_ = false;
     }
 
     inline void get_occupation_matrix(double_complex* destination)
     {
-        std::memcpy(destination, occupation_matrix_.at<CPU>(), 16 * 16 * 2 * 2 * sizeof(double_complex));
+        std::memcpy(destination, occupation_matrix_.at(memory_t::host), 16 * 16 * 2 * 2 * sizeof(double_complex));
     }
 
     inline void set_uj_correction_matrix(const int l, const double_complex* source)
     {
         uj_correction_l_ = l;
-        memcpy(uj_correction_matrix_.at<CPU>(), source, 16 * 16 * 2 * 2 * sizeof(double_complex));
+        memcpy(uj_correction_matrix_.at(memory_t::host), source, 16 * 16 * 2 * 2 * sizeof(double_complex));
         apply_uj_correction_ = true;
     }
 

--- a/src/Unit_cell/atom.hpp
+++ b/src/Unit_cell/atom.hpp
@@ -234,7 +234,7 @@ class Atom
                 #pragma omp for
                 for (int i = 0; i < nrf; i++) {
                     rf_spline[i].interpolate();
-                    std::memcpy(rf_coef.at<CPU>(0, 0, i), rf_spline[i].coeffs().at(memory_t::host), nmtp * 4 * sizeof(double));
+                    std::memcpy(rf_coef.at(memory_t::host, 0, 0, i), rf_spline[i].coeffs().at(memory_t::host), nmtp * 4 * sizeof(double));
                     // cuda_async_copy_to_device(rf_coef.at<GPU>(0, 0, i), rf_coef.at<CPU>(0, 0, i), nmtp * 4 *
                     // sizeof(double), tid);
                 }
@@ -251,27 +251,27 @@ class Atom
                     for (int j = 0; j < num_mag_dims + 1; j++) {
                         int idx         = lm + lmmax * i + lmmax * nrf * j;
                         vrf_spline[idx] = rf_spline[i] * v_spline[lm + j * lmmax];
-                        std::memcpy(vrf_coef.at<CPU>(0, 0, idx), vrf_spline[idx].coeffs().at(memory_t::host),
+                        std::memcpy(vrf_coef.at(memory_t::host, 0, 0, idx), vrf_spline[idx].coeffs().at(memory_t::host),
                                     nmtp * 4 * sizeof(double));
                         // cuda_async_copy_to_device(vrf_coef.at<GPU>(0, 0, idx), vrf_coef.at<CPU>(0, 0, idx), nmtp * 4
                         // *sizeof(double), tid);
                     }
                 }
             }
-            vrf_coef.copy<memory_t::host, memory_t::device>();
+            vrf_coef.copy_to(memory_t::device);
             t1.stop();
 
             result.allocate(memory_t::device);
             //utils::timer t2("sirius::Atom::generate_radial_integrals|inner");
-            spline_inner_product_gpu_v3(idx_ri.at<GPU>(), (int)idx_ri.size(1), nmtp, rgrid.x().at<GPU>(),
-                                        rgrid.dx().at<GPU>(), rf_coef.at<GPU>(), vrf_coef.at<GPU>(), result.at<GPU>());
+            spline_inner_product_gpu_v3(idx_ri.at(memory_t::device), (int)idx_ri.size(1), nmtp, rgrid.x().at(memory_t::device),
+                                        rgrid.dx().at(memory_t::device), rf_coef.at(memory_t::device), vrf_coef.at(memory_t::device), result.at(memory_t::device));
             acc::sync();
             //if (type().parameters().control().print_performance_) {
             //    double tval = t2.stop();
             //    DUMP("spline GPU integration performance: %12.6f GFlops",
             //         1e-9 * double(idx_ri.size(1)) * nmtp * 85 / tval);
             //}
-            result.copy<memory_t::device, memory_t::host>();
+            result.copy_to(memory_t::host);
             result.deallocate(memory_t::device);
 #else
             TERMINATE_NO_GPU

--- a/src/Unit_cell/atom_symmetry_class.hpp
+++ b/src/Unit_cell/atom_symmetry_class.hpp
@@ -762,18 +762,18 @@ inline void Atom_symmetry_class::sync_radial_functions(Communicator const& comm_
 {
     /* don't broadcast Hamiltonian radial functions, because they are used locally */
     int size = (int)(radial_functions_.size(0) * radial_functions_.size(1));
-    comm__.bcast(radial_functions_.at<CPU>(), size, rank__);
-    comm__.bcast(aw_surface_derivatives_.at<CPU>(), (int)aw_surface_derivatives_.size(), rank__);
+    comm__.bcast(radial_functions_.at(memory_t::host), size, rank__);
+    comm__.bcast(aw_surface_derivatives_.at(memory_t::host), (int)aw_surface_derivatives_.size(), rank__);
     // TODO: sync enu to pass to Exciting / Elk
 }
 
 inline void Atom_symmetry_class::sync_radial_integrals(Communicator const& comm__, int const rank__)
 {
-    comm__.bcast(h_spherical_integrals_.at<CPU>(), (int)h_spherical_integrals_.size(), rank__);
-    comm__.bcast(o_radial_integrals_.at<CPU>(), (int)o_radial_integrals_.size(), rank__);
-    comm__.bcast(so_radial_integrals_.at<CPU>(), (int)so_radial_integrals_.size(), rank__);
+    comm__.bcast(h_spherical_integrals_.at(memory_t::host), (int)h_spherical_integrals_.size(), rank__);
+    comm__.bcast(o_radial_integrals_.at(memory_t::host), (int)o_radial_integrals_.size(), rank__);
+    comm__.bcast(so_radial_integrals_.at(memory_t::host), (int)so_radial_integrals_.size(), rank__);
     if (atom_type_.parameters().valence_relativity() == relativity_t::iora) {
-        comm__.bcast(o1_radial_integrals_.at<CPU>(), (int)o1_radial_integrals_.size(), rank__);
+        comm__.bcast(o1_radial_integrals_.at(memory_t::host), (int)o1_radial_integrals_.size(), rank__);
     }
 }
 

--- a/src/Unit_cell/atom_type.hpp
+++ b/src/Unit_cell/atom_type.hpp
@@ -274,7 +274,7 @@ class Atom_type
     inline void set_radial_grid(radial_grid_t grid_type__, int num_points__, double rmin__, double rmax__, double p__)
     {
         radial_grid_ = Radial_grid_factory<double>(grid_type__, num_points__, rmin__, rmax__, p__);
-        if (parameters_.processing_unit() == GPU) {
+        if (parameters_.processing_unit() == device_t::GPU) {
             radial_grid_.copy_to_device();
         }
     }
@@ -1148,8 +1148,7 @@ inline void Atom_type::init(int offset_lo__)
     }
 
     if (parameters_.processing_unit() == device_t::GPU && parameters_.full_potential()) {
-        idx_radial_integrals_.allocate(memory_t::device);
-        idx_radial_integrals_.copy<memory_t::host, memory_t::device>();
+        idx_radial_integrals_.allocate(memory_t::device).copy_to(memory_t::device);
         rf_coef_  = mdarray<double, 3>(num_mt_points(), 4, indexr().size(), memory_t::host_pinned, "Atom_type::rf_coef_");
         vrf_coef_ = mdarray<double, 3>(num_mt_points(), 4, lmmax_pot * indexr().size() * (parameters_.num_mag_dims() + 1),
                                        memory_t::host_pinned, "Atom_type::vrf_coef_");

--- a/src/Unit_cell/unit_cell.hpp
+++ b/src/Unit_cell/unit_cell.hpp
@@ -399,8 +399,8 @@ class Unit_cell
                         atom_coord_[iat](i, x) = atom(ia).position()[x];
                     }
                 }
-                if (parameters_.processing_unit() == GPU) {
-                    atom_coord_[iat].copy<memory_t::host, memory_t::device>();
+                if (parameters_.processing_unit() == device_t::GPU) {
+                    atom_coord_[iat].copy_to(memory_t::device);
                 }
             }
         }

--- a/src/Unit_cell/unit_cell_symmetry.hpp
+++ b/src/Unit_cell/unit_cell_symmetry.hpp
@@ -996,14 +996,14 @@ inline void Unit_cell_symmetry::symmetrize_function(mdarray<double, 3>& frlm__,
             int ja = sym_table_(ia, isym);
             auto location = spl_atoms.location(ja);
             if (location.rank == comm__.rank()) {
-                linalg<CPU>::gemm(0, 0, lmmax, nrmax, lmmax, alpha, rotm.at<CPU>(), rotm.ld(),
-                                  frlm__.at<CPU>(0, 0, ia), frlm__.ld(), 1.0,
-                                  fsym.at<CPU>(0, 0, location.local_index), fsym.ld());
+                linalg<CPU>::gemm(0, 0, lmmax, nrmax, lmmax, alpha, rotm.at(memory_t::host), rotm.ld(),
+                                  frlm__.at(memory_t::host, 0, 0, ia), frlm__.ld(), 1.0,
+                                  fsym.at(memory_t::host, 0, 0, location.local_index), fsym.ld());
             }
         }
     }
-    double* sbuf = spl_atoms.local_size() ? fsym.at<CPU>() : nullptr;
-    comm__.allgather(sbuf, frlm__.at<CPU>(),
+    double* sbuf = spl_atoms.local_size() ? fsym.at(memory_t::host) : nullptr;
+    comm__.allgather(sbuf, frlm__.at(memory_t::host),
                      lmmax * nrmax * spl_atoms.global_offset(),
                      lmmax * nrmax * spl_atoms.local_size());
 }
@@ -1043,15 +1043,15 @@ inline void Unit_cell_symmetry::symmetrize_vector_function(mdarray<double, 3>& v
             int ja = sym_table_(ia, isym);
             auto location = spl_atoms.location(ja);
             if (location.rank == comm__.rank()) {
-                linalg<CPU>::gemm(0, 0, lmmax, nrmax, lmmax, alpha * S(2, 2), rotm.at<CPU>(), rotm.ld(),
-                                  vz_rlm__.at<CPU>(0, 0, ia), vz_rlm__.ld(), 1.0,
-                                  fsym.at<CPU>(0, 0, location.local_index), fsym.ld());
+                linalg<CPU>::gemm(0, 0, lmmax, nrmax, lmmax, alpha * S(2, 2), rotm.at(memory_t::host), rotm.ld(),
+                                  vz_rlm__.at(memory_t::host, 0, 0, ia), vz_rlm__.ld(), 1.0,
+                                  fsym.at(memory_t::host, 0, 0, location.local_index), fsym.ld());
             }
         }
     }
 
-    double* sbuf = spl_atoms.local_size() ? fsym.at<CPU>() : nullptr;
-    comm__.allgather(sbuf, vz_rlm__.at<CPU>(),
+    double* sbuf = spl_atoms.local_size() ? fsym.at(memory_t::host) : nullptr;
+    comm__.allgather(sbuf, vz_rlm__.at(memory_t::host),
                      lmmax * nrmax * spl_atoms.global_offset(),
                      lmmax * nrmax * spl_atoms.local_size());
 }
@@ -1094,9 +1094,9 @@ inline void Unit_cell_symmetry::symmetrize_vector_function(mdarray<double, 3>& v
             auto location = spl_atoms.location(ja);
             if (location.rank == comm__.rank()) {
                 for (int k: {0, 1, 2}) {
-                    linalg<CPU>::gemm(0, 0, lmmax, nrmax, lmmax, alpha, rotm.at<CPU>(), rotm.ld(),
-                                      vrlm[k]->at<CPU>(0, 0, ia), vrlm[k]->ld(), 0.0,
-                                      vtmp.at<CPU>(0, 0, k), vtmp.ld());
+                    linalg<CPU>::gemm(0, 0, lmmax, nrmax, lmmax, alpha, rotm.at(memory_t::host), rotm.ld(),
+                                      vrlm[k]->at(memory_t::host, 0, 0, ia), vrlm[k]->ld(), 0.0,
+                                      vtmp.at(memory_t::host, 0, 0, k), vtmp.ld());
                 }
                 #pragma omp parallel
                 for (int k: {0, 1, 2}) {
@@ -1114,8 +1114,8 @@ inline void Unit_cell_symmetry::symmetrize_vector_function(mdarray<double, 3>& v
     }
 
     for (int k: {0, 1, 2}) {
-        double* sbuf = spl_atoms.local_size() ? v_sym.at<CPU>(0, 0, 0, k) : nullptr;
-        comm__.allgather(sbuf, vrlm[k]->at<CPU>(),
+        double* sbuf = spl_atoms.local_size() ? v_sym.at(memory_t::host, 0, 0, 0, k) : nullptr;
+        comm__.allgather(sbuf, vrlm[k]->at(memory_t::host),
                          lmmax * nrmax * spl_atoms.global_offset(),
                          lmmax * nrmax * spl_atoms.local_size());
     }

--- a/src/eigenproblem.h
+++ b/src/eigenproblem.h
@@ -163,7 +163,7 @@ class Eigensolver_lapack: public Eigensolver<T>
             std::vector<ftn_int> iwork(work_sizes[2]);
 
             utils::timer t1("Eigensolver_lapack::solve_std|zheevd");
-            FORTRAN(zheevd)("V", "U", &matrix_size__, reinterpret_cast<double_complex*>(A__.template at<CPU>()),
+            FORTRAN(zheevd)("V", "U", &matrix_size__, reinterpret_cast<double_complex*>(A__.at(memory_t::host)),
                             &lda, eval__, &work[0], &work_sizes[0], &rwork[0], &work_sizes[1], 
                             &iwork[0], &work_sizes[2], &info, (ftn_int)1, (ftn_int)1);
 
@@ -183,7 +183,7 @@ class Eigensolver_lapack: public Eigensolver<T>
             std::vector<int32_t> iwork(liwork);
 
             utils::timer t1("Eigensolver_lapack::solve_std|dsyevd");
-            FORTRAN(dsyevd)("V", "U", &matrix_size__, reinterpret_cast<double*>(A__.template at<CPU>()), &lda,
+            FORTRAN(dsyevd)("V", "U", &matrix_size__, reinterpret_cast<double*>(A__.at(memory_t::host)), &lda,
                             eval__, &work[0], &lwork, 
                             &iwork[0], &liwork, &info, (ftn_int)1, (ftn_int)1);
             
@@ -195,7 +195,7 @@ class Eigensolver_lapack: public Eigensolver<T>
         }
 
         for (int i = 0; i < matrix_size__; i++) {
-            std::copy(A__.template at<CPU>(0, i), A__.template at<CPU>(0, i) + matrix_size__, Z__.template at<CPU>(0, i));
+            std::copy(A__.at(memory_t::host, 0, i), A__.at(memory_t::host, 0, i) + matrix_size__, Z__.at(memory_t::host, 0, i));
         }
 
         return 0;
@@ -229,8 +229,8 @@ class Eigensolver_lapack: public Eigensolver<T>
             std::vector<double> work(lwork);
             
             utils::timer t1("Eigensolver_lapack::solve_std|dsyevr");
-            FORTRAN(dsyevr)("V", "I", "U", &matrix_size__, reinterpret_cast<double*>(A__.template at<CPU>()), &lda, 
-                            &vl, &vu, &il, &nev__, &abs_tol, &m, &w[0], reinterpret_cast<double*>(Z__.template at<CPU>()),
+            FORTRAN(dsyevr)("V", "I", "U", &matrix_size__, reinterpret_cast<double*>(A__.at(memory_t::host)), &lda, 
+                            &vl, &vu, &il, &nev__, &abs_tol, &m, &w[0], reinterpret_cast<double*>(Z__.at(memory_t::host)),
                             &ldz, 
                             &isuppz[0],
                             &work[0], &lwork,
@@ -254,9 +254,9 @@ class Eigensolver_lapack: public Eigensolver<T>
             std::vector<double> rwork(lrwork);
 
             utils::timer t1("Eigensolver_lapack::solve_std|zheevr");
-            FORTRAN(zheevr)("V", "I", "U", &matrix_size__, reinterpret_cast<double_complex*>(A__.template at<CPU>()), &lda,
+            FORTRAN(zheevr)("V", "I", "U", &matrix_size__, reinterpret_cast<double_complex*>(A__.at(memory_t::host)), &lda,
                             &vl, &vu, &il, &nev__, &abs_tol, &m, 
-                            &w[0], reinterpret_cast<double_complex*>(Z__.template at<CPU>()), &ldz,
+                            &w[0], reinterpret_cast<double_complex*>(Z__.at(memory_t::host)), &ldz,
                             &isuppz[0],
                             &work[0], &lwork,
                             &rwork[0], &lrwork, 
@@ -312,9 +312,9 @@ class Eigensolver_lapack: public Eigensolver<T>
             std::vector<double> rwork(lrwork);
             std::vector<int32_t> iwork(liwork);
        
-            FORTRAN(zhegvx)(&ione, "V", "I", "U", &matrix_size__, reinterpret_cast<double_complex*>(A__.template at<CPU>()),
-                            &lda, reinterpret_cast<double_complex*>(B__.template at<CPU>()), &ldb, 
-                            &vl, &vu, &ione, &nev__, &abs_tol, &m, &w[0], reinterpret_cast<double_complex*>(Z__.template at<CPU>()), &ldz, &work[0], 
+            FORTRAN(zhegvx)(&ione, "V", "I", "U", &matrix_size__, reinterpret_cast<double_complex*>(A__.at(memory_t::host)),
+                            &lda, reinterpret_cast<double_complex*>(B__.at(memory_t::host)), &ldb, 
+                            &vl, &vu, &ione, &nev__, &abs_tol, &m, &w[0], reinterpret_cast<double_complex*>(Z__.at(memory_t::host)), &ldz, &work[0], 
                             &lwork, &rwork[0], &iwork[0], &ifail[0], &info, (ftn_int)1, (ftn_int)1, (ftn_int)1);
 
             if (info) {
@@ -334,9 +334,9 @@ class Eigensolver_lapack: public Eigensolver<T>
             std::vector<double> work(lwork);
             std::vector<int32_t> iwork(liwork);
        
-            FORTRAN(dsygvx)(&ione, "V", "I", "U", &matrix_size__, reinterpret_cast<double*>(A__.template at<CPU>()), &lda,
-                            reinterpret_cast<double*>(B__.template at<CPU>()), &ldb, 
-                            &vl, &vu, &ione, &nev__, &abs_tol, &m, &w[0], reinterpret_cast<double*>(Z__.template at<CPU>()),
+            FORTRAN(dsygvx)(&ione, "V", "I", "U", &matrix_size__, reinterpret_cast<double*>(A__.at(memory_t::host)), &lda,
+                            reinterpret_cast<double*>(B__.at(memory_t::host)), &ldb, 
+                            &vl, &vu, &ione, &nev__, &abs_tol, &m, &w[0], reinterpret_cast<double*>(Z__.at(memory_t::host)),
                             &ldz, &work[0], &lwork,
                             &iwork[0], &ifail[0], &info, (ftn_int)1, (ftn_int)1, (ftn_int)1);
 
@@ -466,10 +466,10 @@ class Eigensolver_elpa: public Eigensolver<T>
             if (stage_ == 1) {
                 success = elpa_solve_evp_complex_1stage_double_precision(matrix_size__,
                                                                          nev__,
-                                                                         reinterpret_cast<double_complex*>(A__.template at<CPU>()),
+                                                                         reinterpret_cast<double_complex*>(A__.at(memory_t::host)),
                                                                          lda,
                                                                          w.data(),
-                                                                         reinterpret_cast<double_complex*>(Z__.template at<CPU>()),
+                                                                         reinterpret_cast<double_complex*>(Z__.at(memory_t::host)),
                                                                          ldz,
                                                                          bs,
                                                                          num_cols_loc,
@@ -480,10 +480,10 @@ class Eigensolver_elpa: public Eigensolver<T>
             } else {
                 success = elpa_solve_evp_complex_2stage_double_precision(matrix_size__,
                                                                          nev__,
-                                                                         reinterpret_cast<double_complex*>(A__.template at<CPU>()),
+                                                                         reinterpret_cast<double_complex*>(A__.at(memory_t::host)),
                                                                          lda,
                                                                          w.data(),
-                                                                         reinterpret_cast<double_complex*>(Z__.template at<CPU>()),
+                                                                         reinterpret_cast<double_complex*>(Z__.at(memory_t::host)),
                                                                          ldz,
                                                                          bs,
                                                                          num_cols_loc,
@@ -498,10 +498,10 @@ class Eigensolver_elpa: public Eigensolver<T>
             if (stage_ == 1) {
                 success = elpa_solve_evp_real_1stage_double_precision(matrix_size__,
                                                                       nev__,
-                                                                      reinterpret_cast<double*>(A__.template at<CPU>()),
+                                                                      reinterpret_cast<double*>(A__.at(memory_t::host)),
                                                                       lda,
                                                                       w.data(),
-                                                                      reinterpret_cast<double*>(Z__.template at<CPU>()),
+                                                                      reinterpret_cast<double*>(Z__.at(memory_t::host)),
                                                                       ldz,
                                                                       bs,
                                                                       num_cols_loc,
@@ -512,10 +512,10 @@ class Eigensolver_elpa: public Eigensolver<T>
             } else {
                 success = elpa_solve_evp_real_2stage_double_precision(matrix_size__,
                                                                       nev__,
-                                                                      reinterpret_cast<double*>(A__.template at<CPU>()),
+                                                                      reinterpret_cast<double*>(A__.at(memory_t::host)),
                                                                       lda,
                                                                       w.data(),
-                                                                      reinterpret_cast<double*>(Z__.template at<CPU>()),
+                                                                      reinterpret_cast<double*>(Z__.at(memory_t::host)),
                                                                       ldz,
                                                                       bs,
                                                                       num_cols_loc,
@@ -595,8 +595,8 @@ class Eigensolver_scalapack: public Eigensolver<T>
 
         if (std::is_same<T, double_complex>::value) {
             /* work size query */
-            FORTRAN(pzheevd)("V", "U", &matrix_size__, reinterpret_cast<double_complex*>(A__.template at<CPU>()),
-                             &ione, &ione, desca, eval__, reinterpret_cast<double_complex*>(Z__.template at<CPU>()),
+            FORTRAN(pzheevd)("V", "U", &matrix_size__, reinterpret_cast<double_complex*>(A__.at(memory_t::host)),
+                             &ione, &ione, desca, eval__, reinterpret_cast<double_complex*>(Z__.at(memory_t::host)),
                              &ione, &ione, descz, &work[0], 
                              &lwork, &rwork[0], &lrwork, &iwork[0], &liwork, &info, (ftn_int)1, (ftn_int)1);
             
@@ -608,8 +608,8 @@ class Eigensolver_scalapack: public Eigensolver<T>
             rwork = std::vector<double>(lrwork);
             iwork = std::vector<int32_t>(liwork);
 
-            FORTRAN(pzheevd)("V", "U", &matrix_size__, reinterpret_cast<double_complex*>(A__.template at<CPU>()),
-                             &ione, &ione, desca, eval__, reinterpret_cast<double_complex*>(Z__.template at<CPU>()),
+            FORTRAN(pzheevd)("V", "U", &matrix_size__, reinterpret_cast<double_complex*>(A__.at(memory_t::host)),
+                             &ione, &ione, desca, eval__, reinterpret_cast<double_complex*>(Z__.at(memory_t::host)),
                              &ione, &ione, descz, &work[0], 
                              &lwork, &rwork[0], &lrwork, &iwork[0], &liwork, &info, (ftn_int)1, (ftn_int)1);
             if (info) {
@@ -655,9 +655,9 @@ class Eigensolver_scalapack: public Eigensolver<T>
             int32_t lwork = -1;
             int32_t lrwork = -1;
             int32_t liwork = -1;
-            FORTRAN(pzheevx)("V", "I", "U", &matrix_size__, reinterpret_cast<double_complex*>(A__.template at<CPU>()), 
+            FORTRAN(pzheevx)("V", "I", "U", &matrix_size__, reinterpret_cast<double_complex*>(A__.at(memory_t::host)), 
                              &ione, &ione, desca, &d1, &d1, &ione, &nev__, &abstol_, &m, &nz, &w[0], &ortfac_,
-                             reinterpret_cast<double_complex*>(Z__.template at<CPU>()), &ione, &ione, descz, &work[0], &lwork,
+                             reinterpret_cast<double_complex*>(Z__.at(memory_t::host)), &ione, &ione, descz, &work[0], &lwork,
                              &rwork[0], &lrwork, &iwork[0], &liwork, &ifail[0], &iclustr[0], &gap[0], &info, 
                              (ftn_int)1, (ftn_int)1, (ftn_int)1); 
             
@@ -669,9 +669,9 @@ class Eigensolver_scalapack: public Eigensolver<T>
             rwork = std::vector<double>(lrwork);
             iwork = std::vector<int32_t>(liwork);
 
-            FORTRAN(pzheevx)("V", "I", "U", &matrix_size__, reinterpret_cast<double_complex*>(A__.template at<CPU>()),
+            FORTRAN(pzheevx)("V", "I", "U", &matrix_size__, reinterpret_cast<double_complex*>(A__.at(memory_t::host)),
                              &ione, &ione, desca, &d1, &d1, &ione, &nev__, &abstol_, &m, &nz, &w[0], &ortfac_,
-                             reinterpret_cast<double_complex*>(Z__.template at<CPU>()), &ione, &ione, descz, &work[0],
+                             reinterpret_cast<double_complex*>(Z__.at(memory_t::host)), &ione, &ione, descz, &work[0],
                              &lwork, &rwork[0], &lrwork, &iwork[0], &liwork, &ifail[0], &iclustr[0], &gap[0], &info, 
                              (ftn_int)1, (ftn_int)1, (ftn_int)1); 
         }
@@ -685,8 +685,8 @@ class Eigensolver_scalapack: public Eigensolver<T>
             int32_t liwork{-1};
 
 
-            FORTRAN(pdsyevx)("V", "I", "U", &matrix_size__, reinterpret_cast<double*>(A__.template at<CPU>()), &ione, &ione, desca, &d1, &d1, 
-                             &ione, &nev__, &abstol_, &m, &nz, &w[0], &ortfac_, reinterpret_cast<double*>(Z__.template at<CPU>()), &ione, &ione, descz, &work[0], &lwork, 
+            FORTRAN(pdsyevx)("V", "I", "U", &matrix_size__, reinterpret_cast<double*>(A__.at(memory_t::host)), &ione, &ione, desca, &d1, &d1, 
+                             &ione, &nev__, &abstol_, &m, &nz, &w[0], &ortfac_, reinterpret_cast<double*>(Z__.at(memory_t::host)), &ione, &ione, descz, &work[0], &lwork, 
                              &iwork[0], &liwork, &ifail[0], &iclustr[0], &gap[0], &info, (ftn_int)1, (ftn_int)1, (ftn_int)1); 
             
             lwork = static_cast<int32_t>(work[0]) + 4 * (1 << 20);
@@ -695,8 +695,8 @@ class Eigensolver_scalapack: public Eigensolver<T>
             work = std::vector<double>(lwork);
             iwork = std::vector<int32_t>(liwork);
 
-            FORTRAN(pdsyevx)("V", "I", "U", &matrix_size__, reinterpret_cast<double*>(A__.template at<CPU>()), &ione, &ione, desca, &d1, &d1, 
-                             &ione, &nev__, &abstol_, &m, &nz, &w[0], &ortfac_, reinterpret_cast<double*>(Z__.template at<CPU>()), &ione, &ione, descz, &work[0], &lwork, 
+            FORTRAN(pdsyevx)("V", "I", "U", &matrix_size__, reinterpret_cast<double*>(A__.at(memory_t::host)), &ione, &ione, desca, &d1, &d1, 
+                             &ione, &nev__, &abstol_, &m, &nz, &w[0], &ortfac_, reinterpret_cast<double*>(Z__.at(memory_t::host)), &ione, &ione, descz, &work[0], &lwork, 
                              &iwork[0], &liwork, &ifail[0], &iclustr[0], &gap[0], &info, 
                              (ftn_int)1, (ftn_int)1, (ftn_int)1); 
 
@@ -770,10 +770,10 @@ class Eigensolver_scalapack: public Eigensolver<T>
             std::vector<double> rwork(3);
             std::vector<int32_t> iwork(1);
             /* work size query */
-            FORTRAN(pzhegvx)(&ione, "V", "I", "U", &matrix_size__, reinterpret_cast<double_complex*>(A__.template at<CPU>()), 
-                             &ione, &ione, desca, reinterpret_cast<double_complex*>(B__.template at<CPU>()), &ione, &ione, 
+            FORTRAN(pzhegvx)(&ione, "V", "I", "U", &matrix_size__, reinterpret_cast<double_complex*>(A__.at(memory_t::host)), 
+                             &ione, &ione, desca, reinterpret_cast<double_complex*>(B__.at(memory_t::host)), &ione, &ione, 
                              descb, &d1, &d1, &ione, &nev__, &abstol_, &m, &nz, &w[0], &ortfac_,
-                             reinterpret_cast<double_complex*>(Z__.template at<CPU>()), &ione, &ione, descz, &work[0], &lwork, 
+                             reinterpret_cast<double_complex*>(Z__.at(memory_t::host)), &ione, &ione, descz, &work[0], &lwork, 
                              &rwork[0], &lrwork, &iwork[0], &liwork, &ifail[0], &iclustr[0], &gap[0], &info, 
                              (ftn_int)1, (ftn_int)1, (ftn_int)1);
 
@@ -785,10 +785,10 @@ class Eigensolver_scalapack: public Eigensolver<T>
             rwork = std::vector<double>(lrwork);
             iwork = std::vector<int32_t>(liwork);
             
-            FORTRAN(pzhegvx)(&ione, "V", "I", "U", &matrix_size__,  reinterpret_cast<double_complex*>(A__.template at<CPU>()),
-                             &ione, &ione, desca, reinterpret_cast<double_complex*>(B__.template at<CPU>()), &ione, &ione,
+            FORTRAN(pzhegvx)(&ione, "V", "I", "U", &matrix_size__,  reinterpret_cast<double_complex*>(A__.at(memory_t::host)),
+                             &ione, &ione, desca, reinterpret_cast<double_complex*>(B__.at(memory_t::host)), &ione, &ione,
                              descb, &d1, &d1, &ione, &nev__, &abstol_, &m, &nz, &w[0], &ortfac_,
-                             reinterpret_cast<double_complex*>(Z__.template at<CPU>()), &ione, &ione, descz, &work[0], &lwork, 
+                             reinterpret_cast<double_complex*>(Z__.at(memory_t::host)), &ione, &ione, descz, &work[0], &lwork, 
                              &rwork[0], &lrwork, &iwork[0], &liwork, &ifail[0], &iclustr[0], &gap[0], &info, 
                              (ftn_int)1, (ftn_int)1, (ftn_int)1);
         }
@@ -798,10 +798,10 @@ class Eigensolver_scalapack: public Eigensolver<T>
             int32_t lwork = -1;
             int32_t liwork = -1;
             /* work size query */
-            FORTRAN(pdsygvx)(&ione, "V", "I", "U", &matrix_size__, reinterpret_cast<double*>(A__.template at<CPU>()),
-                             &ione, &ione, desca, reinterpret_cast<double*>(B__.template at<CPU>()), &ione, &ione, descb,
+            FORTRAN(pdsygvx)(&ione, "V", "I", "U", &matrix_size__, reinterpret_cast<double*>(A__.at(memory_t::host)),
+                             &ione, &ione, desca, reinterpret_cast<double*>(B__.at(memory_t::host)), &ione, &ione, descb,
                              &d1, &d1, &ione, &nev__, &abstol_, &m, &nz, &w[0], &ortfac_,
-                             reinterpret_cast<double*>(Z__.template at<CPU>()), &ione, &ione, descz, &work1, &lwork, 
+                             reinterpret_cast<double*>(Z__.at(memory_t::host)), &ione, &ione, descz, &work1, &lwork, 
                              &liwork, &lwork, &ifail[0], &iclustr[0], &gap[0], &info, (ftn_int)1, (ftn_int)1, (ftn_int)1); 
             
             lwork = static_cast<int32_t>(work1) + 4 * (1 << 20);
@@ -809,10 +809,10 @@ class Eigensolver_scalapack: public Eigensolver<T>
             std::vector<double> work(lwork);
             std::vector<int32_t> iwork(liwork);
             
-            FORTRAN(pdsygvx)(&ione, "V", "I", "U", &matrix_size__,  reinterpret_cast<double*>(A__.template at<CPU>()),
-                             &ione, &ione, desca, reinterpret_cast<double*>(B__.template at<CPU>()), &ione, &ione, descb,
+            FORTRAN(pdsygvx)(&ione, "V", "I", "U", &matrix_size__,  reinterpret_cast<double*>(A__.at(memory_t::host)),
+                             &ione, &ione, desca, reinterpret_cast<double*>(B__.at(memory_t::host)), &ione, &ione, descb,
                              &d1, &d1, &ione, &nev__, &abstol_, &m, &nz, &w[0], &ortfac_,
-                             reinterpret_cast<double*>(Z__.template at<CPU>()), &ione, &ione, descz, &work[0], &lwork, 
+                             reinterpret_cast<double*>(Z__.at(memory_t::host)), &ione, &ione, descz, &work[0], &lwork, 
                              &iwork[0], &liwork, &ifail[0], &iclustr[0], &gap[0], &info, (ftn_int)1, (ftn_int)1, (ftn_int)1); 
         }
 
@@ -882,8 +882,8 @@ class Eigensolver_magma: public Eigensolver<T>
         int ldb = B__.ld();
         std::vector<double> w(matrix_size__);
         if (std::is_same<T, double_complex>::value) {
-            result = magma::zhegvdx_2stage(matrix_size__, nev__, reinterpret_cast<double_complex*>(A__.template at<CPU>()),
-                                           lda, reinterpret_cast<double_complex*>(B__.template at<CPU>()), ldb, w.data());
+            result = magma::zhegvdx_2stage(matrix_size__, nev__, reinterpret_cast<double_complex*>(A__.at(memory_t::host)),
+                                           lda, reinterpret_cast<double_complex*>(B__.at(memory_t::host)), ldb, w.data());
 
             if (nt != omp_get_max_threads()) {
                 TERMINATE("magma has changed the number of threads");
@@ -895,8 +895,8 @@ class Eigensolver_magma: public Eigensolver<T>
             }
         }
         if (std::is_same<T, double>::value) {
-            result = magma::dsygvdx_2stage(matrix_size__, nev__, reinterpret_cast<double*>(A__.template at<CPU>()),
-                                           lda, reinterpret_cast<double*>(B__.template at<CPU>()), ldb, w.data());
+            result = magma::dsygvdx_2stage(matrix_size__, nev__, reinterpret_cast<double*>(A__.at(memory_t::host)),
+                                           lda, reinterpret_cast<double*>(B__.at(memory_t::host)), ldb, w.data());
             if (result) {
                 //return Eigenproblem_lapack().solve(matrix_size, nevec, A, lda, B, ldb, eval, Z, ldz);
                 return result;
@@ -906,7 +906,7 @@ class Eigensolver_magma: public Eigensolver<T>
         std::copy(w.begin(), w.begin() + nev__, eval__);
         #pragma omp parallel for schedule(static)
         for (int i = 0; i < nev__; i++) {
-            std::copy(A__.template at<CPU>(0, i), A__.template at<CPU>(0, i) + matrix_size__, Z__.template at<CPU>(0, i));
+            std::copy(A__.at(memory_t::host, 0, i), A__.at(memory_t::host, 0, i) + matrix_size__, Z__.at(memory_t::host, 0, i));
         }
 
         return 0;
@@ -920,7 +920,7 @@ class Eigensolver_magma: public Eigensolver<T>
         int lda = A__.ld();
         std::vector<double> w(matrix_size__);
         if (std::is_same<T, double>::value) {
-            result = magma::dsyevdx(matrix_size__, nev__, reinterpret_cast<double*>(A__.template at<CPU>()),
+            result = magma::dsyevdx(matrix_size__, nev__, reinterpret_cast<double*>(A__.at(memory_t::host)),
                                     lda, w.data());
 
             if (nt != omp_get_max_threads()) {
@@ -933,7 +933,7 @@ class Eigensolver_magma: public Eigensolver<T>
             }
         }
         if (std::is_same<T, double_complex>::value) {
-            result = magma::zheevdx(matrix_size__, nev__, reinterpret_cast<magmaDoubleComplex*>(A__.template at<CPU>()),
+            result = magma::zheevdx(matrix_size__, nev__, reinterpret_cast<magmaDoubleComplex*>(A__.at(memory_t::host)),
                                            lda, w.data());
             if (result) {
                 //return Eigenproblem_lapack().solve(matrix_size, nevec, A, lda, B, ldb, eval, Z, ldz);
@@ -944,7 +944,7 @@ class Eigensolver_magma: public Eigensolver<T>
         std::copy(w.begin(), w.begin() + nev__, eval__);
         #pragma omp parallel for schedule(static)
         for (int i = 0; i < nev__; i++) {
-            std::copy(A__.template at<CPU>(0, i), A__.template at<CPU>(0, i) + matrix_size__, Z__.template at<CPU>(0, i));
+            std::copy(A__.at(memory_t::host, 0, i), A__.at(memory_t::host, 0, i) + matrix_size__, Z__.at(memory_t::host, 0, i));
         }
 
         return 0;
@@ -1758,22 +1758,22 @@ std::unique_ptr<Eigensolver<T>> Eigensolver_factory(ev_solver_t ev_solver_type__
 //==             FORTRAN(elpa_invert_trm_complex_wrapper)(&matrix_size__, B__, &ldb__, &block_size_, &num_cols_loc__, &mpi_comm_rows_, &mpi_comm_cols_);
 //==        
 //==             FORTRAN(elpa_mult_ah_b_complex_wrapper)("U", "L", &matrix_size__, &matrix_size__, B__, &ldb__, &num_cols_loc__, A__, &lda__, &num_cols_loc__, &block_size_, 
-//==                                                     &mpi_comm_rows_, &mpi_comm_cols_, tmp1__.at<CPU>(), &num_rows_loc__, &num_cols_loc__,
+//==                                                     &mpi_comm_rows_, &mpi_comm_cols_, tmp1__.at(memory_t::host), &num_rows_loc__, &num_cols_loc__,
 //==                                                     (int32_t)1, (int32_t)1);
 //== 
 //==             int32_t descc[9];
 //==             linalg_base::descinit(descc, matrix_size__, matrix_size__, block_size_, block_size_, 0, 0, blacs_context_, lda__);
 //==             
-//==             linalg_base::pztranc(matrix_size__, matrix_size__, linalg_const<double_complex>::one(), tmp1__.at<CPU>(), 1, 1, descc, 
-//==                                  linalg_const<double_complex>::zero(), tmp2__.at<CPU>(), 1, 1, descc);
+//==             linalg_base::pztranc(matrix_size__, matrix_size__, linalg_const<double_complex>::one(), tmp1__.at(memory_t::host), 1, 1, descc, 
+//==                                  linalg_const<double_complex>::zero(), tmp2__.at(memory_t::host), 1, 1, descc);
 //== 
 //==             FORTRAN(elpa_mult_ah_b_complex_wrapper)("U", "U", &matrix_size__, &matrix_size__, B__, &ldb__, &num_cols_loc__, 
-//==                                                     tmp2__.at<CPU>(), &num_rows_loc__, &num_cols_loc__,
+//==                                                     tmp2__.at(memory_t::host), &num_rows_loc__, &num_cols_loc__,
 //==                                                     &block_size_, &mpi_comm_rows_, &mpi_comm_cols_, A__, &lda__, &num_cols_loc__,
 //==                                                     (int32_t)1, (int32_t)1);
 //== 
 //==             linalg_base::pztranc(matrix_size__, matrix_size__, linalg_const<double_complex>::one(), A__, 1, 1, descc, linalg_const<double_complex>::zero(), 
-//==                                  tmp1__.at<CPU>(), 1, 1, descc);
+//==                                  tmp1__.at(memory_t::host), 1, 1, descc);
 //== 
 //==             for (int i = 0; i < num_cols_loc__; i++)
 //==             {
@@ -1801,20 +1801,20 @@ std::unique_ptr<Eigensolver<T>> Eigensolver_factory(ev_solver_t ev_solver_type__
 //==             FORTRAN(elpa_invert_trm_real_wrapper)(&matrix_size__, B__, &ldb__, &block_size_, &num_cols_loc__, &mpi_comm_rows_, &mpi_comm_cols_);
 //==        
 //==             FORTRAN(elpa_mult_at_b_real_wrapper)("U", "L", &matrix_size__, &matrix_size__, B__, &ldb__, &num_cols_loc__, A__, &lda__, &num_cols_loc__, &block_size_, 
-//==                                                  &mpi_comm_rows_, &mpi_comm_cols_, tmp1__.at<CPU>(), &num_rows_loc__, &num_cols_loc__, 
+//==                                                  &mpi_comm_rows_, &mpi_comm_cols_, tmp1__.at(memory_t::host), &num_rows_loc__, &num_cols_loc__, 
 //==                                                  (int32_t)1, (int32_t)1);
 //== 
 //==             int32_t descc[9];
 //==             linalg_base::descinit(descc, matrix_size__, matrix_size__, block_size_, block_size_, 0, 0, blacs_context_, lda__);
 //==             
-//==             linalg_base::pdtran(matrix_size__, matrix_size__, 1.0, tmp1__.at<CPU>(), 1, 1, descc, 0.0,
-//==                                 tmp2__.at<CPU>(), 1, 1, descc);
+//==             linalg_base::pdtran(matrix_size__, matrix_size__, 1.0, tmp1__.at(memory_t::host), 1, 1, descc, 0.0,
+//==                                 tmp2__.at(memory_t::host), 1, 1, descc);
 //== 
-//==             FORTRAN(elpa_mult_at_b_real_wrapper)("U", "U", &matrix_size__, &matrix_size__, B__, &ldb__, &num_cols_loc__, tmp2__.at<CPU>(), &num_rows_loc__, 
+//==             FORTRAN(elpa_mult_at_b_real_wrapper)("U", "U", &matrix_size__, &matrix_size__, B__, &ldb__, &num_cols_loc__, tmp2__.at(memory_t::host), &num_rows_loc__, 
 //==                                                 &num_cols_loc__, &block_size_, &mpi_comm_rows_, &mpi_comm_cols_, A__, &lda__, &num_cols_loc__, 
 //==                                                 (int32_t)1, (int32_t)1);
 //== 
-//==             linalg_base::pdtran(matrix_size__, matrix_size__, 1.0, A__, 1, 1, descc, 0.0, tmp1__.at<CPU>(), 1, 1, descc);
+//==             linalg_base::pdtran(matrix_size__, matrix_size__, 1.0, A__, 1, 1, descc, 0.0, tmp1__.at(memory_t::host), 1, 1, descc);
 //== 
 //==             for (int i = 0; i < num_cols_loc__; i++)
 //==             {
@@ -1840,9 +1840,9 @@ std::unique_ptr<Eigensolver<T>> Eigensolver_factory(ev_solver_t ev_solver_type__
 //==             linalg_base::descinit(descb, matrix_size__, matrix_size__, block_size_, block_size_, 0, 0, blacs_context_, ldb__);
 //== 
 //==             linalg_base::pztranc(matrix_size__, matrix_size__, linalg_const<double_complex>::one(), B__, 1, 1, descb, linalg_const<double_complex>::zero(), 
-//==                                  tmp2__.at<CPU>(), 1, 1, descb);
+//==                                  tmp2__.at(memory_t::host), 1, 1, descb);
 //== 
-//==             FORTRAN(elpa_mult_ah_b_complex_wrapper)("L", "N", &matrix_size__, &nevec__, tmp2__.at<CPU>(), &num_rows_loc__, &num_cols_loc__, tmp1__.at<CPU>(), 
+//==             FORTRAN(elpa_mult_ah_b_complex_wrapper)("L", "N", &matrix_size__, &nevec__, tmp2__.at(memory_t::host), &num_rows_loc__, &num_cols_loc__, tmp1__.at(memory_t::host), 
 //==                                                     &num_rows_loc__, &num_cols_loc__, &block_size_, &mpi_comm_rows_, &mpi_comm_cols_, Z__, &ldz__, &num_cols_loc__,
 //==                                                     (int32_t)1, (int32_t)1);
 //==         }
@@ -1859,9 +1859,9 @@ std::unique_ptr<Eigensolver<T>> Eigensolver_factory(ev_solver_t ev_solver_type__
 //==             int32_t descb[9];
 //==             linalg_base::descinit(descb, matrix_size__, matrix_size__, block_size_, block_size_, 0, 0, blacs_context_, ldb__);
 //== 
-//==             linalg_base::pdtran(matrix_size__, matrix_size__, 1.0, B__, 1, 1, descb, 0.0, tmp2__.at<CPU>(), 1, 1, descb);
+//==             linalg_base::pdtran(matrix_size__, matrix_size__, 1.0, B__, 1, 1, descb, 0.0, tmp2__.at(memory_t::host), 1, 1, descb);
 //== 
-//==             FORTRAN(elpa_mult_at_b_real_wrapper)("L", "N", &matrix_size__, &nevec__, tmp2__.at<CPU>(), &num_rows_loc__, &num_cols_loc__, tmp1__.at<CPU>(), 
+//==             FORTRAN(elpa_mult_at_b_real_wrapper)("L", "N", &matrix_size__, &nevec__, tmp2__.at(memory_t::host), &num_rows_loc__, &num_cols_loc__, tmp1__.at(memory_t::host), 
 //==                                                  &num_rows_loc__, &num_cols_loc__, &block_size_, &mpi_comm_rows_, &mpi_comm_cols_, Z__, &ldz__, &num_cols_loc__,
 //==                                                  (int32_t)1, (int32_t)1);
 //==         }
@@ -1897,7 +1897,7 @@ std::unique_ptr<Eigensolver<T>> Eigensolver_factory(ev_solver_t ev_solver_type__
 //== 
 //==             std::vector<double> w(matrix_size);
 //==             utils::timer t("Eigenproblem_elpa1|diag");
-//==             FORTRAN(elpa_solve_evp_complex)(&matrix_size, &nevec, A, &lda, &w[0], tmp1.at<CPU>(), &num_rows_loc, 
+//==             FORTRAN(elpa_solve_evp_complex)(&matrix_size, &nevec, A, &lda, &w[0], tmp1.at(memory_t::host), &num_rows_loc, 
 //==                                             &block_size_, &num_cols_loc, &mpi_comm_rows_, &mpi_comm_cols_, &mpi_comm_all_);
 //==             t.stop();
 //==             std::memcpy(eval, &w[0], nevec * sizeof(double));
@@ -1925,7 +1925,7 @@ std::unique_ptr<Eigensolver<T>> Eigensolver_factory(ev_solver_t ev_solver_type__
 //== 
 //==             std::vector<double> w(matrix_size);
 //==             utils::timer t("Eigenproblem_elpa1|diag");
-//==             FORTRAN(elpa_solve_evp_real)(&matrix_size, &nevec, A, &lda, &w[0], tmp1.at<CPU>(), &num_rows_loc, 
+//==             FORTRAN(elpa_solve_evp_real)(&matrix_size, &nevec, A, &lda, &w[0], tmp1.at(memory_t::host), &num_rows_loc, 
 //==                                          &block_size_, &num_cols_loc, &mpi_comm_rows_, &mpi_comm_cols_, &mpi_comm_all_);
 //==             t.stop();
 //==             std::memcpy(eval, &w[0], nevec * sizeof(double));
@@ -2010,7 +2010,7 @@ std::unique_ptr<Eigensolver<T>> Eigensolver_factory(ev_solver_t ev_solver_type__
 //== 
 //==             std::vector<double> w(matrix_size);
 //==             utils::timer t("Eigenproblem_elpa2|diag");
-//==             FORTRAN(elpa_solve_evp_complex_2stage)(&matrix_size, &nevec, A, &lda, &w[0], tmp1.at<CPU>(), &num_rows_loc, 
+//==             FORTRAN(elpa_solve_evp_complex_2stage)(&matrix_size, &nevec, A, &lda, &w[0], tmp1.at(memory_t::host), &num_rows_loc, 
 //==                                                    &block_size_, &num_cols_loc, &mpi_comm_rows_, &mpi_comm_cols_, &mpi_comm_all_);
 //==             t.stop();
 //==             std::memcpy(eval, &w[0], nevec * sizeof(double));
@@ -2036,7 +2036,7 @@ std::unique_ptr<Eigensolver<T>> Eigensolver_factory(ev_solver_t ev_solver_type__
 //== 
 //==             std::vector<double> w(matrix_size);
 //==             utils::timer t("Eigenproblem_elpa2|diag");
-//==             FORTRAN(elpa_solve_evp_real_2stage)(&matrix_size, &nevec, A, &lda, &w[0], tmp1.at<CPU>(), &num_rows_loc, 
+//==             FORTRAN(elpa_solve_evp_real_2stage)(&matrix_size, &nevec, A, &lda, &w[0], tmp1.at(memory_t::host), &num_rows_loc, 
 //==                                                 &block_size_, &num_cols_loc, &mpi_comm_rows_, &mpi_comm_cols_, &mpi_comm_all_);
 //==             t.stop();
 //==             std::memcpy(eval, &w[0], nevec * sizeof(double));
@@ -2144,7 +2144,7 @@ std::unique_ptr<Eigensolver<T>> Eigensolver_factory(ev_solver_t ev_solver_type__
 //==             std::vector<double> eval_tmp(matrix_size);
 //== 
 //==             int info;
-//==             libevs_gen_eig_cpu('L', matrix_size, nevec, A, 1, 1, desca, B, 1, 1, descb, &eval_tmp[0], ztmp.at<CPU>(), 1, 1, descz, &info);
+//==             libevs_gen_eig_cpu('L', matrix_size, nevec, A, 1, 1, desca, B, 1, 1, descb, &eval_tmp[0], ztmp.at(memory_t::host), 1, 1, descz, &info);
 //==             if (info) {
 //==                 std::stringstream s;
 //==                 s << "libevs_gen_eig_cpu: info=" << info; 
@@ -2224,7 +2224,7 @@ std::unique_ptr<Eigensolver<T>> Eigensolver_factory(ev_solver_t ev_solver_type__
 //==             std::vector<double> eval_tmp(matrix_size);
 //== 
 //==             int info;
-//==             libevs_gen_eig('L', matrix_size, nevec, A, 1, 1, desca, B, 1, 1, descb, &eval_tmp[0], ztmp.at<CPU>(), 1, 1, descz, &info);
+//==             libevs_gen_eig('L', matrix_size, nevec, A, 1, 1, desca, B, 1, 1, descb, &eval_tmp[0], ztmp.at(memory_t::host), 1, 1, descz, &info);
 //==             if (info) {
 //==                 std::stringstream s;
 //==                 s << "libevs_gen_eig: info=" << info; 

--- a/src/mixer.hpp
+++ b/src/mixer.hpp
@@ -117,7 +117,7 @@ class Mixer // TODO: review mixer implementation, it's too obscure
             vectors_(i, ipos) = beta__ * input_buffer_(i) + (1 - beta__) * vectors_(i, ipos1);
         }
 
-        T* ptr = (this->output_buffer_.size() == 0) ? nullptr : this->output_buffer_.template at<CPU>();
+        T* ptr = (this->output_buffer_.size() == 0) ? nullptr : this->output_buffer_.template at(memory_t::host);
 
         /* collect shared data */
         comm_.allgather(&vectors_(0, ipos), ptr, spl_shared_size_.global_offset(), spl_shared_size_.local_size());
@@ -285,7 +285,7 @@ class Broyden1 : public Mixer<T>
             //    this->vectors_(i, i1) = this->input_buffer_(i);
             //}
 
-            // this->comm_.allgather(&this->vectors_(0, i1), this->output_buffer_.template at<CPU>(),
+            // this->comm_.allgather(&this->vectors_(0, i1), this->output_buffer_.template at(memory_t::host),
             //                      this->spl_shared_size_.global_offset(), this->spl_shared_size_.local_size());
             return 0.0;
         }
@@ -343,7 +343,7 @@ class Broyden1 : public Mixer<T>
                     S(j2, j1) = S(j1, j2) = t;
                 }
             }
-            this->comm_.allreduce(S.at<CPU>(), (int)S.size());
+            this->comm_.allreduce(S.at(memory_t::host), (int)S.size());
 
             // printf("[mixer] S matrix\n");
             // for (int i = 0; i < N; i++)
@@ -381,7 +381,7 @@ class Broyden1 : public Mixer<T>
                 }
                 c(j) = t;
             }
-            this->comm_.allreduce(c.at<CPU>(), (int)c.size());
+            this->comm_.allreduce(c.at(memory_t::host), (int)c.size());
 
             for (int j = 0; j < N; j++) {
                 double gamma = 0;
@@ -410,7 +410,7 @@ class Broyden1 : public Mixer<T>
                 this->vectors_(i, ipos) + this->beta_ * residuals_(i, ipos) + this->input_buffer_(i);
         }
 
-        T* ptr = (this->output_buffer_.size() == 0) ? nullptr : this->output_buffer_.template at<CPU>();
+        T* ptr = (this->output_buffer_.size() == 0) ? nullptr : this->output_buffer_.template at(memory_t::host);
 
         this->comm_.allgather(&this->vectors_(0, i1), ptr, this->spl_shared_size_.global_offset(),
                               this->spl_shared_size_.local_size());
@@ -521,7 +521,7 @@ class Broyden2 : public Mixer<T>
                     S(j2, j1) = S(j1, j2) = t;
                 }
             }
-            this->comm_.allreduce(S.at<CPU>(), (int)S.size());
+            this->comm_.allreduce(S.at(memory_t::host), (int)S.size());
             for (int j1 = 0; j1 < N; j1++) {
                 for (int j2 = 0; j2 < N; j2++) {
                     S(j1, j2) /= this->total_size_;

--- a/src/periodic_function.hpp
+++ b/src/periodic_function.hpp
@@ -144,7 +144,7 @@ class Periodic_function : public Smooth_periodic_function<T>
 
     inline void copy_to_global_ptr(T* f_mt__, T* f_it__) const
     {
-        std::memcpy(f_it__, this->f_rg_.template at(memory_t::host), this->fft_->local_size() * sizeof(T));
+        std::memcpy(f_it__, this->f_rg_.at(memory_t::host), this->fft_->local_size() * sizeof(T));
 
         if (ctx_.full_potential()) {
             mdarray<T, 3> f_mt(f_mt__, angular_domain_size_, unit_cell_.max_num_mt_points(), unit_cell_.num_atoms());

--- a/src/periodic_function.hpp
+++ b/src/periodic_function.hpp
@@ -144,7 +144,7 @@ class Periodic_function : public Smooth_periodic_function<T>
 
     inline void copy_to_global_ptr(T* f_mt__, T* f_it__) const
     {
-        std::memcpy(f_it__, this->f_rg_.template at<CPU>(), this->fft_->local_size() * sizeof(T));
+        std::memcpy(f_it__, this->f_rg_.template at(memory_t::host), this->fft_->local_size() * sizeof(T));
 
         if (ctx_.full_potential()) {
             mdarray<T, 3> f_mt(f_mt__, angular_domain_size_, unit_cell_.max_num_mt_points(), unit_cell_.num_atoms());

--- a/src/radial_grid.hpp
+++ b/src/radial_grid.hpp
@@ -161,10 +161,8 @@ class Radial_grid
 
     void copy_to_device()
     {
-        x_.allocate(memory_t::device);
-        x_.template copy<memory_t::host, memory_t::device>();
-        dx_.allocate(memory_t::device);
-        dx_.template copy<memory_t::host, memory_t::device>();
+        x_.allocate(memory_t::device).copy_to(memory_t::device);
+        dx_.allocate(memory_t::device).copy_to(memory_t::device);
     }
 
     mdarray<T, 1> const& x() const

--- a/src/simulation_context.hpp
+++ b/src/simulation_context.hpp
@@ -946,8 +946,8 @@ class Simulation_context : public Simulation_parameters
             utils::timer t2("sirius::Simulation_context::sum_fg_fl_yg|mul");
             switch (processing_unit()) {
                 case CPU: {
-                    linalg<CPU>::gemm(0, 0, lmmax, na, ngv_loc, zm.at<CPU>(), zm.ld(), phase_factors.at<CPU>(),
-                                      phase_factors.ld(), tmp.at<CPU>(), tmp.ld());
+                    linalg<CPU>::gemm(0, 0, lmmax, na, ngv_loc, zm.at(memory_t::host), zm.ld(), phase_factors.at(memory_t::host),
+                                      phase_factors.ld(), tmp.at(memory_t::host), tmp.ld());
                     break;
                 }
                 case GPU: {

--- a/src/simulation_context.hpp
+++ b/src/simulation_context.hpp
@@ -560,7 +560,7 @@ class Simulation_context : public Simulation_parameters
                     gvec_coord_(igloc, x) = G[x];
                 }
             }
-            gvec_coord_.copy<memory_t::host, memory_t::device>();
+            gvec_coord_.copy_to(memory_t::device);
         }
 #endif
         if (full_potential()) {
@@ -803,8 +803,8 @@ class Simulation_context : public Simulation_parameters
             case GPU: {
 #ifdef __GPU
                 acc::set_device();
-                generate_phase_factors_gpu(gvec().count(), na, gvec_coord().at<GPU>(),
-                                           unit_cell().atom_coord(iat__).at<GPU>(), phase_factors__.at<GPU>());
+                generate_phase_factors_gpu(gvec().count(), na, gvec_coord().at(memory_t::device),
+                                           unit_cell().atom_coord(iat__).at(memory_t::device), phase_factors__.at(memory_t::device));
 #else
                 TERMINATE_NO_GPU
 #endif
@@ -952,10 +952,10 @@ class Simulation_context : public Simulation_parameters
                 }
                 case GPU: {
 #if defined(__GPU)
-                    zm.copy<memory_t::host, memory_t::device>();
-                    linalg<GPU>::gemm(0, 0, lmmax, na, ngv_loc, zm.at<GPU>(), zm.ld(), phase_factors.at<GPU>(),
-                                      phase_factors.ld(), tmp.at<GPU>(), tmp.ld());
-                    tmp.copy<memory_t::device, memory_t::host>();
+                    zm.copy_to(memory_t::device);
+                    linalg<GPU>::gemm(0, 0, lmmax, na, ngv_loc, zm.at(memory_t::device), zm.ld(), phase_factors.at(memory_t::device),
+                                      phase_factors.ld(), tmp.at(memory_t::device), tmp.ld());
+                    tmp.copy_to(memory_t::host);
 #endif
                     break;
                 }

--- a/src/sirius_api.cpp
+++ b/src/sirius_api.cpp
@@ -2049,7 +2049,7 @@ void sirius_get_gvec_arrays(void* const* handler__,
         auto d2 = sim_ctx.fft().limits(2);
 
         mdarray<int, 3> index_by_gvec(index_by_gvec__, d0, d1, d2);
-        std::fill(index_by_gvec.at<CPU>(), index_by_gvec.at<CPU>() + index_by_gvec.size(), -1);
+        std::fill(index_by_gvec.at(memory_t::host), index_by_gvec.at(memory_t::host) + index_by_gvec.size(), -1);
 
         for (int ig = 0; ig < sim_ctx.gvec().num_gvec(); ig++) {
             auto G = sim_ctx.gvec().gvec(ig);

--- a/src/smooth_periodic_function.hpp
+++ b/src/smooth_periodic_function.hpp
@@ -59,7 +59,7 @@ class Smooth_periodic_function
     /// Gather plane-wave coefficients for the subsequent FFT call.
     inline void gather_f_pw_fft()
     {
-        gvecp_->gather_pw_fft(f_pw_local_.at<CPU>(), f_pw_fft_.at<CPU>());
+        gvecp_->gather_pw_fft(f_pw_local_.at(memory_t::host), f_pw_fft_.at(memory_t::host));
     }
 
   public:
@@ -165,16 +165,17 @@ class Smooth_periodic_function
         switch (direction__) {
             case 1: {
                 gather_f_pw_fft();
-                fft_->transform<1>(f_pw_fft_.at<CPU>());
-                fft_->output(f_rg_.template at<CPU>());
+                fft_->transform<1>(f_pw_fft_.at(memory_t::host));
+                fft_->output(f_rg_.at(memory_t::host));
                 break;
             }
             case -1: {
-                fft_->input(f_rg_.template at<CPU>());
-                fft_->transform<-1>(f_pw_fft_.at<CPU>());
+                fft_->input(f_rg_.at(memory_t::host));
+                fft_->transform<-1>(f_pw_fft_.at(memory_t::host));
                 int count  = gvecp_->gvec_fft_slab().counts[gvecp_->comm_ortho_fft().rank()];
                 int offset = gvecp_->gvec_fft_slab().offsets[gvecp_->comm_ortho_fft().rank()];
-                std::memcpy(f_pw_local_.at<CPU>(), f_pw_fft_.at<CPU>(offset), count * sizeof(double_complex));
+                std::memcpy(f_pw_local_.at(memory_t::host), f_pw_fft_.at(memory_t::host, offset),
+                            count * sizeof(double_complex));
                 break;
             }
             default: {

--- a/src/spline.hpp
+++ b/src/spline.hpp
@@ -278,11 +278,11 @@ class Spline : public Radial_grid<U>
         int ns = this->num_points();
         assert(ns >= 4);
         /* lower diagonal (use coeffs as temporary storage) */
-        T* dl = coeffs_.template at<CPU>(0, 1);
+        T* dl = coeffs_.at(memory_t::host, 0, 1);
         /* main diagonal */
-        T* d = coeffs_.template at<CPU>(0, 2);
+        T* d = coeffs_.at(memory_t::host, 0, 2);
         /* upper diagonal */
-        T* du = coeffs_.template at<CPU>(0, 3);
+        T* du = coeffs_.at(memory_t::host, 0, 3);
         /* m_i = 2 c_i */
         std::vector<T> m(ns);
         /* derivatives of function */


### PR DESCRIPTION
This is a continuation of the on-going refactoring. In this commit:

* remove templated .at<>() method of the mdarray class
* use stream_id wrapper for cuda- related calls