### PR TITLE
reliably check for MPI support of libvdwxc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,10 @@ MACRO(SIRIUS_SETUP_TARGET _target)
     target_link_libraries(${_target} PUBLIC OpenMP::OpenMP_CXX)
   endif()
 
+  if(HAVE_LIBVDW_WITH_MPI)
+    target_compile_definitions(${_target} PUBLIC -D__HAVE_VDWXC_MPI)
+  endif()
+
   # target_link_libraries(${_target} PRIVATE GSL::gsl)
 
   if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")

--- a/cmake/modules/FindLibVDWXC.cmake
+++ b/cmake/modules/FindLibVDWXC.cmake
@@ -2,6 +2,7 @@
 # if in non-standard location set environment variabled `VDWCXC_DIR` to the root directory
 
 include(FindPackageHandleStandardArgs)
+include(CheckSymbolExists)
 find_package(PkgConfig REQUIRED)
 
 pkg_search_module(_LIBVDWXC libvdwxc>=${LibVDWXC_FIND_VERSION})
@@ -26,5 +27,9 @@ find_library(LIBVDWXC_LIBRARIES
   ENV VDWXCROOT
   ${_LIBVDWXC_LIBRARY_DIRS}
   DOC "vdwxc libraries list")
+
+# try linking in C (C++ fails because vdwxc_mpi.h includes mpi.h inside extern "C"{...})
+set(CMAKE_REQUIRED_LIBRARIES "${LIBVDWXC_LIBRARIES}")
+check_symbol_exists(vdwxc_init_mpi "${LIBVDWXC_INCLUDE_DIR}/vdwxc_mpi.h" HAVE_LIBVDW_WITH_MPI)
 
 find_package_handle_standard_args(LibVDWXC DEFAULT_MSG LIBVDWXC_LIBRARIES LIBVDWXC_INCLUDE_DIR)

--- a/python_module/py_sirius.cpp
+++ b/python_module/py_sirius.cpp
@@ -387,7 +387,6 @@ PYBIND11_MODULE(py_sirius, m)
              [](py::object& obj) -> py::array_t<complex_double> {
                  Density& density = obj.cast<Density&>();
                  auto& dm         = density.density_matrix();
-                 int sz           = sizeof(complex_double);
                  if (dm.at(memory_t::host) == nullptr) {
                      throw std::runtime_error("trying to access null pointer");
                  }

--- a/src/Potential/xc_functional.hpp
+++ b/src/Potential/xc_functional.hpp
@@ -31,7 +31,7 @@
 #include "SDDK/fft3d.hpp"
 #ifdef USE_VDWXC
 #include <vdwxc.h>
-#if VDWXC_FFTW_MPI == 1
+#if __HAVE_VDWXC_MPI
 #include <vdwxc_mpi.h>
 #endif
 #endif
@@ -116,7 +116,7 @@ namespace sirius {
                 if (fft.comm().size() == 1) {
                     vdwxc_init_serial(handler_vdw_);
                 } else {
-#if VDWXC_FFTW_MPI == 1
+#if __HAVE_VDWXC_MPI
                     vdwxc_init_mpi(handler_vdw_, fft.comm().mpi_comm());
 #else
                     vdwxc_init_serial(handler_vdw_);


### PR DESCRIPTION
- added call to `check_symbol_exsists` in cmake
- call `vdwxc_init_mpi` or `vdw_init_serial` depending on the detected version in cmake