### PR TITLE
optimize jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,8 @@ pipeline {
                            cat build-daint-gpu.out
                            echo "---------- build-daint-gpu.err ----------"
                            cat build-daint-gpu.err
+                           # check that sirius.scf has been built
+                           type -f apps/dft_loop/sirius.scf
                            '''
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,12 +45,9 @@ pipeline {
                            export SIRIUS_BINARIES=$(realpath apps/dft_loop)
                            type -f ${SIRIUS_BINARIES}/sirius.scf
                            export ENVFILE=$(realpath ../ci/env-gnu-gpu)
-                           rm -f sirius-mc-tests.out
-                           rm -rf sirius-mc-tests.err
                            sbatch --wait ../ci/run-mc-verification.sh
                            cat sirius-mc-tests.err
                            cat sirius-mc-tests.out
-                           cp *.{out,err} ../
                            '''
                         }
                     }
@@ -63,11 +60,9 @@ pipeline {
                            export SIRIUS_BINARIES=$(realpath apps/dft_loop)
                            type -f ${SIRIUS_BINARIES}/sirius.scf
                            export ENVFILE=$(realpath ../ci/env-gnu-gpu)
-                           rm -f sirius-gpu-tests{.out,.err}
                            sbatch --wait ../ci/run-gpu-verification.sh
                            cat sirius-gpu-tests.err
                            cat sirius-gpu-tests.out
-                           cp *.{out,err} ../
                            '''
                         }
                     }
@@ -80,12 +75,9 @@ pipeline {
                            export SIRIUS_BINARIES=$(realpath apps/dft_loop)
                            type -f ${SIRIUS_BINARIES}/sirius.scf
                            export ENVFILE=$(realpath ../ci/env-gnu-gpu)
-                           rm -f sirius-mcp-tests{.out,.err}
                            sbatch --wait ../ci/run-mcp-verification.sh
                            cat sirius-mcp-tests.err
                            cat sirius-mcp-tests.out
-                           cp *.{out,err} ../
-                           # delete some of the heavy directories
                            cd ../
                            '''
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
                            echo "---------- build-daint-gpu.err ----------"
                            cat build-daint-gpu.err
                            # check that sirius.scf has been built
-                           type -f apps/dft_loop/sirius.scf
+                           type -f build/apps/dft_loop/sirius.scf
                            '''
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,30 +67,36 @@ pipeline {
                         }
                     }
                 }
-                stage('Test MC Parallel') {
-                    steps {
-                        dir('SIRIUS') {
-                            sh '''
-                           cd build
-                           export SIRIUS_BINARIES=$(realpath apps/dft_loop)
-                           type -f ${SIRIUS_BINARIES}/sirius.scf
-                           export ENVFILE=$(realpath ../ci/env-gnu-gpu)
-                           sbatch --wait ../ci/run-mcp-verification.sh
-                           cat sirius-mcp-tests.err
-                           cat sirius-mcp-tests.out
-                           cd ../
-                           '''
-                        }
-                    }
-                }
+                // stage('Test MC Parallel') {
+                //     steps {
+                //         dir('SIRIUS') {
+                //             sh '''
+                //            cd build
+                //            export SIRIUS_BINARIES=$(realpath apps/dft_loop)
+                //            type -f ${SIRIUS_BINARIES}/sirius.scf
+                //            export ENVFILE=$(realpath ../ci/env-gnu-gpu)
+                //            sbatch --wait ../ci/run-mcp-verification.sh
+                //            cat sirius-mcp-tests.err
+                //            cat sirius-mcp-tests.out
+                //            cd ../
+                //            '''
+                //         }
+                //     }
+                // }
             }
         }
     }
 
     post {
         always {
-                archiveArtifacts artifacts: '**/*.out', fingerprint: true
-                archiveArtifacts artifacts: '**/*.err', fingerprint: true
+            // dir('SIRIUS') {
+            //     sh '''
+            //        # delete heavy directories
+            //        rm -rf  build verification examples
+            //        '''
+            // }
+            archiveArtifacts artifacts: '**/*.out', fingerprint: true
+            archiveArtifacts artifacts: '**/*.err', fingerprint: true
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,26 +72,25 @@ pipeline {
                         }
                     }
                 }
-                // stage('Test GPU Parallel') {
-                //     steps {
-                //         dir('SIRIUS') {
-                //             sh '''
-                //            cd build
-                //            export SIRIUS_BINARIES=$(realpath apps/dft_loop)
-                //            type -f ${SIRIUS_BINARIES}/sirius.scf
-                //            export ENVFILE=$(realpath ../ci/env-gnu-gpu)
-                //            rm -f sirius-gpup-tests{.out,.err}
-                //            sbatch --wait ../ci/run-gpup-verification.sh
-                //            cat sirius-gpup-tests.err
-                //            cat sirius-gpup-tests.out
-                //            cp *.{out,err} ../
-                //            # delete some of the heavy directories
-                //            cd ../
-                //            rm -rf build verification examples
-                //            '''
-                //         }
-                //     }
-                // }
+                stage('Test MC Parallel') {
+                    steps {
+                        dir('SIRIUS') {
+                            sh '''
+                           cd build
+                           export SIRIUS_BINARIES=$(realpath apps/dft_loop)
+                           type -f ${SIRIUS_BINARIES}/sirius.scf
+                           export ENVFILE=$(realpath ../ci/env-gnu-gpu)
+                           rm -f sirius-mcp-tests{.out,.err}
+                           sbatch --wait ../ci/run-mcp-verification.sh
+                           cat sirius-mcp-tests.err
+                           cat sirius-mcp-tests.out
+                           cp *.{out,err} ../
+                           # delete some of the heavy directories
+                           cd ../
+                           '''
+                        }
+                    }
+                }
             }
         }
     }

