### PR TITLE
Misc fixes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ if(USE_CUDA)
 endif()
 if(CREATE_FORTRAN_BINDINGS)
   add_library(sirius_f "sirius_api.cpp;sirius.f90")
-  add_dependencies(sirius_f generate_version_hpp runtime_options_json_hpp)
+  SIRIUS_SETUP_TARGET(sirius_f)
   INSTALL (TARGETS sirius_f ARCHIVE DESTINATION
     ${CMAKE_INSTALL_PREFIX}/lib/)
   set_target_properties(sirius_f PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/src/Unit_cell/unit_cell_symmetry.hpp
+++ b/src/Unit_cell/unit_cell_symmetry.hpp
@@ -26,7 +26,7 @@
 #define __UNIT_CELL_SYMMETRY_HPP__
 
 extern "C" {
-#include <spglib/spglib.h>
+#include <spglib.h>
 }
 
 #include "geometry3d.hpp"


### PR DESCRIPTION
While RedHat seems to install the `spglib` header into its own subdirectory, `spglib` does not seem to do that by itself when simply using `make install`. Distros (including Spack) which follow upstream would currently have to patch SIRIUS to locate the `spglib.h` properly.

The second issue occurs when trying to link dynamically against `libsirius_f.so` (obtain with with CMake's `-DBUILD_SHARED_LIBS=ON`): at this point the linker complains about undefined symbols due to missing linker flags when building the library.

This information will also be needed if you at some point should provide CMake package config/version files for discovering SIRIUS (and the required flags in case of static linking) via CMake (via the CMake functions `configure_package_config_file` and `write_basic_package_version_file`, see for example [DBCSR](https://github.com/cp2k/dbcsr/blob/develop/src/CMakeLists.txt#L284-L300))