### PR TITLE
Add relative tolerance in the Davidson method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ src/version.h
 .cproject
 .project
 .settings
+.vscode
 
 html/
 latex/

--- a/src/band/diag_full_potential.cpp
+++ b/src/band/diag_full_potential.cpp
@@ -328,6 +328,12 @@ void Band::get_singular_components(Hamiltonian_k& Hk__, mdarray<double, 2>& o_di
 
     auto& std_solver = ctx_.std_evp_solver();
 
+    /* tolerance for the norm of L2-norms of the residuals, used for
+     * relative convergence criterion. We can only compute this after
+     * we have the first residual norms available */
+    double relative_frobenius_tolerance{0};
+    double current_frobenius_norm{0};
+
     /* start iterative diagonalization */
     for (int k = 0; k < itso.num_steps_; k++) {
         /* apply Hamiltonian and overlap operators to the new basis functions */
@@ -396,28 +402,45 @@ void Band::get_singular_components(Hamiltonian_k& Hk__, mdarray<double, 2>& o_di
             kp.message(4, __function_name__, "eval[%i]=%20.16f, diff=%20.16f\n", i, eval[i], std::abs(eval[i] - eval_old[i]));
         }
 
+        bool last_iteration = k == (itso.num_steps_ - 1);
+
         /* don't compute residuals on last iteration */
-        if (k != itso.num_steps_ - 1) {
+        if (!last_iteration) {
             /* get new preconditionined residuals, and also opsi and psi as a by-product */
-            n = sirius::residuals(ctx_.preferred_memory_t(), ctx_.blas_linalg_t(), 0,
+            auto result = sirius::residuals(ctx_.preferred_memory_t(), ctx_.blas_linalg_t(), 0,
                                   N, ncomp, eval, evec, ophi, phi, opsi, psi, res, o_diag__, diag1,
                                   itso.converge_by_energy_, itso.residual_tolerance_,
                                   [&](int i, int ispn){return std::abs(eval[i] - eval_old[i]) < itso.energy_tolerance_;});
+            n = result.first;
+            current_frobenius_norm = result.second;
+
+            /* set the relative tolerance convergence criterion */
+            if (k == 0) {
+                relative_frobenius_tolerance = current_frobenius_norm * itso.relative_tolerance_;
+            }
+
             kp.message(3, __function_name__, "number of added residuals: %i\n", n);
             if (ctx_.control().print_checksum_) {
                 res.print_checksum(ctx_.processing_unit(), "res", 0, n);
             }
         }
+        /* verify convergence criteria */
+        bool converged_by_relative_tol = k > 0 && current_frobenius_norm < relative_frobenius_tolerance ;
+        bool converged_by_absolute_tol = n <= itso.min_num_res_;
+        bool converged = converged_by_absolute_tol || converged_by_relative_tol;
+
+        /* check if running out of space */
+        bool should_restart = N + n > num_phi;
 
         /* check if we run out of variational space or eigen-vectors are converged or it's a last iteration */
-        if (N + n > num_phi || n <= itso.min_num_res_ || k == (itso.num_steps_ - 1)) {
+        if (should_restart || converged || last_iteration) {
             PROFILE("sirius::Band::get_singular_components|update_phi");
             /* recompute wave-functions */
             /* \Psi_{i} = \sum_{mu} \phi_{mu} * Z_{mu, i} */
             transform(ctx_.preferred_memory_t(), ctx_.blas_linalg_t(), 0, phi, 0, N, evec, 0, 0, psi, 0, ncomp);
 
             /* exit the loop if the eigen-vectors are converged or this is a last iteration */
-            if (n <= itso.min_num_res_ || k == (itso.num_steps_ - 1)) {
+            if (converged || last_iteration) {
                 break;
             } else { /* otherwise, set Psi as a new trial basis */
                 kp.message(3, __function_name__, "%s", "subspace size limit reached\n");
@@ -595,8 +618,17 @@ void Band::diag_full_potential_first_variation_davidson(Hamiltonian_k& Hk__) con
 
     auto& std_solver = ctx_.std_evp_solver();
 
+    /* tolerance for the norm of L2-norms of the residuals, used for
+     * relative convergence criterion. We can only compute this after
+     * we have the first residual norms available */
+    double relative_frobenius_tolerance{0};
+    double current_frobenius_norm{0};
+
     /* start iterative diagonalization */
     for (int k = 0; k < itso.num_steps_; k++) {
+
+        bool last_iteration = k == (itso.num_steps_ - 1);
+
         /* apply Hamiltonian and overlap operators to the new basis functions */
         if (k == 0) {
             Hk__.apply_fv_h_o(false, true, 0, nlo, phi, &hphi, &ophi);
@@ -629,23 +661,42 @@ void Band::diag_full_potential_first_variation_davidson(Hamiltonian_k& Hk__) con
         }
 
         /* don't compute residuals on last iteration */
-        if (k != itso.num_steps_ - 1) {
+        if (!last_iteration) {
             /* get new preconditionined residuals, and also hpsi and opsi as a by-product */
-            n = sirius::residuals(ctx_.preferred_memory_t(), ctx_.blas_linalg_t(), 0,
+            auto result = sirius::residuals(ctx_.preferred_memory_t(), ctx_.blas_linalg_t(), 0,
                                   N, num_bands, eval, evec, hphi, ophi, hpsi, opsi, res, h_o_diag.first, h_o_diag.second,
                                   itso.converge_by_energy_, itso.residual_tolerance_,
                                   [&](int i, int ispn){return std::abs(eval[i] - eval_old[i]) < itso.energy_tolerance_;});
+            n = result.first;
+            current_frobenius_norm = result.second;
+
+            /* set the relative tolerance convergence criterion */
+            if (k == 0) {
+                relative_frobenius_tolerance = current_frobenius_norm * itso.relative_tolerance_;
+            }
+        }
+
+        /* verify convergence criteria */
+        bool converged_by_relative_tol = k > 0 && current_frobenius_norm < relative_frobenius_tolerance ;
+        bool converged_by_absolute_tol = n <= itso.min_num_res_;
+        bool converged = converged_by_absolute_tol || converged_by_relative_tol;
+
+        /* check if running out of space */
+        bool should_restart = N + n > num_phi;
+
+        if (converged) {
+            kp.message(3, __function_name__, "converged by %s tolerance\n", converged_by_relative_tol ? "relative" : "absolute");
         }
 
         /* check if we run out of variational space or eigen-vectors are converged or it's a last iteration */
-        if (N + n > num_phi || n <= itso.min_num_res_ || k == (itso.num_steps_ - 1)) {
+        if (should_restart || converged || last_iteration) {
             PROFILE("sirius::Band::diag_fv_davidson|update_phi");
             /* recompute wave-functions */
             /* \Psi_{i} = \sum_{mu} \phi_{mu} * Z_{mu, i} */
             transform(ctx_.preferred_memory_t(), ctx_.blas_linalg_t(), 0, phi, 0, N, evec, 0, 0, psi, 0, num_bands);
 
             /* exit the loop if the eigen-vectors are converged or this is a last iteration */
-            if (n <= itso.min_num_res_ || k == (itso.num_steps_ - 1)) {
+            if (converged || last_iteration) {
                 break;
             } else { /* otherwise, set Psi as a new trial basis */
                 kp.message(3, __function_name__, "%s", "subspace size limit reached\n");

--- a/src/band/diag_full_potential.cpp
+++ b/src/band/diag_full_potential.cpp
@@ -379,7 +379,7 @@ void Band::get_singular_components(Hamiltonian_k& Hk__, mdarray<double, 2>& o_di
         /* solve standard eigen-value problem with the size N */
         if (std_solver.solve(N, ncomp, ovlp, &eval[0], evec)) {
             std::stringstream s;
-            s << "[sirius::Band::get_singular_components] error in diagonalziation";
+            s << "[sirius::Band::get_singular_components] error in diagonalization";
             TERMINATE(s);
         }
 

--- a/src/band/diag_pseudo_potential.cpp
+++ b/src/band/diag_pseudo_potential.cpp
@@ -428,8 +428,8 @@ Band::diag_pseudo_potential_davidson(Hamiltonian_k& Hk__) const
             }
         }
 
-        /* fisrt phase: setup and diagonalize reduced Hamiltonian and get eigen-values;
-         * this is done before the main itertive loop */
+        /* first phase: setup and diagonalize reduced Hamiltonian and get eigen-values;
+         * this is done before the main iterative loop */
 
         /* apply Hamiltonian and S operators to the basis functions */
         Hk__.apply_h_s<T>(spin_range(nc_mag ? 2 : ispin_step), 0, num_bands, phi, &hphi, &sphi);
@@ -452,7 +452,7 @@ Band::diag_pseudo_potential_davidson(Hamiltonian_k& Hk__) const
             double max_diff = check_hermitian(hmlt, num_bands);
             if (max_diff > 1e-12) {
                 std::stringstream s;
-                s << "H matrix is not hermitian, max_err = " << max_diff;
+                s << "H matrix is not Hermitian, max_err = " << max_diff;
                 WARNING(s);
             }
         }
@@ -551,7 +551,7 @@ Band::diag_pseudo_potential_davidson(Hamiltonian_k& Hk__) const
                 }
             }
 
-            /* expand variational subspace with new basis vectors obtatined from residuals */
+            /* expand variational subspace with new basis vectors obtained from residuals */
             for (int ispn = 0; ispn < num_sc; ispn++) {
                 phi.copy_from(res, n, ispn, 0, ispn, N);
             }
@@ -572,7 +572,7 @@ Band::diag_pseudo_potential_davidson(Hamiltonian_k& Hk__) const
                 double max_diff = check_hermitian(hmlt, N + n);
                 if (max_diff > 1e-12) {
                     std::stringstream s;
-                    s << "H matrix is not hermitian, max_err = " << max_diff;
+                    s << "H matrix is not Hermitian, max_err = " << max_diff;
                     WARNING(s);
                 }
             }
@@ -585,7 +585,7 @@ Band::diag_pseudo_potential_davidson(Hamiltonian_k& Hk__) const
                     double max_diff = check_hermitian(ovlp, N + n);
                     if (max_diff > 1e-12) {
                         std::stringstream s;
-                        s << "S matrix is not hermitian, max_err = " << max_diff;
+                        s << "S matrix is not Hermitian, max_err = " << max_diff;
                         WARNING(s);
                     }
                 }
@@ -601,14 +601,14 @@ Band::diag_pseudo_potential_davidson(Hamiltonian_k& Hk__) const
                 /* solve standard eigen-value problem with the size N */
                 if (std_solver.solve(N, num_bands, hmlt, &eval[0], evec)) {
                     std::stringstream s;
-                    s << "error in diagonalziation";
+                    s << "error in diagonalization";
                     TERMINATE(s);
                 }
             } else {
                 /* solve generalized eigen-value problem with the size N */
                 if (gen_solver.solve(N, num_bands, hmlt, ovlp, &eval[0], evec)) {
                     std::stringstream s;
-                    s << "error in diagonalziation";
+                    s << "error in diagonalization";
                     TERMINATE(s);
                 }
             }

--- a/src/band/diag_pseudo_potential.cpp
+++ b/src/band/diag_pseudo_potential.cpp
@@ -402,11 +402,7 @@ Band::diag_pseudo_potential_davidson(Hamiltonian_k& Hk__) const
             if (std::abs(kp.band_occupancy(j__, ispn__)) < ctx_.min_occupancy() * ctx_.max_occupancy()) {
                 tol += empy_tol;
             }
-            if (std::abs(eval[j__] - eval_old[j__]) > tol) {
-                return false;
-            } else {
-                return true;
-            }
+            return std::abs(eval[j__] - eval_old[j__]) <= tol;
         };
 
         if (itso.init_eval_old_) {
@@ -480,20 +476,47 @@ Band::diag_pseudo_potential_davidson(Hamiltonian_k& Hk__) const
         /* number of newly added basis functions */
         int n{0};
 
+        /* tolerance for the norm of L2-norms of the residuals, used for
+         * relative convergence criterion. We can only compute this after
+         * we have the first residual norms available */
+        double relative_frobenius_tolerance{0};
+        double current_frobenius_norm{0};
+
         /* second phase: start iterative diagonalization */
         for (int k = 0; k < itso.num_steps_; k++) {
 
+            bool last_iteration = k == (itso.num_steps_ - 1);
+
             /* don't compute residuals on last iteration */
-            if (k != itso.num_steps_ - 1) {
-                /* get new preconditionined residuals, and also hpsi and opsi as a by-product */
-                n = sirius::residuals<T>(ctx_.preferred_memory_t(), ctx_.blas_linalg_t(), nc_mag ? 2 : ispin_step,
+            if (!last_iteration) {
+                /* get new preconditioned residuals, and also hpsi and opsi as a by-product */
+                auto result = sirius::residuals<T>(ctx_.preferred_memory_t(), ctx_.blas_linalg_t(), nc_mag ? 2 : ispin_step,
                                          N, num_bands, eval, evec, hphi, sphi, hpsi, spsi, res, h_o_diag.first,
                                          h_o_diag.second, itso.converge_by_energy_, itso.residual_tolerance_,
                                          is_converged);
+                n = result.first;
+                current_frobenius_norm = result.second;
+
+                /* set the relative tolerance convergence criterion */
+                if (k == 0) {
+                    relative_frobenius_tolerance = current_frobenius_norm * itso.relative_tolerance_;
+                }
+            }
+
+            /* verify convergence criteria */
+            bool converged_by_relative_tol = k > 0 && current_frobenius_norm < relative_frobenius_tolerance ;
+            bool converged_by_absolute_tol = n <= itso.min_num_res_;
+            bool converged = converged_by_absolute_tol || converged_by_relative_tol;
+
+            /* check if running out of space */
+            bool should_restart = N + n > num_phi;
+
+            if (converged) {
+                kp.message(3, __function_name__, "converged by %s tolerance\n", converged_by_relative_tol ? "relative" : "absolute");
             }
 
             /* check if we run out of variational space or eigen-vectors are converged or it's a last iteration */
-            if (N + n > num_phi || n <= itso.min_num_res_ || k == (itso.num_steps_ - 1)) {
+            if (should_restart || converged || last_iteration) {
                 PROFILE("sirius::Band::diag_pseudo_potential_davidson|update_phi");
                 /* recompute wave-functions */
                 /* \Psi_{i} = \sum_{mu} \phi_{mu} * Z_{mu, i} */
@@ -509,7 +532,7 @@ Band::diag_pseudo_potential_davidson(Hamiltonian_k& Hk__) const
                     kp.message(2, __function_name__, "%s", "wave-functions are not recomputed\n");
                 }
 
-                if (k == (itso.num_steps_ - 1) && n > itso.min_num_res_) {
+                if (last_iteration && !converged) {
                     std::stringstream s;
                     s << "[sirius::Band::diag_pseudo_potential_davidson] maximum number of iterations reached, but " <<
                          n << " residual(s) did not converge for k-point " << kp.vk();
@@ -517,7 +540,7 @@ Band::diag_pseudo_potential_davidson(Hamiltonian_k& Hk__) const
                 }
 
                 /* exit the loop if the eigen-vectors are converged or this is a last iteration */
-                if (n <= itso.min_num_res_ || k == (itso.num_steps_ - 1)) {
+                if (converged || last_iteration) {
                     kp.message(3, __function_name__, "end of iterative diagonalization; n=%i, k=%i\n", n, k);
                     break;
                 } else { /* otherwise, set Psi as a new trial basis */
@@ -807,6 +830,12 @@ Band::diag_S_davidson(Hamiltonian_k& Hk__) const
     mdarray<double, 1> eval_old(nevec);
     eval_old = [](){return 1e10;};
 
+    /* tolerance for the norm of L2-norms of the residuals, used for
+     * relative convergence criterion. We can only compute this after
+     * we have the first residual norms available */
+    double relative_frobenius_tolerance{0};
+    double current_frobenius_norm{0};
+
     for (int k = 0; k < itso.num_steps_; k++) {
 
         /* apply Hamiltonian and S operators to the basis functions */
@@ -847,20 +876,37 @@ Band::diag_S_davidson(Hamiltonian_k& Hk__) const
             }
 
             /* get new preconditionined residuals, and also opsi and psi as a by-product */
-            n = sirius::residuals<T>(ctx_.preferred_memory_t(), ctx_.blas_linalg_t(), nc_mag ? 2 : 0,
+            auto result = sirius::residuals<T>(ctx_.preferred_memory_t(), ctx_.blas_linalg_t(), nc_mag ? 2 : 0,
                                      N, nevec, eval, evec, sphi, phi, spsi, psi, res, o_diag, o_diag1,
                                      itso.converge_by_energy_, itso.residual_tolerance_,
                                      [&](int i, int ispn){return std::abs(eval[i] - eval_old[i]) < iterative_solver_tolerance;});
+            n = result.first;
+            current_frobenius_norm = result.second;
+
+            /* set the relative tolerance convergence criterion */
+            if (k == 0) {
+                relative_frobenius_tolerance = current_frobenius_norm * itso.relative_tolerance_;
+            }
         }
 
+        /* verify convergence criteria */
+        bool converged_by_relative_tol = k > 0 && current_frobenius_norm < relative_frobenius_tolerance ;
+        bool converged_by_absolute_tol = n <= itso.min_num_res_;
+        bool converged = converged_by_absolute_tol || converged_by_relative_tol;
+
+        /* check if running out of space */
+        bool should_restart = N + n > num_phi;
+
+        bool last_iteration = k == (itso.num_steps_ - 1);
+
         /* check if we run out of variational space or eigen-vectors are converged or it's a last iteration */
-        if (N + n > num_phi || n <= itso.min_num_res_ || k == (itso.num_steps_ - 1)) {
+        if (should_restart || converged || last_iteration) {
             /* recompute wave-functions */
             /* \Psi_{i} = \sum_{mu} \phi_{mu} * Z_{mu, i} */
             transform(ctx_.preferred_memory_t(), ctx_.blas_linalg_t(), nc_mag ? 2 : 0, phi, 0, N, evec, 0, 0, psi, 0, nevec);
 
             /* exit the loop if the eigen-vectors are converged or this is a last iteration */
-            if (n <= itso.min_num_res_ || k == (itso.num_steps_ - 1)) {
+            if (converged || last_iteration) {
                 break;
             } else { /* otherwise, set Psi as a new trial basis */
                 kp.message(3, __function_name__, "%s", "subspace size limit reached\n");

--- a/src/band/residuals.cpp
+++ b/src/band/residuals.cpp
@@ -117,7 +117,7 @@ apply_preconditioner(sddk::memory_t mem_type__, sddk::spin_range spins__, int nu
 }
 
 template <typename T>
-static inline int
+static inline std::pair<int, double>
 normalized_preconditioned_residuals(sddk::memory_t mem_type__, sddk::spin_range spins__, int num_bands__,
                                     sddk::mdarray<double,1>& eval__, sddk::Wave_functions& hpsi__,
                                     sddk::Wave_functions& opsi__, sddk::Wave_functions& res__,
@@ -135,6 +135,11 @@ normalized_preconditioned_residuals(sddk::memory_t mem_type__, sddk::spin_range 
 
     /* compute norm of the "raw" residuals */
     auto res_norm = res__.l2norm(pu, spins__, num_bands__);
+
+    auto frobenius_norm = 0.0;
+    for (int i = 0; i < num_bands__; i++)
+        frobenius_norm += res_norm[i] * res_norm[i];
+    frobenius_norm = std::sqrt(frobenius_norm);
 
     /* apply preconditioner */
     apply_preconditioner(mem_type__, spins__, num_bands__, res__, h_diag__, o_diag__, eval__);
@@ -171,12 +176,12 @@ normalized_preconditioned_residuals(sddk::memory_t mem_type__, sddk::spin_range 
         }
     }
 
-    return n;
+    return std::make_pair(n, frobenius_norm);
 }
 
 /// Compute residuals from eigen-vectors.
 template <typename T>
-int
+static inline std::pair<int, double>
 residuals(sddk::memory_t mem_type__, sddk::linalg_t la_type__, int ispn__, int N__, int num_bands__,
           sddk::mdarray<double, 1>& eval__, sddk::dmatrix<T>& evec__, sddk::Wave_functions& hphi__,
           sddk::Wave_functions& ophi__, sddk::Wave_functions& hpsi__,
@@ -246,20 +251,18 @@ residuals(sddk::memory_t mem_type__, sddk::linalg_t la_type__, int ispn__, int N
         n = num_bands__;
     }
     if (!n) {
-        return 0;
+        return std::make_pair(0, 0);
     }
 
     /* compute H\Psi_{i} = \sum_{mu} H\phi_{mu} * Z_{mu, i} and O\Psi_{i} = \sum_{mu} O\phi_{mu} * Z_{mu, i} */
     sddk::transform<T>(mem_type__, la_type__, ispn__, {&hphi__, &ophi__}, 0, N__, *evec_ptr, 0, 0, {&hpsi__, &opsi__}, 0, n);
 
-    n = normalized_preconditioned_residuals<T>(mem_type__, sddk::spin_range(ispn__), n, *eval_ptr, hpsi__, opsi__, res__,
+    return normalized_preconditioned_residuals<T>(mem_type__, sddk::spin_range(ispn__), n, *eval_ptr, hpsi__, opsi__, res__,
                                                h_diag__, o_diag__, norm_tolerance__);
-
-    return n;
 }
 
 template
-int
+static std::pair<int, double>
 residuals<double>(sddk::memory_t mem_type__, sddk::linalg_t la_type__, int ispn__, int N__, int num_bands__,
                   sddk::mdarray<double, 1>& eval__, sddk::dmatrix<double>& evec__, sddk::Wave_functions& hphi__,
                   sddk::Wave_functions& ophi__, sddk::Wave_functions& hpsi__,
@@ -268,7 +271,7 @@ residuals<double>(sddk::memory_t mem_type__, sddk::linalg_t la_type__, int ispn_
                   std::function<bool(int, int)> is_converged__);
 
 template
-int
+static std::pair<int, double>
 residuals<double_complex>(sddk::memory_t mem_type__, sddk::linalg_t la_type__, int ispn__, int N__, int num_bands__,
                           sddk::mdarray<double, 1>& eval__, sddk::dmatrix<double_complex>& evec__,
                           sddk::Wave_functions& hphi__, sddk::Wave_functions& ophi__, sddk::Wave_functions& hpsi__,

--- a/src/band/residuals.hpp
+++ b/src/band/residuals.hpp
@@ -70,7 +70,7 @@ extern "C" void make_real_g0_gpu(double_complex* res__,
 namespace sirius {
 
 /// Compute preconditionined residuals.
-/** The residuals of wave-functions are difined as:
+/** The residuals of wave-functions are defined as:
     \f[
       R_{i} = \hat H \psi_{i} - \epsilon_{i} \hat S \psi_{i}
     \f]

--- a/src/band/residuals.hpp
+++ b/src/band/residuals.hpp
@@ -76,7 +76,7 @@ namespace sirius {
     \f]
  */
 template <typename T>
-int
+std::pair<int, double>
 residuals(sddk::memory_t mem_type__, sddk::linalg_t la_type__, int ispn__, int N__, int num_bands__,
           sddk::mdarray<double, 1>& eval__, sddk::dmatrix<T>& evec__, sddk::Wave_functions& hphi__,
           sddk::Wave_functions& ophi__, sddk::Wave_functions& hpsi__,

--- a/src/input.hpp
+++ b/src/input.hpp
@@ -260,6 +260,9 @@ struct Iterative_solver_input
     /// Tolerance for the residual L2 norm.
     double residual_tolerance_{1e-6};
 
+    /// Relative tolerance for the residual L2 norm. (0 means this criterion is effectively not used)
+    double relative_tolerance_{0};
+
     /// Additional tolerance for empty states.
     /** Setting this variable to 0 will treat empty states with the same tolerance as occupied states. */
     double empty_states_tolerance_{0};
@@ -298,6 +301,7 @@ struct Iterative_solver_input
             subspace_size_          = section.value("subspace_size", subspace_size_);
             energy_tolerance_       = section.value("energy_tolerance", energy_tolerance_);
             residual_tolerance_     = section.value("residual_tolerance", residual_tolerance_);
+            relative_tolerance_     = section.value("relative_tolerance", relative_tolerance_);
             empty_states_tolerance_ = section.value("empty_states_tolerance", empty_states_tolerance_);
             converge_by_energy_     = section.value("converge_by_energy", converge_by_energy_);
             min_num_res_            = section.value("min_num_res", min_num_res_);

--- a/src/linalg/eigenproblem.hpp
+++ b/src/linalg/eigenproblem.hpp
@@ -138,8 +138,8 @@ class Eigensolver_lapack : public Eigensolver
         if (m != nev__) {
             std::stringstream s;
             s << "not all eigen-values are found" << std::endl
-              << "target number of eign-values: " << nev__ << std::endl
-              << "number of eign-values found: " << m;
+              << "target number of eigen-values: " << nev__ << std::endl
+              << "number of eigen-values found: " << m;
             WARNING(s);
             return 1;
         }
@@ -192,8 +192,8 @@ class Eigensolver_lapack : public Eigensolver
         if (m != nev__) {
             std::stringstream s;
             s << "not all eigen-values are found" << std::endl
-              << "target number of eign-values: " << nev__ << std::endl
-              << "number of eign-values found: " << m;
+              << "target number of eigen-values: " << nev__ << std::endl
+              << "number of eigen-values found: " << m;
             WARNING(s);
             return 1;
         }
@@ -241,8 +241,8 @@ class Eigensolver_lapack : public Eigensolver
         if (m != nev__) {
             std::stringstream s;
             s << "not all eigen-values are found" << std::endl
-              << "target number of eign-values: " << nev__ << std::endl
-              << "number of eign-values found: " << m;
+              << "target number of eigen-values: " << nev__ << std::endl
+              << "number of eigen-values found: " << m;
             WARNING(s);
             return 1;
         }
@@ -292,8 +292,8 @@ class Eigensolver_lapack : public Eigensolver
         if (m != nev__) {
             std::stringstream s;
             s << "not all eigen-values are found" << std::endl
-              << "target number of eign-values: " << nev__ << std::endl
-              << "number of eign-values found: " << m;
+              << "target number of eigen-values: " << nev__ << std::endl
+              << "number of eigen-values found: " << m;
             WARNING(s);
             return 1;
         }

--- a/src/options.json
+++ b/src/options.json
@@ -65,9 +65,15 @@
         },
         "residual_tolerance" :
         {
-            "description" : "Tolerance for the residual L2 norm." ,
-          "usage" :  "residual_tolerance (1e-6)" ,
-          "default_value" :  0.000001
+            "description" : "Absolute tolerance for the residual L2 norm." ,
+            "usage" :  "residual_tolerance (1e-6)" ,
+            "default_value" :  0.000001
+        },
+        "relative_tolerance" :
+        {
+            "description" : "Relative tolerance for the residual L2 norm." ,
+            "usage" : "relative_tolerance (0.1)" ,
+            "default_value" : 0.0
         },
         "empty_state_tolerance" :
         {


### PR DESCRIPTION
This allows the user to set `iterative_solver.relative_tolerance` to something, say `0.1`, and gives an additional convergence criterion for the Davidson method. 

By default `iterative_solver.relative_tolerance = 0`, so it will not change a thing. 

The residual used here is simply the norm of the vector of L2-norms aka the Frobenius norm of the targeted residual block.

I have to benchmark it a bit better to see if it reduces the total number of global matrix-blockvec products. Small relative tolerance = few inner iterations of Davidson, but more outer iterations of self consistency loop.