### PR TITLE
remove static variables from header files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,7 @@ set(_SOURSES
   "SDDK/gvec.cpp"
   "SDDK/matrix_storage.cpp"
   "gpu/acc.cpp"
+  "gpu/acc_blas.cpp"
   "gpu/cusolver.cpp"
   "gpu/cublas.cpp"
   "sht/sht.cpp"

--- a/src/gpu/acc_blas.cpp
+++ b/src/gpu/acc_blas.cpp
@@ -1,0 +1,30 @@
+#if defined __CUDA || __ROCM
+#include "acc_blas.hpp"
+
+namespace accblas {
+
+::acc::blas::handle_t&
+null_stream_handle()
+{
+    static ::acc::blas::handle_t null_stream_handle_;
+    return null_stream_handle_;
+}
+
+std::vector<::acc::blas::handle_t>&
+stream_handles()
+{
+    static std::vector<::acc::blas::handle_t> stream_handles_;
+    return stream_handles_;
+}
+
+namespace xt {
+cublasXtHandle_t&
+cublasxt_handle()
+{
+    static cublasXtHandle_t handle;
+    return handle;
+}
+} // namespace xt
+}  // xt
+
+#endif

--- a/src/gpu/acc_blas.hpp
+++ b/src/gpu/acc_blas.hpp
@@ -160,20 +160,11 @@ get_gpublasDiagonal_t(char c)
     }
 
 /// Store the default (null) stream handler.
-inline ::acc::blas::handle_t&
-null_stream_handle()
-{
-    static ::acc::blas::handle_t null_stream_handle_;
-    return null_stream_handle_;
-}
+::acc::blas::handle_t& null_stream_handle();
+
 
 /// Store the gpublas handlers associated with acc streams.
-inline std::vector<::acc::blas::handle_t>&
-stream_handles()
-{
-    static std::vector<::acc::blas::handle_t> stream_handles_;
-    return stream_handles_;
-}
+std::vector<::acc::blas::handle_t>& stream_handles();
 
 inline void
 create_stream_handles()
@@ -320,12 +311,7 @@ zaxpy(int n__, acc_complex_double_t const* alpha__, acc_complex_double_t const* 
 #if defined(__CUDA)
 namespace xt {
 
-inline cublasXtHandle_t&
-cublasxt_handle()
-{
-    static cublasXtHandle_t handle;
-    return handle;
-}
+cublasXtHandle_t& cublasxt_handle();
 
 inline void
 create_handle()


### PR DESCRIPTION
add `acc_blas.cpp` to store static variables acting as singletons.