### PR TITLE
cuda 10: get rid of deprecated warning (devicePtr check)

### DIFF
--- a/src/SDDK/GPU/acc.hpp
+++ b/src/SDDK/GPU/acc.hpp
@@ -487,7 +487,7 @@ inline bool check_device_ptr(void const* ptr__)
     if (error != cudaSuccess) {
         return false;
     }
-    if (attr.memoryType == cudaMemoryTypeDevice) {
+    if (attr.devicePointer) {
         return true;
     }
     return false;


### PR DESCRIPTION
memoryType attribute is deprecated, check if devicePtr is null instead.