### PR TITLE
make cuda run on cpu-only hosts

### DIFF
--- a/src/SDDK/GPU/acc.hpp
+++ b/src/SDDK/GPU/acc.hpp
@@ -203,6 +203,7 @@ std::vector<acc_stream_t>& streams();
 /// Return a single device stream.
 inline acc_stream_t stream(stream_id sid__)
 {
+    assert(sid__() < int(streams().size()));
     return (sid__() == -1) ? NULL : streams()[sid__()];
 }
 

--- a/src/SDDK/wf_ortho.cpp
+++ b/src/SDDK/wf_ortho.cpp
@@ -233,8 +233,11 @@ void orthogonalize(memory_t mem__, linalg_t la__, int ispn__, std::vector<Wave_f
                 }
             }
         }
-        for (int i = 0; i < sid; i++) {
-            acc::sync_stream(stream_id(i));
+        if (la__ == linalg_t::gpublas || la__ == linalg_t::cublasxt || la__ == linalg_t::magma) {
+            // sync stream only if processing unit is gpu
+            for (int i = 0; i < sid; i++) {
+                acc::sync_stream(stream_id(i));
+            }
         }
         t2.stop();
     } else { /* parallel transformation */


### PR DESCRIPTION
Current develop with CUDA enabled suddenly crashed on hosts that have no gpu or had it disabled by `export CUDA_VISIBLE_DEVICES=`.  
