### PR TITLE
simplify i-pi integration / repair upf_to_json

### DIFF
--- a/apps/upf/upf2_to_json.py
+++ b/apps/upf/upf2_to_json.py
@@ -197,7 +197,7 @@ def parse_PAW(upf_dict, root):
 
     # ------ Read PP_PAW section: occupation, AE_NLCC, AE_VLOC
     node = root.findall("./PP_PAW")[0]
-    if 'core_energy' in node.attrib:
+    try:
         upf_dict['header']["paw_core_energy"] = float(
             node.attrib['core_energy']) / 2  # convert to Ha
     except KeyError:

--- a/python_module/CMakeLists.txt
+++ b/python_module/CMakeLists.txt
@@ -28,16 +28,28 @@ if(CREATE_PYTHON_MODULE)
 
   SIRIUS_SETUP_TARGET(${libname})
   # collect python files in module dir
-  file(GLOB_RECURSE _pyfiles "sirius/*.py")
   # install to cmake prefix
-  install(TARGETS ${libname}
-    LIBRARY
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages/sirius)
-  install(DIRECTORY sirius
-    DESTINATION
-    ${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages/
-    FILES_MATCHING REGEX
-    ".*py"
-    )
+
+  if(NOT PYTHON2)
+    install(TARGETS ${libname}
+      LIBRARY
+      DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages/sirius)
+    install(DIRECTORY sirius
+      DESTINATION
+      ${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages/
+      FILES_MATCHING REGEX
+      ".*py"
+      )
+  else()
+    # minimal support for Python 2.7, full functionality is provided for Python >3.5 only
+    install(TARGETS ${libname}
+      LIBRARY
+      DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages/sirius)
+    install(DIRECTORY sirius_minimal/
+      DESTINATION
+      ${CMAKE_INSTALL_PREFIX}/lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/site-packages/sirius
+      FILES_MATCHING REGEX
+      ".*py")
+  endif()
 
 endif(CREATE_PYTHON_MODULE)

--- a/python_module/sirius_minimal/__init__.py
+++ b/python_module/sirius_minimal/__init__.py
@@ -1,0 +1,1 @@
+from .py_sirius import *


### PR DESCRIPTION
- build only pybind11 interface for python2 and skip the rest
- upf_to_json2.py had a broken try,except statement
