### PR TITLE
Revert "switch to cmake for spglib"

### DIFF
--- a/prerequisite.py
+++ b/prerequisite.py
@@ -1,6 +1,5 @@
 import sys
 import os
-import shutil
 import tarfile
 import subprocess
 import json
@@ -52,7 +51,7 @@ def configure_package(package_name, prefix):
     cwdlibs = os.getcwd() + "/libs/"
 
     if not os.path.exists(cwdlibs):
-        os.mkdir(cwdlibs)
+        os.makedirs(cwdlibs)
 
     if (not os.path.exists("./libs/" + local_file_name)):
         try:
@@ -92,38 +91,30 @@ def configure_package(package_name, prefix):
 
     # spglib requires a special care
     if package_name == 'spg':
-        os.mkdir('./libs/_build')
-        p = subprocess.Popen(["cmake", "../" + package_dir, "-DCMAKE_INSTALL_PREFIX=" + prefix], cwd = './libs/_build', env = new_env)
+        p = subprocess.Popen(["aclocal"], cwd = "./libs/" + package_dir, env = new_env)
+        p.wait()
+        p = subprocess.Popen(["autoheader"], cwd = "./libs/" + package_dir, env = new_env)
+        p.wait()
+        if sys.platform == 'darwin':
+            p = subprocess.Popen(["glibtoolize"], cwd = "./libs/" + package_dir, env = new_env)
+        else:
+            p = subprocess.Popen(["libtoolize"], cwd = "./libs/" + package_dir, env = new_env)
+        p.wait()
+        p = subprocess.Popen(["touch", "INSTALL", "NEWS", "README", "AUTHORS"], cwd = "./libs/" + package_dir, env = new_env)
+        p.wait()
+        p = subprocess.Popen(["automake", "-acf"], cwd = "./libs/" + package_dir, env = new_env)
+        p.wait()
+        p = subprocess.Popen(["autoconf"], cwd = "./libs/" + package_dir, env = new_env)
         p.wait()
 
-        #p = subprocess.Popen(["aclocal"], cwd = "./libs/" + package_dir, env = new_env)
-        #p.wait()
-        #p = subprocess.Popen(["autoheader"], cwd = "./libs/" + package_dir, env = new_env)
-        #p.wait()
-        #if sys.platform == 'darwin':
-        #    p = subprocess.Popen(["glibtoolize"], cwd = "./libs/" + package_dir, env = new_env)
-        #else:
-        #    p = subprocess.Popen(["libtoolize"], cwd = "./libs/" + package_dir, env = new_env)
-        #p.wait()
-        #p = subprocess.Popen(["touch", "INSTALL", "NEWS", "README", "AUTHORS"], cwd = "./libs/" + package_dir, env = new_env)
-        #p.wait()
-        #p = subprocess.Popen(["automake", "-acf"], cwd = "./libs/" + package_dir, env = new_env)
-        #p.wait()
-        #p = subprocess.Popen(["autoconf"], cwd = "./libs/" + package_dir, env = new_env)
-        #p.wait()
-        p = subprocess.Popen(["make", "install"], cwd = './libs/_build', env = new_env)
-        p.wait()
-        shutil.rmtree('./libs/_build')
-        os.makedirs(prefix + '/include/spglib', exist_ok=True)
-        shutil.copyfile(prefix + '/include/spglib.h', prefix + '/include/spglib/spglib.h')
-    else:
-        cmd = ["./configure"] + package["options"] + ["--prefix=%s"%prefix]
-        p = subprocess.Popen(cmd, cwd = "./libs/" + package_dir, env = new_env)
-        p.wait()
-        p = subprocess.Popen(["make"], cwd = "./libs/" + package_dir, env = new_env)
-        p.wait()
-        p = subprocess.Popen(["make", "install"], cwd = "./libs/" + package_dir, env = new_env)
-        p.wait()
+
+    cmd = ["./configure"] + package["options"] + ["--prefix=%s"%prefix]
+    p = subprocess.Popen(cmd, cwd = "./libs/" + package_dir, env = new_env)
+    p.wait()
+    p = subprocess.Popen(["make"], cwd = "./libs/" + package_dir, env = new_env)
+    p.wait()
+    p = subprocess.Popen(["make", "install"], cwd = "./libs/" + package_dir, env = new_env)
+    p.wait()
 
 
 def main():


### PR DESCRIPTION
This reverts commit c544aa63b8872db45d9946470ffca680d43272ba.
spglib cmake is not consistent with current easybuild scripts (include/spglib)
and with package managers (archlinux/fedora).
Wait with using spglib cmake until paths used by spglib are consistent between
autotools and cmake.