### PR TITLE
More logic in density generation

### DIFF
--- a/python_module/py_sirius.cpp
+++ b/python_module/py_sirius.cpp
@@ -233,7 +233,7 @@ PYBIND11_MODULE(py_sirius, m)
         .def_property_readonly("num_atoms", [](const Atom_type& atype) { return atype.num_atoms(); });
 
     py::class_<Unit_cell>(m, "Unit_cell")
-        .def("add_atom_type", &Unit_cell::add_atom_type)
+        .def("add_atom_type", &Unit_cell::add_atom_type, py::return_value_policy::reference)
         .def("add_atom", py::overload_cast<const std::string, std::vector<double>>(&Unit_cell::add_atom))
         .def("atom", py::overload_cast<int>(&Unit_cell::atom), py::return_value_policy::reference)
         .def("atom_type", py::overload_cast<int>(&Unit_cell::atom_type), py::return_value_policy::reference)

--- a/src/Band/diag_pseudo_potential.cpp
+++ b/src/Band/diag_pseudo_potential.cpp
@@ -428,13 +428,7 @@ Band::diag_pseudo_potential_davidson(Hamiltonian_k& Hk__) const
             }
         };
 
-        //std::vector<double> eval(num_bands);
-        //std::vector<double> eval_old(num_bands, 1e100);
-
         if (itso.init_eval_old_) {
-            //for (int j = 0; j < num_bands; j++) {
-            //    eval_old[j] = kp__->band_energy(j, ispin_step);
-            //}
             eval_old = [&](int64_t j) {return kp.band_energy(j, ispin_step);};
         }
 
@@ -465,8 +459,6 @@ Band::diag_pseudo_potential_davidson(Hamiltonian_k& Hk__) const
          * N is the number of previous basis functions
          * n is the number of new basis functions */
         set_subspace_mtrx(0, num_bands, phi, hphi, hmlt, &hmlt_old);
-        /* setup overlap matrix */
-       // set_subspace_mtrx(0, num_bands, phi, sphi, ovlp, &ovlp_old);
 
         if (ctx_.control().verification_ >= 1) {
             double max_diff = check_hermitian(hmlt, num_bands);
@@ -475,13 +467,6 @@ Band::diag_pseudo_potential_davidson(Hamiltonian_k& Hk__) const
                 s << "H matrix is not hermitian, max_err = " << max_diff;
                 WARNING(s);
             }
-            //max_diff = check_hermitian(ovlp, num_bands);
-            //if (max_diff > 1e-12) {
-            //    std::stringstream s;
-            //    s << "S matrix is not hermitian, max_err = " << max_diff;
-            //    WARNING(s);
-            //}
-
         }
         //if (ctx_.control().verification_ >= 2 && ctx_.control().verbosity_ >= 2) {
         //    hmlt.serialize("H matrix", num_bands);

