### PR TITLE
Disactivated the mpi version of libvdwxc. This needs proper fixing in…

### DIFF
--- a/src/Potential/xc_functional.hpp
+++ b/src/Potential/xc_functional.hpp
@@ -116,11 +116,11 @@ namespace sirius {
                 if (fft.comm().size() == 1) {
                     vdwxc_init_serial(handler_vdw_);
                 } else {
-#if VDWXC_FFTW_MPI == 1
-                    vdwxc_init_mpi(handler_vdw_, fft.comm().mpi_comm());
-#else
+//#if VDWXC_FFTW_MPI
+//                    vdwxc_init_mpi(handler_vdw_, fft.comm().mpi_comm());
+//#else
                     vdwxc_init_serial(handler_vdw_);
-#endif
+//#endif
                 }
                 vdw_functional_ = true;
                 return;


### PR DESCRIPTION
We never compile SIRIUS with libvdwxc present by default but CP2K does. libvdwxc supports fftw-mpi but there is currently no way to know at compilation time (SIRIUS) which means I can not use their constants to know about it.
This problem can be solved on our side by checking the presence of vdwxc_init_mpi in the library or by fixing the library itself. Right now I simply deactivate the mpi support in libvdwxc

