### PR TITLE
Configure Jenkins to push build logs to another repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,8 +8,8 @@ pipeline {
     }
     environment {
         EB_CUSTOM_REPOSITORY = '/users/simonpi/jenkins/production/easybuild'
-        LOGS_REPO = 'git@github.com:haampie/SIRIUS_logs.git'
-        LOGS_TREE_URL = 'https://github.com/haampie/SIRIUS_logs/tree/master/'
+        LOGS_REPO = 'git@github.com:electronic-structure/SIRIUS-ci-logs.git'
+        LOGS_TREE_URL = 'https://github.com/electronic-structure/SIRIUS-ci-logs/blob/master/'
     }
     stages {
         stage('Checkout') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,6 +41,8 @@ pipeline {
             }
         }
         stage('Test') {
+            // Disable the tests temporarily
+            when { expression { return false } }
             parallel {
                 stage('Test MC') {
                     steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -147,5 +147,8 @@ pipeline {
                 pullRequest.comment("See ${env.LOGS_TREE_URL}${pullRequest.head} for the build details and benchmarks of this PR (${pullRequest.head}).")
             }
         }
+        cleanup {
+            cleanWs()
+        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,8 +112,8 @@ pipeline {
 
     post {
         always {
-            archiveArtifacts artifacts: '**/sirius*.out', fingerprint: true
-            archiveArtifacts artifacts: '**/sirius*.err', fingerprint: true
+            //archiveArtifacts artifacts: '**/sirius*.out', fingerprint: true
+            //archiveArtifacts artifacts: '**/sirius*.err', fingerprint: true
             archiveArtifacts artifacts: '**/build*.out', fingerprint: true
             archiveArtifacts artifacts: '**/build*.err', fingerprint: true
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
                 dir('SIRIUS') {
                     checkout scm
                     echo "Running ${env.BUILD_ID} on ${env.JENKINS_URL}"
+                    sh "git --version"
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,8 +124,10 @@ pipeline {
                 dir('tmp') {
                     deleteDir()
                     withCredentials([sshUserPrivateKey(credentialsId: 'github-logs', keyFileVariable: 'SSH_KEY_PATH')]) {
+                        env.GIT_SSH_COMMAND = 'ssh -o StrictHostKeyChecking=no -i $SSH_KEY_PATH'
+
                         // Clone the logs repo
-                        sh """GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i \$SSH_KEY_PATH" git clone --depth=1 ${env.LOGS_REPO} ."""
+                        sh "git clone --depth=1 ${env.LOGS_REPO} ."
 
                         // Unpack the artifacts plus a readme in a folder with the name of the SHA
                         dir(pullRequest.head) {
@@ -136,7 +138,7 @@ pipeline {
                         // Push
                         sh "git add ${pullRequest.head}"
                         sh "git commit --allow-empty -m 'Add logs for ${pullRequest.url}'"
-                        sh """GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no -i \$SSH_KEY_PATH" git push origin master"""
+                        sh "git push origin master"
                     }
                 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,12 +112,6 @@ pipeline {
 
     post {
         always {
-            // dir('SIRIUS') {
-            //     sh '''
-            //        # delete heavy directories
-            //        rm -rf  build verification examples
-            //        '''
-            // }
             archiveArtifacts artifacts: '**/sirius*.out', fingerprint: true
             archiveArtifacts artifacts: '**/sirius*.err', fingerprint: true
             archiveArtifacts artifacts: '**/build*.out', fingerprint: true


### PR DESCRIPTION
The idea is to push the build artifacts / logs to another GitHub repo.

TODO:

- [x] configure the bot / user that pushes from Jenkins
- [x] move the repo under this org.