### PR TITLE
 cmake library install paths, add missing stuff

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,22 +244,23 @@ include_directories(BEFORE ${PROJECT_BINARY_DIR}/src)
 
 MACRO(SIRIUS_SETUP_TARGET _target)
   if(USE_CUDA)
-    add_dependencies(${_target} sirius_cu)
+    add_dependencies(${_target} sirius)
   endif()
 
   add_dependencies(${_target} generate_version_hpp)
   add_dependencies(${_target} runtime_options_json_hpp)
 
+  target_link_libraries(${_target} PRIVATE "${sirius_location};${SYSTEM_LIBRARIES};${HDF5_C_LIBRARIES};${HDF5_C_HL_LIBRARIES}")
   if(USE_MKL)
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-      target_link_libraries(${_target} PRIVATE "${sirius_cu_location};${SYSTEM_LIBRARIES};${HDF5_C_LIBRARIES};${HDF5_C_HL_LIBRARIES};-Wl,--no-as-needed;${MKL_LIBRARIES}")
+      target_link_libraries(${_target} PRIVATE "-Wl,--no-as-needed;${MKL_LIBRARIES}")
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")
-      target_link_libraries(${_target} PRIVATE "${sirius_cu_location};${SYSTEM_LIBRARIES};${MKL_LIBRARIES};${HDF5_C_LIBRARIES};${HDF5_C_HL_LIBRARIES}")
+      target_link_libraries(${_target} PRIVATE "${MKL_LIBRARIES}")
     else()
       message(FATAL_ERROR "Unsupported compiler")
     endif()
   else()
-    target_link_libraries(${_target} PRIVATE "${SYSTEM_LIBRARIES};${LAPACK_LIBRARIES};${FFTW_LIBRARIES};${HDF5_C_LIBRARIES};${HDF5_C_HL_LIBRARIES}")
+    target_link_libraries(${_target} PRIVATE "${LAPACK_LIBRARIES};${FFTW_LIBRARIES}")
   endif()
 
   if(USE_ROCM)
@@ -280,7 +281,7 @@ ENDMACRO()
 # sirius library
 add_subdirectory(src)
 if(USE_CUDA)
-  set(sirius_cu_location $<TARGET_FILE:sirius_cu>)
+  set(sirius_location $<TARGET_FILE:sirius>)
 endif()
 
 # applications

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,19 +13,18 @@ endif()
 if(USE_CUDA)
   file(GLOB_RECURSE CUFILES_SDDK "SDDK/*.cu")
   file(GLOB_RECURSE CUFILES_KERNELS "Kernels/*.cu")
-  set(_CUSOURCES "${CUFILES_KERNELS};${CUFILES_KERNELS}")
+  set(_CUSOURCES "${CUFILES_KERNELS};${CUFILES_SDDK}")
 endif()
 
 
 if(CREATE_FORTRAN_BININGS OR USE_CUDA)
-  add_library(sirius STATIC "${_FSOURCES};${_CUSOURCES}")
+  add_library(sirius STATIC "${_CUSOURCES};${_FSOURCES}")
+  set_target_properties(sirius PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  set_target_properties(sirius PROPERTIES Fortran_MODULE_DIRECTORY mod_files)
   INSTALL (TARGETS sirius ARCHIVE DESTINATION
     ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
     )
-
-  set_target_properties(sirius PROPERTIES POSITION_INDEPENDENT_CODE ON)
-  set_target_properties(sirius PROPERTIES Fortran_MODULE_DIRECTORY mod_files)
   target_link_libraries(sirius PUBLIC OpenMP::OpenMP_CXX)
 
 endif()


### PR DESCRIPTION
bugfix for accidentally merged PR #382

fortran mod file goes into `include/sirius/`,

move `libsirius_cu.a` into `libsirius.a`