### PR TITLE
ci: test on GPU and GPU + mpi_grid

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,44 @@ pipeline {
                            cat sirius-mc-tests.err
                            cat sirius-mc-tests.out
                            cp *.{out,err} ../
+                           '''
+                    }
+                }
+            }
+        }
+        stage('Test GPU') {
+            steps {
+                node('ssl_daintvm1') {
+                    dir('SIRIUS') {
+                        sh '''
+                           cd build
+                           export SIRIUS_BINARIES=$(realpath apps/dft_loop)
+                           type -f ${SIRIUS_BINARIES}/sirius.scf
+                           export ENVFILE=$(realpath ../ci/env-gnu-gpu)
+                           rm -f sirius-gpu-tests{.out,.err}
+                           sbatch --wait ../ci/run-gpu-verification.sh
+                           cat sirius-gpu-tests.err
+                           cat sirius-gpu-tests.out
+                           cp *.{out,err} ../
+                           '''
+                    }
+                }
+            }
+        }
+        stage('Test GPU Parallel') {
+            steps {
+                node('ssl_daintvm1') {
+                    dir('SIRIUS') {
+                        sh '''
+                           cd build
+                           export SIRIUS_BINARIES=$(realpath apps/dft_loop)
+                           type -f ${SIRIUS_BINARIES}/sirius.scf
+                           export ENVFILE=$(realpath ../ci/env-gnu-gpu)
+                           rm -f sirius-gpup-tests{.out,.err}
+                           sbatch --wait ../ci/run-gpup-verification.sh
+                           cat sirius-gpup-tests.err
+                           cat sirius-gpup-tests.out
+                           cp *.{out,err} ../
                            # delete some of the heavy directories
                            cd ../
                            rm -rf build verification examples
@@ -56,6 +94,7 @@ pipeline {
                 }
             }
         }
+
     }
 
     post {

--- a/ci/run-gpu-verification.sh
+++ b/ci/run-gpu-verification.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -l
+#SBATCH --job-name=sirius-gpu-tests
+#SBATCH --nodes=1
+#SBATCH --cpus-per-socket=6
+#SBATCH --constraint=gpu
+#SBATCH --partition=cscsci
+#SBATCH --time=00:20:00
+#SBATCH --output=sirius-gpu-tests.out
+#SBATCH --error=sirius-gpu-tests.err
+
+set -e
+
+source ${ENVFILE}
+
+(
+    export OMP_NUM_THREADS=2
+    module list
+    echo "run-gpu-verification: running on $(hostname)"
+    cd ../verification
+    ./run_tests_gpu.x
+)

--- a/ci/run-gpup-verification.sh
+++ b/ci/run-gpup-verification.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -l
+#SBATCH --job-name=sirius-gpup-tests
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=4
+#SBATCH --ntasks-per-core=3
+#SBATCH --constraint=gpu
+#SBATCH --partition=cscsci
+#SBATCH --time=00:20:00
+#SBATCH --output=sirius-gpup-tests.out
+#SBATCH --error=sirius-gpup-tests.err
+
+set -e
+
+source ${ENVFILE}
+
+(
+    export OMP_NUM_THREADS=3
+    module list
+    echo "run-gpup-verification: running on $(hostname)"
+    cd ../verification
+    ./run_tests_parallel_gpu.x
+)


### PR DESCRIPTION
Run verification also on GPU and in parallel. 

Currently stages have the following durations on daint:
Compile: 2min 52s
Test MC: 6min 22s
Test GPU: 5min 52s
Test GPU+mpi_grid: 1min 52s

It could make sense to use greasy to speed-up the MC / GPU single rank stages.