--- a/src/Density/density.cpp
+++ b/src/Density/density.cpp
@@ -1759,6 +1759,8 @@ void Density::mixer_init(Mixer_input mixer_cfg__)
 
 void Density::mixer_input()
 {
+    PROFILE("sirius::Density::mixer_input");
+
     mixer_->set_input<0>(component(0));
     if (ctx_.num_mag_dims() > 0) {
         mixer_->set_input<1>(component(1));
@@ -1777,6 +1779,8 @@ void Density::mixer_input()
 
 void Density::mixer_output()
 {
+    PROFILE("sirius::Density::mixer_output");
+
     mixer_->get_output<0>(component(0));
     if (ctx_.num_mag_dims() > 0) {
         mixer_->get_output<1>(component(1));
@@ -1809,6 +1813,8 @@ void Density::mixer_output()
 
 double Density::mix()
 {
+    PROFILE("sirius::Density::mix");
+
     mixer_input();
     double rms = mixer_->mix(ctx_.settings().mixer_rms_min_);
     mixer_output();

--- a/src/Density/density.cpp
+++ b/src/Density/density.cpp
@@ -1798,17 +1798,6 @@ void Density::mixer_output()
 
     /* transform mixed density to plane-wave domain */
     this->fft_transform(-1);
-
-
-    //if (ctx_.full_potential()) { // TODO: this seems to be useless; why it is here? remove after tests
-    //    /* split real-space points between available ranks */
-    //    splindex<splindex_t::block> spl_np(ctx_.spfft().local_slice_size(), ctx_.comm_ortho_fft().size(),
-    //                                       ctx_.comm_ortho_fft().rank());
-    //    for (int j = 0; j < ctx_.num_mag_dims() + 1; j++) {
-    //        ctx_.comm_ortho_fft().allgather(&component(j).f_rg(0), spl_np.global_offset(), spl_np.local_size());
-    //        component(j).sync_mt();
-    //    }
-    //}
 }
 
 double Density::mix()

--- a/src/Density/density.cpp
+++ b/src/Density/density.cpp
@@ -1792,6 +1792,10 @@ void Density::mixer_output()
         mixer_->get_output<5>(paw_density_);
     }
 
+    /* transform mixed density to plane-wave domain */
+    this->fft_transform(-1);
+
+
     //if (ctx_.full_potential()) { // TODO: this seems to be useless; why it is here? remove after tests
     //    /* split real-space points between available ranks */
     //    splindex<splindex_t::block> spl_np(ctx_.spfft().local_slice_size(), ctx_.comm_ortho_fft().size(),

--- a/src/Density/paw_density.hpp
+++ b/src/Density/paw_density.hpp
@@ -1,0 +1,109 @@
+// Copyright (c) 2013-2019 Anton Kozhevnikov, Thomas Schulthess
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+// the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+//    following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/** \file paw_density.hpp
+ *
+ *  \brief Contains definition and implementation of helper class sirius::paw_density.
+ */
+
+#ifndef __PAW_DENSITY_HPP__
+#define __PAW_DENSITY_HPP__
+
+namespace sirius {
+
+class paw_density
+{
+  private:
+    Simulation_context* ctx_{nullptr};
+    sddk::mdarray<Spheric_function<function_domain_t::spectral, double>, 2> ae_density_;
+    sddk::mdarray<Spheric_function<function_domain_t::spectral, double>, 2> ps_density_;
+    std::vector<int> atoms_;
+
+    paw_density(paw_density const& src__) = delete;
+    paw_density& operator=(paw_density const& src__) = delete;
+
+  public:
+    paw_density()
+    {
+    }
+
+    paw_density(Simulation_context& ctx__)
+        : ctx_(&ctx__)
+    {
+        auto& uc = ctx__.unit_cell();
+        if (!uc.num_paw_atoms()) {
+            return;
+        }
+
+        using sf = Spheric_function<function_domain_t::spectral, double>;
+
+        ae_density_ = sddk::mdarray<sf, 2>(ctx__.num_mag_dims() + 1, uc.spl_num_paw_atoms().local_size());
+        ps_density_ = sddk::mdarray<sf, 2>(ctx__.num_mag_dims() + 1, uc.spl_num_paw_atoms().local_size());
+
+        for (int i = 0; i < uc.spl_num_paw_atoms().local_size(); i++) {
+            int ia_paw      = uc.spl_num_paw_atoms(i);
+            int ia          = uc.paw_atom_index(ia_paw);
+            auto& atom      = uc.atom(ia);
+            auto& atom_type = atom.type();
+
+            int l_max      = 2 * atom_type.indexr().lmax_lo();
+            int lm_max_rho = utils::lmmax(l_max);
+
+            atoms_.push_back(ia);
+
+            /* allocate density arrays */
+            for (int j = 0; j < ctx__.num_mag_dims() + 1; j++) {
+                ae_density_(j, i) = sf(lm_max_rho, atom.radial_grid());
+                ps_density_(j, i) = sf(lm_max_rho, atom.radial_grid());
+            }
+        }
+    }
+
+    paw_density(paw_density&& src__) = default;
+    paw_density& operator=(paw_density&& src__) = default;
+
+    Spheric_function<function_domain_t::spectral, double>& ae_density(int i, int j)
+    {
+        return ae_density_(i, j);
+    }
+
+    Spheric_function<function_domain_t::spectral, double> const& ae_density(int i, int j) const
+    {
+        return ae_density_(i, j);
+    }
+
+    Spheric_function<function_domain_t::spectral, double>& ps_density(int i, int j)
+    {
+        return ps_density_(i, j);
+    }
+
+    Spheric_function<function_domain_t::spectral, double> const& ps_density(int i, int j) const
+    {
+        return ps_density_(i, j);
+    }
+
+    Simulation_context const& ctx() const
+    {
+        return *ctx_;
+    }
+};
+
+} // namespace sirius
+
+#endif

--- a/src/Mixer/mixer.hpp
+++ b/src/Mixer/mixer.hpp
@@ -57,7 +57,8 @@ struct FunctionProperties
      *  \param [in]  axpy_         Function, which scales and adds one object to the other (y = alpha * x + y).
      */
     FunctionProperties(std::function<double(const FUNC&)> size_,
-                       std::function<double(const FUNC&, const FUNC&)> inner_, std::function<void(double, FUNC&)> scal_,
+                       std::function<double(const FUNC&, const FUNC&)> inner_,
+                       std::function<void(double, FUNC&)> scal_,
                        std::function<void(const FUNC&, FUNC&)> copy_,
                        std::function<void(double, const FUNC&, FUNC&)> axpy_)
         : size(size_)

--- a/src/Mixer/mixer_functions.cpp
+++ b/src/Mixer/mixer_functions.cpp
@@ -38,8 +38,7 @@ FunctionProperties<Periodic_function<double>> periodic_function_property()
     };
 
     auto inner_prod_func = [](const Periodic_function<double>& x, const Periodic_function<double>& y) -> double {
-        return sirius::inner(static_cast<Smooth_periodic_function<double> const&>(x),
-                             static_cast<Smooth_periodic_function<double> const&>(y));
+        return sirius::inner(x, y);
     };
 
     auto scal_function = [](double alpha, Periodic_function<double>& x) -> void {

--- a/src/Mixer/mixer_functions.cpp
+++ b/src/Mixer/mixer_functions.cpp
@@ -143,6 +143,46 @@ FunctionProperties<sddk::mdarray<double_complex, 4>> density_function_property()
                                                                 copy_function, axpy_function);
 }
 
+FunctionProperties<paw_density> paw_density_function_property()
+{
+    auto global_size_func = [](paw_density const& x) -> double { return x.ctx().unit_cell().num_paw_atoms(); };
+
+    auto inner_prod_func = []( paw_density const& x,  paw_density const& y) -> double {
+        // do not contribute to mixing
+        return 0.0;
+    };
+
+    auto scal_function = [](double alpha, paw_density& x) -> void {
+        for (int i = 0; i < x.ctx().unit_cell().spl_num_paw_atoms().local_size(); i++) {
+            for (int j = 0; j < x.ctx().num_mag_dims() + 1; j++) {
+                x.ae_density(j, i) *= alpha;
+                x.ps_density(j, i) *= alpha;
+            }
+        }
+    };
+
+    auto copy_function = [](paw_density const& x, paw_density& y) -> void {
+        for (int i = 0; i < x.ctx().unit_cell().spl_num_paw_atoms().local_size(); i++) {
+            for (int j = 0; j < x.ctx().num_mag_dims() + 1; j++) {
+                x.ae_density(j, i) >> y.ae_density(j, i);
+                x.ps_density(j, i) >> y.ps_density(j, i);
+            }
+        }
+    };
+
+    auto axpy_function = [](double alpha, paw_density const& x, paw_density& y) -> void {
+        for (int i = 0; i < x.ctx().unit_cell().spl_num_paw_atoms().local_size(); i++) {
+            for (int j = 0; j < x.ctx().num_mag_dims() + 1; j++) {
+                y.ae_density(j, i) = x.ae_density(j, i) * alpha + y.ae_density(j, i);
+                y.ps_density(j, i) = x.ps_density(j, i) * alpha + y.ps_density(j, i);
+            }
+        }
+    };
+
+    return FunctionProperties<paw_density>(global_size_func, inner_prod_func, scal_function, copy_function,
+                                           axpy_function);
+}
+
 } // namespace mixer
 
 } // namespace sirius