--- a/ci/build-daint-gpu.sh
+++ b/ci/build-daint-gpu.sh
@@ -23,5 +23,6 @@ mkdir -p build
           -DCMAKE_BUILD_TYPE=RELWITHDEBINFO \
           -DCREATE_PYTHON_MODULE=On \
           ../
+    make clean
     make -j VERBOSE=1
 ) && echo "build successful"

--- a/ci/run-gpu-verification.sh
+++ b/ci/run-gpu-verification.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -l
 #SBATCH --job-name=sirius-gpu-tests
 #SBATCH --nodes=1
-#SBATCH --cpus-per-socket=6
 #SBATCH --constraint=gpu
 #SBATCH --partition=cscsci
 #SBATCH --time=00:20:00

--- a/ci/run-mcp-verification.sh
+++ b/ci/run-mcp-verification.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -l
+#SBATCH --job-name=sirius-mcp-tests
+#SBATCH --nodes=1
+#SBATCH --cpus-per-task=4
+#SBATCH --constraint=gpu
+#SBATCH --partition=cscsci
+#SBATCH --time=00:20:00
+#SBATCH --output=sirius-mcp-tests.out
+#SBATCH --error=sirius-mcp-tests.err
+
+set -e
+
+source ${ENVFILE}
+
+(
+    export OMP_NUM_THREADS=2
+    module list
+    echo "run-mc-parallel-verification: running on $(hostname)"
+    cd ../verification
+    ./run_tests_parallel.x
+)

--- a/python_module/sirius/__init__.py
+++ b/python_module/sirius/__init__.py
@@ -1,12 +1,12 @@
 from .helpers import *
 from .coefficient_array import *
 from .py_sirius import *
-from .py_sirius import K_point_set
+from .py_sirius import K_point_set, Density
 from .logger import Logger
 from .operators import S_operator
 import numpy as np
 from numpy import array, zeros
-__all__ = ["ot", "baarman", "bands", "edft", "marzari"]
+__all__ = ["ot", "baarman", "bands", "edft"]
 
 
 class OccupancyDescriptor(object):
@@ -85,7 +85,32 @@ class BandEnergiesDescriptor(object):
         instance.sync_band_energies()
 
 
+class DensityDescriptor(object):
+    def __init__(self, i):
+        self.i = i
+
+    def __get__(self, instance, owner):
+        return np.array(instance.f_pw_local(self.i))
+
+    def __set__(self, instance, value):
+        instance.f_pw_local(self.i)[:] = value
+
+
+class DensityMatrixDescriptor(object):
+    def __get__(self, instance, owner):
+        return np.array(instance.density_matrix())
+
+    def __set__(self, instance, value):
+        instance.density_matrix()[:] = value
+
+
 K_point_set.fn = OccupancyDescriptor()
 K_point_set.C = PWDescriptor()
 K_point_set.w = KPointWeightDescriptor()
 K_point_set.e = BandEnergiesDescriptor()
+
+Density.rho = DensityDescriptor(0)
+Density.mx = DensityDescriptor(1)
+Density.my = DensityDescriptor(2)
+Density.mz = DensityDescriptor(3)
+Density.dm = DensityMatrixDescriptor()

--- a/src/field4d.hpp
+++ b/src/field4d.hpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <array>
 #include <cassert>
+#include <stdexcept>
 
 namespace sirius {
 
@@ -84,6 +85,15 @@ class Field4D
     Periodic_function<double>& component(int i)
     {
         assert(i >= 0 && i <= 3);
+        return *(components_[i]);
+    }
+
+    /// Throws error in case of invalid access.
+    Periodic_function<double>& component_raise(int i)
+    {
+        if (components_[i] == nullptr) {
+            throw std::runtime_error("invalid access");
+        }
         return *(components_[i]);
     }
 

--- a/verification/run_tests_parallel.x
+++ b/verification/run_tests_parallel.x
@@ -31,7 +31,7 @@ for f in ./*; do
                 echo "'${f}' failed"
                 exit ${err}
             fi
-        )
+        ) || exit ${err}
     fi
 done
 


### PR DESCRIPTION
Jenkins:
- request daint node only once, run test mc/gpu/gpup stages in parallel
- run scalapack tests on CPU

Python:
- added python accessors for density coefficients/density matrix
- added `Field4d::components_raise` (same as `Field4D::compoentents(int)`, but throws on invalid access) to prevent segfaults when giving wrong arguments in python.