--- a/src/Mixer/mixer_functions.hpp
+++ b/src/Mixer/mixer_functions.hpp
@@ -28,6 +28,7 @@
 #include "periodic_function.hpp"
 #include "SDDK/memory.hpp"
 #include "Mixer/mixer.hpp"
+#include "Density/paw_density.hpp"
 
 namespace sirius {
 
@@ -36,6 +37,8 @@ namespace mixer {
 FunctionProperties<Periodic_function<double>> periodic_function_property();
 
 FunctionProperties<sddk::mdarray<double_complex, 4>> density_function_property();
+
+FunctionProperties<paw_density> paw_density_function_property();
 
 } // namespace mixer
 

--- a/src/Potential/paw_potential.cpp
+++ b/src/Potential/paw_potential.cpp
@@ -35,13 +35,13 @@ void Potential::init_PAW()
 
     for (int i = 0; i < unit_cell_.spl_num_paw_atoms().local_size(); i++) {
         int ia_paw = unit_cell_.spl_num_paw_atoms(i);
-        int ia = unit_cell_.paw_atom_index(ia_paw);
+        int ia     = unit_cell_.paw_atom_index(ia_paw);
 
         auto& atom = unit_cell_.atom(ia);
 
         auto& atom_type = atom.type();
 
-        int l_max = 2 * atom_type.indexr().lmax_lo();
+        int l_max      = 2 * atom_type.indexr().lmax_lo();
         int lm_max_rho = utils::lmmax(l_max);
 
         paw_potential_data_t ppd;
@@ -64,14 +64,14 @@ void Potential::init_PAW()
     }
 
     for (int i = 0; i < unit_cell_.num_paw_atoms(); i++) {
-        int ia = unit_cell_.paw_atom_index(i);
-        int bs = unit_cell_.atom(ia).mt_basis_size();
+        int ia              = unit_cell_.paw_atom_index(i);
+        int bs              = unit_cell_.atom(ia).mt_basis_size();
         max_paw_basis_size_ = std::max(max_paw_basis_size_, bs);
     }
 
     /* initialize dij matrix */
-    paw_dij_ = mdarray<double, 4>(max_paw_basis_size_, max_paw_basis_size_, ctx_.num_mag_dims() + 1, unit_cell_.num_paw_atoms(),
-                                  memory_t::host, "paw_dij_");
+    paw_dij_ = mdarray<double, 4>(max_paw_basis_size_, max_paw_basis_size_, ctx_.num_mag_dims() + 1,
+                                  unit_cell_.num_paw_atoms(), memory_t::host, "paw_dij_");
 
     /* allocate PAW energy array */
     paw_hartree_energies_.resize(unit_cell_.num_paw_atoms());
@@ -97,14 +97,13 @@ void Potential::generate_PAW_effective_potential(Density const& density)
     paw_dij_.zero();
 
     /* calculate xc and hartree for atoms */
-    for(int i = 0; i < unit_cell_.spl_num_paw_atoms().local_size(); i++) {
+    for (int i = 0; i < unit_cell_.spl_num_paw_atoms().local_size(); i++) {
         calc_PAW_local_potential(paw_potential_data_[i], density.paw_ae_density(i), density.paw_ps_density(i));
     }
 
-
     /* calculate PAW Dij matrix */
     #pragma omp parallel for
-    for(int i = 0; i < unit_cell_.spl_num_paw_atoms().local_size(); i++) {
+    for (int i = 0; i < unit_cell_.spl_num_paw_atoms().local_size(); i++) {
         calc_PAW_local_Dij(paw_potential_data_[i], paw_dij_);
 
         calc_PAW_one_elec_energy(paw_potential_data_[i], density.density_matrix(), paw_dij_);
@@ -124,19 +123,19 @@ void Potential::generate_PAW_effective_potential(Density const& density)
     // calc total energy
     double energies[] = {0.0, 0.0, 0.0, 0.0};
 
-    for(int ia = 0; ia < unit_cell_.spl_num_paw_atoms().local_size(); ia++) {
+    for (int ia = 0; ia < unit_cell_.spl_num_paw_atoms().local_size(); ia++) {
         energies[0] += paw_potential_data_[ia].hartree_energy_;
         energies[1] += paw_potential_data_[ia].xc_energy_;
         energies[2] += paw_potential_data_[ia].one_elec_energy_;
-        energies[3] += paw_potential_data_[ia].core_energy_;  // it is light operation
+        energies[3] += paw_potential_data_[ia].core_energy_; // it is light operation
     }
 
     comm_.allreduce(&energies[0], 4);
 
     paw_hartree_total_energy_ = energies[0];
-    paw_xc_total_energy_ = energies[1];
-    paw_one_elec_energy_ = energies[2];
-    paw_total_core_energy_ = energies[3];
+    paw_xc_total_energy_      = energies[1];
+    paw_one_elec_energy_      = energies[2];
+    paw_total_core_energy_    = energies[3];
 }
 
 double Potential::xc_mt_PAW_nonmagnetic(sf& full_potential, sf const& full_density, std::vector<double> const& rho_core)
@@ -151,11 +150,11 @@ double Potential::xc_mt_PAW_nonmagnetic(sf& full_potential, sf const& full_densi
     full_rho_lm_sf_new.zero();
     full_rho_lm_sf_new += full_density;
 
-    double invY00 = 1.0 / y00 ;
+    double invY00 = 1.0 / y00;
 
     /* adding core part */
     for (int ir = 0; ir < rgrid.num_points(); ir++) {
-        full_rho_lm_sf_new(0,ir) += invY00 * rho_core[ir];
+        full_rho_lm_sf_new(0, ir) += invY00 * rho_core[ir];
     }
 
     auto full_rho_tp_sf = transform(*sht_, full_rho_lm_sf_new);
@@ -171,7 +170,7 @@ double Potential::xc_mt_PAW_nonmagnetic(sf& full_potential, sf const& full_densi
     full_potential += transform(*sht_, vxc_tp_sf);
 
     /* calculate energy */
-    auto exc_lm_sf = transform(*sht_, exc_tp_sf );
+    auto exc_lm_sf = transform(*sht_, exc_tp_sf);
 
     return inner(exc_lm_sf, full_rho_lm_sf_new);
 }
@@ -192,8 +191,8 @@ double Potential::xc_mt_PAW_collinear(std::vector<sf>& potential, std::vector<sf
     double invY00 = 1 / y00;
 
     /* adding core part */
-    for (int ir = 0; ir < rgrid.num_points(); ir++ ) {
-        full_rho_lm_sf_new(0,ir) += invY00 * rho_core[ir];
+    for (int ir = 0; ir < rgrid.num_points(); ir++) {
+        full_rho_lm_sf_new(0, ir) += invY00 * rho_core[ir];
     }
 
     /* calculate spin up spin down density components in lm components */
@@ -223,17 +222,16 @@ double Potential::xc_mt_PAW_collinear(std::vector<sf>& potential, std::vector<sf
     //------------------------
     //--- calculate energy ---
     //------------------------
-    Spheric_function<function_domain_t::spectral, double> exc_lm_sf = transform(*sht_, exc_tp_sf );
+    Spheric_function<function_domain_t::spectral, double> exc_lm_sf = transform(*sht_, exc_tp_sf);
 
     return inner(exc_lm_sf, full_rho_lm_sf_new);
 }
 
-
 double Potential::xc_mt_PAW_noncollinear(std::vector<sf>& potential, std::vector<sf const*> density,
                                          std::vector<double> const& rho_core)
 {
-    if (density.size() != 4 || potential.size() != 4){
-       TERMINATE("xc_mt_PAW_noncollinear FATAL ERROR!")
+    if (density.size() != 4 || potential.size() != 4) {
+        TERMINATE("xc_mt_PAW_noncollinear FATAL ERROR!")
     }
 
     Radial_grid<double> const& rgrid = density[0]->radial_grid();
@@ -241,7 +239,7 @@ double Potential::xc_mt_PAW_noncollinear(std::vector<sf>& potential, std::vector
     /* transform density to theta phi components */
     std::vector<Spheric_function<function_domain_t::spatial, double>> rho_tp(density.size());
 
-    for (size_t i = 0; i < density.size(); i++){
+    for (size_t i = 0; i < density.size(); i++) {
         rho_tp[i] = transform(*sht_, *density[i]);
     }
 
@@ -249,8 +247,8 @@ double Potential::xc_mt_PAW_noncollinear(std::vector<sf>& potential, std::vector
     Spheric_function<function_domain_t::spatial, double> rho_u_tp(sht_->num_points(), rgrid);
     Spheric_function<function_domain_t::spatial, double> rho_d_tp(sht_->num_points(), rgrid);
 
-    for (int ir = 0; ir < rgrid.num_points(); ir++ ) {
-        for (int itp = 0; itp < sht_->num_points(); itp++ ) {
+    for (int ir = 0; ir < rgrid.num_points(); ir++) {
+        for (int itp = 0; itp < sht_->num_points(); itp++) {
             vector3d<double> magn({rho_tp[2](itp, ir), rho_tp[3](itp, ir), rho_tp[1](itp, ir)});
             double norm = magn.length();
 
@@ -277,13 +275,13 @@ double Potential::xc_mt_PAW_noncollinear(std::vector<sf>& potential, std::vector
     std::vector<Spheric_function<function_domain_t::spatial, double>> vxc_tp;
 
     /* allocate the rest */
-    for (size_t i = 0; i < potential.size(); i++){
+    for (size_t i = 0; i < potential.size(); i++) {
         vxc_tp.push_back(Spheric_function<function_domain_t::spatial, double>(sht_->num_points(), rgrid));
     }
 
     /* transform back potential from up/down to 4D form*/
-    for (int ir = 0; ir < rgrid.num_points(); ir++ ) {
-        for (int itp = 0; itp < sht_->num_points(); itp++ ) {
+    for (int ir = 0; ir < rgrid.num_points(); ir++) {
+        for (int itp = 0; itp < sht_->num_points(); itp++) {
             /* get total potential and field abs value*/
             double pot   = 0.5 * (vxc_u_tp(itp, ir) + vxc_d_tp(itp, ir));
             double field = 0.5 * (vxc_u_tp(itp, ir) - vxc_d_tp(itp, ir));
@@ -291,18 +289,18 @@ double Potential::xc_mt_PAW_noncollinear(std::vector<sf>& potential, std::vector
             /* get unit magnetization vector*/
             vector3d<double> magn({rho_tp[2](itp, ir), rho_tp[3](itp, ir), rho_tp[1](itp, ir)});
             double norm = magn.length();
-            magn = magn * (norm > 0.0 ? field / norm : 0.0);
+            magn        = magn * (norm > 0.0 ? field / norm : 0.0);
 
             /* add total potential and effective field values at current point */
             vxc_tp[0](itp, ir) = pot;
-            for (int i: {0, 1, 2}) {
+            for (int i : {0, 1, 2}) {
                 vxc_tp[i + 1](itp, ir) = magn[i];
             }
         }
     }
 
     /* transform back to lm- domain */
-    for(size_t i = 0; i < density.size(); i++){
+    for (size_t i = 0; i < density.size(); i++) {
         potential[i] += transform(*sht_, vxc_tp[i]);
     }
 
@@ -332,27 +330,27 @@ double Potential::calc_PAW_hartree_potential(Atom& atom, sf const& full_density,
     auto l_by_lm = utils::l_by_lm(utils::lmax(lmsize_rho));
 
     /* create array for integration */
-    std::vector<double> intdata(grid.num_points(),0);
+    std::vector<double> intdata(grid.num_points(), 0);
 
     double hartree_energy{0};
 
-    for (int lm=0; lm < lmsize_rho; lm++){
+    for (int lm = 0; lm < lmsize_rho; lm++) {
         /* fill data to integrate */
-        for (int irad = 0; irad < grid.num_points(); irad++){
-            intdata[irad] = full_density(lm,irad) * full_potential(lm, irad) * grid[irad] * grid[irad];
+        for (int irad = 0; irad < grid.num_points(); irad++) {
+            intdata[irad] = full_density(lm, irad) * full_potential(lm, irad) * grid[irad] * grid[irad];
         }
 
         /* create spline from the data */
-        Spline<double> h_spl(grid,intdata);
+        Spline<double> h_spl(grid, intdata);
         hartree_energy += 0.5 * h_spl.integrate(0);
     }
 
     return hartree_energy;
 }
 
-void Potential::calc_PAW_local_potential(paw_potential_data_t &ppd,
-                                         std::vector<Spheric_function<function_domain_t::spectral, double> const*> ae_density,
-                                         std::vector<Spheric_function<function_domain_t::spectral, double> const*> ps_density)
+void Potential::calc_PAW_local_potential(
+    paw_potential_data_t& ppd, std::vector<Spheric_function<function_domain_t::spectral, double> const*> ae_density,
+    std::vector<Spheric_function<function_domain_t::spectral, double> const*> ps_density)
 {
     /* calculation of Hartree potential */
     for (int i = 0; i < ctx_.num_mag_dims() + 1; i++) {
@@ -360,13 +358,9 @@ void Potential::calc_PAW_local_potential(paw_potential_data_t &ppd,
         ppd.ps_potential_[i].zero();
     }
 
-    double ae_hartree_energy = calc_PAW_hartree_potential(*ppd.atom_,
-                                                          *ae_density[0],
-                                                          ppd.ae_potential_[0]);
+    double ae_hartree_energy = calc_PAW_hartree_potential(*ppd.atom_, *ae_density[0], ppd.ae_potential_[0]);
 
-    double ps_hartree_energy = calc_PAW_hartree_potential(*ppd.atom_,
-                                                          *ps_density[0],
-                                                          ppd.ps_potential_[0]);
+    double ps_hartree_energy = calc_PAW_hartree_potential(*ppd.atom_, *ps_density[0], ppd.ps_potential_[0]);
 
     ppd.hartree_energy_ = ae_hartree_energy - ps_hartree_energy;
 
@@ -390,13 +384,13 @@ void Potential::calc_PAW_local_potential(paw_potential_data_t &ppd,
             break;
         }
 
-        case 3:{
+        case 3: {
             ae_xc_energy = xc_mt_PAW_noncollinear(ppd.ae_potential_, ae_density, ae_core);
             ps_xc_energy = xc_mt_PAW_noncollinear(ppd.ps_potential_, ps_density, ps_core);
             break;
         }
 
-        default:{
+        default: {
             TERMINATE("PAW local potential error! Wrong number of spins!")
         }
     }
@@ -415,7 +409,7 @@ void Potential::calc_PAW_local_Dij(paw_potential_data_t& pdd, mdarray<double, 4>
     auto& paw_ps_wfs = atom_type.ps_paw_wfs_array();
 
     /* get lm size for density */
-    int lmax = atom_type.indexr().lmax_lo();
+    int lmax       = atom_type.indexr().lmax_lo();
     int lmsize_rho = utils::lmmax(2 * lmax);
 
     auto l_by_lm = utils::l_by_lm(2 * lmax);
@@ -423,17 +417,18 @@ void Potential::calc_PAW_local_Dij(paw_potential_data_t& pdd, mdarray<double, 4>
     Gaunt_coefficients<double> GC(lmax, 2 * lmax, lmax, SHT::gaunt_rlm);
 
     /* store integrals here */
-    mdarray<double, 3> integrals(lmsize_rho, atom_type.num_beta_radial_functions() * (atom_type.num_beta_radial_functions() + 1) / 2,
-                                 ctx_.num_mag_dims() + 1);
+    mdarray<double, 3> integrals(
+        lmsize_rho, atom_type.num_beta_radial_functions() * (atom_type.num_beta_radial_functions() + 1) / 2,
+        ctx_.num_mag_dims() + 1);
 
     auto& rgrid = atom_type.radial_grid();
 
-    for(int imagn = 0; imagn < ctx_.num_mag_dims() + 1; imagn++ ){
-        auto &ae_atom_pot = pdd.ae_potential_[imagn];
-        auto &ps_atom_pot = pdd.ps_potential_[imagn];
+    for (int imagn = 0; imagn < ctx_.num_mag_dims() + 1; imagn++) {
+        auto& ae_atom_pot = pdd.ae_potential_[imagn];
+        auto& ps_atom_pot = pdd.ps_potential_[imagn];
 
-        for (int irb2 = 0; irb2 < atom_type.num_beta_radial_functions(); irb2++){
-            for (int irb1 = 0; irb1 <= irb2; irb1++){
+        for (int irb2 = 0; irb2 < atom_type.num_beta_radial_functions(); irb2++) {
+            for (int irb1 = 0; irb1 <= irb2; irb1++) {
                 int iqij = (irb2 * (irb2 + 1)) / 2 + irb1;
 
                 /* create array for integration */
@@ -475,9 +470,9 @@ void Potential::calc_PAW_local_Dij(paw_potential_data_t& pdd, mdarray<double, 4>
             int iqij = (irb2 * (irb2 + 1)) / 2 + irb1;
 
             /* get num of non-zero GC */
-            int num_non_zero_gk = GC.num_gaunt(lm1,lm2);
+            int num_non_zero_gk = GC.num_gaunt(lm1, lm2);
 
-            for (int imagn = 0; imagn < ctx_.num_mag_dims() + 1; imagn++ ){
+            for (int imagn = 0; imagn < ctx_.num_mag_dims() + 1; imagn++) {
                 /* add nonzero coefficients */
                 for (int inz = 0; inz < num_non_zero_gk; inz++) {
                     auto& lm3coef = GC.gaunt(lm1, lm2, inz);
@@ -494,21 +489,20 @@ void Potential::calc_PAW_local_Dij(paw_potential_data_t& pdd, mdarray<double, 4>
     }
 }
 
-double Potential::calc_PAW_one_elec_energy(paw_potential_data_t& pdd,
-                                                  const mdarray<double_complex, 4>& density_matrix,
-                                                  const mdarray<double, 4>& paw_dij)
+double Potential::calc_PAW_one_elec_energy(paw_potential_data_t& pdd, const mdarray<double_complex, 4>& density_matrix,
+                                           const mdarray<double, 4>& paw_dij)
 {
-    int ia = pdd.ia;
+    int ia      = pdd.ia;
     int paw_ind = pdd.ia_paw;
 
     double_complex energy = 0.0;
 
-    for (int ib2 = 0; ib2 < pdd.atom_->mt_lo_basis_size(); ib2++ ) {
-        for (int ib1 = 0; ib1 < pdd.atom_->mt_lo_basis_size(); ib1++ ) {
-            double dm[4]={0,0,0,0};
+    for (int ib2 = 0; ib2 < pdd.atom_->mt_lo_basis_size(); ib2++) {
+        for (int ib1 = 0; ib1 < pdd.atom_->mt_lo_basis_size(); ib1++) {
+            double dm[4] = {0, 0, 0, 0};
             switch (ctx_.num_mag_dims()) {
                 case 3: {
-                    dm[2] =  2 * std::real(density_matrix(ib1, ib2, 2, ia));
+                    dm[2] = 2 * std::real(density_matrix(ib1, ib2, 2, ia));
                     dm[3] = -2 * std::imag(density_matrix(ib1, ib2, 2, ia));
                 }
                 case 1: {
@@ -520,12 +514,12 @@ double Potential::calc_PAW_one_elec_energy(paw_potential_data_t& pdd,
                     dm[0] = density_matrix(ib1, ib2, 0, ia).real();
                     break;
                 }
-                default:{
+                default: {
                     TERMINATE("calc_PAW_one_elec_energy FATAL ERROR!");
                     break;
                 }
             }
-            for (int imagn = 0; imagn < ctx_.num_mag_dims() + 1; imagn++ ){
+            for (int imagn = 0; imagn < ctx_.num_mag_dims() + 1; imagn++) {
                 energy += dm[imagn] * paw_dij(ib1, ib2, imagn, paw_ind);
             }
         }
@@ -533,7 +527,7 @@ double Potential::calc_PAW_one_elec_energy(paw_potential_data_t& pdd,
 
     if (std::abs(energy.imag()) > 1e-10) {
         std::stringstream s;
-        s << "PAW energy is not real: "<< energy;
+        s << "PAW energy is not real: " << energy;
         TERMINATE(s.str());
     }
 
@@ -546,13 +540,13 @@ void Potential::add_paw_Dij_to_atom_Dmtrx()
 {
     #pragma omp parallel for
     for (int i = 0; i < unit_cell_.num_paw_atoms(); i++) {
-        int ia = unit_cell_.paw_atom_index(i);
+        int ia     = unit_cell_.paw_atom_index(i);
         auto& atom = unit_cell_.atom(ia);
 
-        for (int imagn = 0; imagn < ctx_.num_mag_dims() + 1; imagn++ ){
+        for (int imagn = 0; imagn < ctx_.num_mag_dims() + 1; imagn++) {
             for (int ib2 = 0; ib2 < atom.mt_lo_basis_size(); ib2++) {
                 for (int ib1 = 0; ib1 < atom.mt_lo_basis_size(); ib1++) {
-                     atom.d_mtrx(ib1, ib2, imagn) += paw_dij_(ib1, ib2, imagn, i);
+                    atom.d_mtrx(ib1, ib2, imagn) += paw_dij_(ib1, ib2, imagn, i);
                 }
             }
         }

--- a/src/Potential/potential.hpp
+++ b/src/Potential/potential.hpp
@@ -38,6 +38,10 @@ namespace sirius {
 class Potential : public Field4D
 {
   private:
+
+    /* Alias for spherical functions */
+    using sf = Spheric_function<function_domain_t::spectral, double>;
+
     Unit_cell& unit_cell_;
 
     Communicator const& comm_;
@@ -111,8 +115,8 @@ class Potential : public Field4D
 
         int ia_paw{-1};
 
-        std::vector<Spheric_function<function_domain_t::spectral, double>> ae_potential_;
-        std::vector<Spheric_function<function_domain_t::spectral, double>> ps_potential_;
+        std::vector<sf> ae_potential_;
+        std::vector<sf> ps_potential_;
 
         double hartree_energy_{0.0};
         double xc_energy_{0.0};
@@ -146,8 +150,6 @@ class Potential : public Field4D
     double scale_rho_xc_{1};
 
     void init_PAW();
-
-    using sf = Spheric_function<function_domain_t::spectral, double>;
 
     double xc_mt_PAW_nonmagnetic(sf& full_potential, sf const& full_density, std::vector<double> const& rho_core);
 

--- a/src/Potential/potential.hpp
+++ b/src/Potential/potential.hpp
@@ -147,31 +147,25 @@ class Potential : public Field4D
 
     void init_PAW();
 
-    double xc_mt_PAW_nonmagnetic(Spheric_function<function_domain_t::spectral, double>&       full_potential,
-                                 Spheric_function<function_domain_t::spectral, double> const& full_density,
-                                 std::vector<double> const&                rho_core);
+    using sf = Spheric_function<function_domain_t::spectral, double>;
 
-    double xc_mt_PAW_collinear(std::vector<Spheric_function<function_domain_t::spectral, double>>&       potential,
-                               std::vector<Spheric_function<function_domain_t::spectral, double>> const& density,
-                               std::vector<double> const&                             rho_core);
+    double xc_mt_PAW_nonmagnetic(sf& full_potential, sf const& full_density, std::vector<double> const& rho_core);
 
-    double xc_mt_PAW_noncollinear(std::vector<Spheric_function<function_domain_t::spectral, double>>&       potential,
-                                  std::vector<Spheric_function<function_domain_t::spectral, double>> const& density,
-                                  std::vector<double> const&                             rho_core);
+    double xc_mt_PAW_collinear(std::vector<sf>& potential, std::vector<sf const*> density,
+                               std::vector<double> const& rho_core);
 
-    void calc_PAW_local_potential(paw_potential_data_t&                                  pdd,
-                                  std::vector<Spheric_function<function_domain_t::spectral, double>> const& ae_density,
-                                  std::vector<Spheric_function<function_domain_t::spectral, double>> const& ps_density);
+    double xc_mt_PAW_noncollinear(std::vector<sf>& potential, std::vector<sf const*> density,
+                                  std::vector<double> const& rho_core);
+
+    void calc_PAW_local_potential(paw_potential_data_t& pdd, std::vector<sf const*> ae_density,
+                                  std::vector<sf const*> ps_density);
 
     void calc_PAW_local_Dij(paw_potential_data_t& pdd, mdarray<double, 4>& paw_dij);
 
-    double calc_PAW_hartree_potential(Atom&                                     atom,
-                                      Spheric_function<function_domain_t::spectral, double> const& full_density,
-                                      Spheric_function<function_domain_t::spectral, double>&       full_potential);
+    double calc_PAW_hartree_potential(Atom& atom, sf const& full_density, sf& full_potential);
 
-    double calc_PAW_one_elec_energy(paw_potential_data_t&             pdd,
-                                    const mdarray<double_complex, 4>& density_matrix,
-                                    const mdarray<double, 4>&         paw_dij);
+    double calc_PAW_one_elec_energy(paw_potential_data_t& pdd, mdarray<double_complex, 4> const& density_matrix,
+                                    mdarray<double, 4> const& paw_dij);
 
     void add_paw_Dij_to_atom_Dmtrx();
 

--- a/src/Potential/xc.cpp
+++ b/src/Potential/xc.cpp
@@ -397,7 +397,7 @@ void Potential::xc_mt(Density const& density__)
                     /* compute magnitude of the magnetization vector */
                     double mag = 0.0;
                     for (int j = 0; j < ctx_.num_mag_dims(); j++) {
-                        mag += pow(vecmagtp[j](itp, ir), 2);
+                        mag += std::pow(vecmagtp[j](itp, ir), 2);
                     }
                     mag = std::sqrt(mag);
 

--- a/src/SDDK/memory.hpp
+++ b/src/SDDK/memory.hpp
@@ -1393,7 +1393,14 @@ class mdarray
     //==     }
     //== }
 
-    /// Copy the content of the array to dest
+    /// Copy the content of the array to another array of identical size.
+    /** For example:
+        \code{.cpp}
+        mdarray<double, 2> src(10, 20);
+        mdarray<double, 2> dest(10, 20);
+        src >> dest;
+        \endcode
+     */
     void operator>>(mdarray<T, N>& dest__) const
     {
         for (int i = 0; i < N; i++) {

--- a/src/SDDK/wf_trans.cpp
+++ b/src/SDDK/wf_trans.cpp
@@ -251,12 +251,13 @@ void transform(memory_t mem__, linalg_t la__, int ispn__, double alpha__, std::v
                                 local_size_row * sizeof(T));
                 }
             }
-            time_mpi -= MPI::Wtime();
+            auto t = std::chrono::high_resolution_clock::now();
             PROFILE_START("sddk::transform|mpi");
             /* collect submatrix */
             comm.allgather(&buf[0], sd.counts.data(), sd.offsets.data());
             PROFILE_STOP("sddk::transform|mpi");
-            time_mpi += MPI::Wtime();
+            auto dt = std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::high_resolution_clock::now() - t).count();
+            time_mpi += dt;
 
             if (is_device_memory(mem__)) {
                 /* wait for the data copy; as soon as this is done, CPU buffer is free and can be reused */

--- a/src/Unit_cell/atom.hpp
+++ b/src/Unit_cell/atom.hpp
@@ -214,7 +214,6 @@ class Atom
             utils::timer t1("sirius::Atom::generate_radial_integrals|interp");
             #pragma omp parallel
             {
-                // int tid = Platform::thread_id();
                 #pragma omp for
                 for (int i = 0; i < nrf; i++) {
                     rf_spline[i].interpolate();

--- a/src/Unit_cell/unit_cell.hpp
+++ b/src/Unit_cell/unit_cell.hpp
@@ -210,7 +210,7 @@ class Unit_cell
     /// Add PAW atoms.
     void init_paw();
 
-    /// Return number of PAW atoms.
+    /// Return number of atoms with PAW pseudopotential.
     int num_paw_atoms() const
     {
         return static_cast<int>(paw_atom_index_.size());
@@ -227,6 +227,7 @@ class Unit_cell
         return spl_num_paw_atoms_[idx__];
     }
 
+    /// Return global index of atom by the index in the list of PAW atoms.
     inline int paw_atom_index(int ipaw__) const
     {
         return paw_atom_index_[ipaw__];

--- a/src/dft_ground_state.cpp
+++ b/src/dft_ground_state.cpp
@@ -320,9 +320,6 @@ json DFT_ground_state::find(double rms_tol, double energy_tol, double initial_to
         /* mix density */
         rms = density_.mix();
 
-        /* transform mixed density to plane-wave domain */
-        density_.fft_transform(-1);
-
         double old_tol = ctx_.iterative_solver_tolerance();
         /* estimate new tolerance of iterative solver */
         double tol = std::min(ctx_.settings().itsol_tol_scale_[0] * rms, ctx_.settings().itsol_tol_scale_[1] * old_tol);

--- a/src/dft_ground_state.cpp
+++ b/src/dft_ground_state.cpp
@@ -320,6 +320,9 @@ json DFT_ground_state::find(double rms_tol, double energy_tol, double initial_to
         /* mix density */
         rms = density_.mix();
 
+        /* transform mixed density to plane-wave domain */
+        density_.fft_transform(-1);
+
         double old_tol = ctx_.iterative_solver_tolerance();
         /* estimate new tolerance of iterative solver */
         double tol = std::min(ctx_.settings().itsol_tol_scale_[0] * rms, ctx_.settings().itsol_tol_scale_[1] * old_tol);

--- a/src/field4d.cpp
+++ b/src/field4d.cpp
@@ -24,9 +24,6 @@
 
 #include "field4d.hpp"
 #include "periodic_function.hpp"
-#include "Mixer/mixer.hpp"
-#include "Mixer/mixer_functions.hpp"
-#include "Mixer/mixer_factory.hpp"
 #include "Symmetry/symmetrize.hpp"
 
 namespace sirius {

--- a/src/field4d.hpp
+++ b/src/field4d.hpp
@@ -29,7 +29,6 @@
 #include <array>
 #include <cassert>
 #include <stdexcept>
-#include "Mixer/mixer.hpp"
 #include "SDDK/memory.hpp"
 #include "typedefs.hpp"
 
@@ -42,7 +41,7 @@ namespace sirius {
 // forward declarations
 class Simulation_context;
 template<class> class Periodic_function;
-class Mixer_input;
+//class Mixer_input;
 
 class Field4D
 {

--- a/src/spheric_function.hpp
+++ b/src/spheric_function.hpp
@@ -35,7 +35,8 @@ namespace sirius {
 
 /// Function in spherical harmonics or spherical coordinates representation.
 /** This class works in conjugation with SHT class which provides the transformation between spherical
- *  harmonics and spherical coordinates and also a conversion between real and complex spherical harmonics. */
+    harmonics and spherical coordinates and also a conversion between real and complex spherical harmonics.
+ */
 template <function_domain_t domain_t, typename T = double_complex>
 class Spheric_function: public mdarray<T, 2>
 {
@@ -109,6 +110,18 @@ class Spheric_function: public mdarray<T, 2>
         for (int i1 = 0; i1 < (int)this->size(1); i1++) {
             for (int i0 = 0; i0 < (int)this->size(0); i0++) {
                 (*this)(i0, i1) += rhs__(i0, i1);
+            }
+        }
+
+        return *this;
+    }
+
+    /// Multiply by a constant.
+    inline Spheric_function<domain_t, T>& operator*=(double alpha__)
+    {
+        for (int i1 = 0; i1 < (int)this->size(1); i1++) {
+            for (int i0 = 0; i0 < (int)this->size(0); i0++) {
+                (*this)(i0, i1) *= alpha__;
             }
         }
 
@@ -336,9 +349,10 @@ T inner(Spheric_function<domain_t, T> const& f1, Spheric_function<domain_t, T> c
 
 /// Compute Laplacian of the spheric function.
 /** Laplacian in spherical coordinates has the following expression:
- *  \f[
- *      \Delta = \frac{1}{r^2}\frac{\partial}{\partial r}\Big( r^2 \frac{\partial}{\partial r} \Big) + \frac{1}{r^2}\Delta_{\theta, \phi}
- *  \f]
+    \f[
+    \Delta = \frac{1}{r^2}\frac{\partial}{\partial r}\Big( r^2 \frac{\partial}{\partial r} \Big) +
+      \frac{1}{r^2}\Delta_{\theta, \phi}
+    \f]
  */
 template <typename T>
 Spheric_function<function_domain_t::spectral, T> laplacian(Spheric_function<function_domain_t::spectral, T> const& f__)

--- a/src/utils/timer.hpp
+++ b/src/utils/timer.hpp
@@ -174,7 +174,6 @@ class timer
         static std::map<std::string, timer> ftimers__;
         return ftimers__;
     }
-
 };
 
 /// Triggers the creation of the global timer.

--- a/verification/test02/sirius.json
+++ b/verification/test02/sirius.json
@@ -3,10 +3,10 @@
         "processing_unit" : "cpu",
         "std_evp_solver_type" : "lapack",
         "gen_evp_solver_type" : "lapack",
-        "verbosity" : 5,
+        "verbosity" : 1,
         "print_forces" : false,
         "print_stress" : false,
-        "print_checksum" : true
+        "print_checksum" : false
     },
 
     "parameters" : {

--- a/verification/test18/sirius.json
+++ b/verification/test18/sirius.json
@@ -52,8 +52,8 @@
     }
   },
   "mixer": {
-    "max_history": 10,
-    "beta": 0.9,
+    "max_history": 4,
+    "beta": 0.5,
     "type": "broyden1",
     "!linear_mix_rms_tol": 20.0,
     "!beta0": 0.15


### PR DESCRIPTION
Now PAW density is generated at the same place where valence
density and density matrix are computed. PAW density is then
loaded to the mixer. The mixer returnes the new values for
valence density, density matrix and PAW density.