### PR TITLE
Multiple fixes

### DIFF
--- a/src/band/diag_full_potential.cpp
+++ b/src/band/diag_full_potential.cpp
@@ -738,13 +738,9 @@ void Band::diag_full_potential_second_variation(Hamiltonian_k& Hk__) const
     /* product of the second-variational Hamiltonian and a first-variational wave-function */
     std::vector<Wave_functions> hpsi;
     for (int i = 0; i < ctx_.num_mag_comp(); i++) {
-        hpsi.push_back(std::move(Wave_functions(kp.gkvec_partition(),
-                                                unit_cell_.num_atoms(),
-                                                [this](int ia) {
-                                                    return unit_cell_.atom(ia).mt_basis_size();
-                                                },
-                                                ctx_.num_fv_states(),
-                                                ctx_.preferred_memory_t())));
+        hpsi.push_back(Wave_functions(kp.gkvec_partition(), unit_cell_.num_atoms(),
+                                      [this](int ia) { return unit_cell_.atom(ia).mt_basis_size(); },
+                                      ctx_.num_fv_states(), ctx_.preferred_memory_t()));
     }
 
     /* compute product of magnetic field and wave-function */

--- a/src/band/residuals.cpp
+++ b/src/band/residuals.cpp
@@ -117,7 +117,7 @@ apply_preconditioner(sddk::memory_t mem_type__, sddk::spin_range spins__, int nu
 }
 
 template <typename T>
-static inline std::pair<int, double>
+static std::pair<int, double>
 normalized_preconditioned_residuals(sddk::memory_t mem_type__, sddk::spin_range spins__, int num_bands__,
                                     sddk::mdarray<double,1>& eval__, sddk::Wave_functions& hpsi__,
                                     sddk::Wave_functions& opsi__, sddk::Wave_functions& res__,
@@ -181,11 +181,11 @@ normalized_preconditioned_residuals(sddk::memory_t mem_type__, sddk::spin_range 
 
 /// Compute residuals from eigen-vectors.
 template <typename T>
-static inline std::pair<int, double>
+std::pair<int, double>
 residuals(sddk::memory_t mem_type__, sddk::linalg_t la_type__, int ispn__, int N__, int num_bands__,
           sddk::mdarray<double, 1>& eval__, sddk::dmatrix<T>& evec__, sddk::Wave_functions& hphi__,
-          sddk::Wave_functions& ophi__, sddk::Wave_functions& hpsi__,
-          sddk::Wave_functions& opsi__, sddk::Wave_functions& res__, sddk::mdarray<double, 2> const& h_diag__,
+          sddk::Wave_functions& ophi__, sddk::Wave_functions& hpsi__, sddk::Wave_functions& opsi__,
+          sddk::Wave_functions& res__, sddk::mdarray<double, 2> const& h_diag__,
           sddk::mdarray<double, 2> const& o_diag__, bool estimate_eval__, double norm_tolerance__,
           std::function<bool(int, int)> is_converged__)
 {
@@ -261,17 +261,15 @@ residuals(sddk::memory_t mem_type__, sddk::linalg_t la_type__, int ispn__, int N
                                                h_diag__, o_diag__, norm_tolerance__);
 }
 
-template
-static std::pair<int, double>
+template std::pair<int, double>
 residuals<double>(sddk::memory_t mem_type__, sddk::linalg_t la_type__, int ispn__, int N__, int num_bands__,
                   sddk::mdarray<double, 1>& eval__, sddk::dmatrix<double>& evec__, sddk::Wave_functions& hphi__,
-                  sddk::Wave_functions& ophi__, sddk::Wave_functions& hpsi__,
-                  sddk::Wave_functions& opsi__, sddk::Wave_functions& res__, sddk::mdarray<double, 2> const& h_diag__,
+                  sddk::Wave_functions& ophi__, sddk::Wave_functions& hpsi__, sddk::Wave_functions& opsi__,
+                  sddk::Wave_functions& res__, sddk::mdarray<double, 2> const& h_diag__,
                   sddk::mdarray<double, 2> const& o_diag__, bool estimate_eval__, double norm_tolerance__,
                   std::function<bool(int, int)> is_converged__);
 
-template
-static std::pair<int, double>
+template std::pair<int, double>
 residuals<double_complex>(sddk::memory_t mem_type__, sddk::linalg_t la_type__, int ispn__, int N__, int num_bands__,
                           sddk::mdarray<double, 1>& eval__, sddk::dmatrix<double_complex>& evec__,
                           sddk::Wave_functions& hphi__, sddk::Wave_functions& ophi__, sddk::Wave_functions& hpsi__,

--- a/src/geometry/force.cpp
+++ b/src/geometry/force.cpp
@@ -310,7 +310,6 @@ mdarray<double, 2> const& Force::calc_forces_ewald()
 
             /* cartesian form for getting cartesian force components */
             vector3d<double> gvec_cart = ctx_.gvec().gvec_cart<index_domain_t::local>(igloc);
-            double_complex rho(0, 0);
 
             double scalar_part = prefac * (rho_tmp[igloc] * ctx_.gvec_phase_factor(ig, ja)).imag() *
                                  static_cast<double>(unit_cell.atom(ja).zn()) * std::exp(-g2 / (4 * alpha)) / g2;

--- a/src/gpu/acc_blas.cpp
+++ b/src/gpu/acc_blas.cpp
@@ -1,4 +1,4 @@
-#if defined __CUDA || __ROCM
+#if defined(__CUDA) || defined(__ROCM)
 #include "acc_blas.hpp"
 
 namespace accblas {
@@ -17,6 +17,7 @@ stream_handles()
     return stream_handles_;
 }
 
+#if defined(__CUDA)
 namespace xt {
 cublasXtHandle_t&
 cublasxt_handle()
@@ -25,6 +26,7 @@ cublasxt_handle()
     return handle;
 }
 } // namespace xt
-}  // xt
+#endif
+}
 
 #endif

--- a/src/gpu/acc_blas_api.hpp
+++ b/src/gpu/acc_blas_api.hpp
@@ -104,13 +104,11 @@ namespace fill {
 #if defined(__CUDA)
 constexpr auto Upper = CUBLAS_FILL_MODE_UPPER;
 constexpr auto Lower = CUBLAS_FILL_MODE_LOWER;
-constexpr auto Full =  CUBLAS_FILL_MODE_FULL;
 #endif
 
 #if defined(__ROCM)
 constexpr auto Upper = rocblas_fill_upper;
 constexpr auto Lower = rocblas_fill_lower;
-constexpr auto Full = rocblas_fill_full;
 #endif
 }  // namespace fill
 

--- a/src/linalg/eigensolver.cpp
+++ b/src/linalg/eigensolver.cpp
@@ -29,7 +29,7 @@ std::unique_ptr<Eigensolver> Eigensolver_factory(std::string name__, memory_pool
 {
     std::transform(name__.begin(), name__.end(), name__.begin(), ::tolower);
 
-    Eigensolver* ptr;
+    Eigensolver* ptr = nullptr;
     switch (get_ev_solver_t(name__)) {
         case ev_solver_t::lapack: {
             ptr = new Eigensolver_lapack();

--- a/src/radial/radial_solver.hpp
+++ b/src/radial/radial_solver.hpp
@@ -663,10 +663,10 @@ class Radial_solver
         int nn{0};
 
         for (int j = 0; j <= dme__; j++) {
-            p.push_back(std::move(std::vector<double>(nr)));
-            q.push_back(std::move(std::vector<double>(nr)));
-            dpdr.push_back(std::move(std::vector<double>(nr)));
-            dqdr.push_back(std::move(std::vector<double>(nr)));
+            p.push_back(std::vector<double>(nr));
+            q.push_back(std::vector<double>(nr));
+            dpdr.push_back(std::vector<double>(nr));
+            dqdr.push_back(std::vector<double>(nr));
 
             if (j) {
                 if (rel__ == relativity_t::none || rel__ == relativity_t::zora) {

--- a/src/simulation_parameters.hpp
+++ b/src/simulation_parameters.hpp
@@ -576,7 +576,7 @@ class Simulation_parameters
     memory_pool& mem_pool(memory_t M__) const
     {
         if (memory_pool_.count(M__) == 0) {
-            memory_pool_.emplace(M__, std::move(memory_pool(M__)));
+            memory_pool_.emplace(M__, memory_pool(M__));
         }
         return memory_pool_.at(M__);
     }

--- a/src/unit_cell/atom_type.hpp
+++ b/src/unit_cell/atom_type.hpp
@@ -454,7 +454,7 @@ class Atom_type
         local_orbital_descriptor lod;
 
         Spline<double> s(radial_grid_, f__);
-        ps_atomic_wfs_.push_back(std::move(std::make_tuple(n__, l__, occ__, std::move(s))));
+        ps_atomic_wfs_.push_back(std::make_tuple(n__, l__, occ__, std::move(s)));
     }
 
     /// Return a tuple describing a given atomic radial function
@@ -483,7 +483,7 @@ class Atom_type
             TERMINATE("can't add more beta projectors");
         }
         Spline<double> s(radial_grid_, beta__);
-        beta_radial_functions_.push_back(std::move(std::make_pair(l__, std::move(s))));
+        beta_radial_functions_.push_back(std::make_pair(l__, std::move(s)));
 
         local_orbital_descriptor lod;
         lod.l = std::abs(l__);

--- a/src/unit_cell/unit_cell.cpp
+++ b/src/unit_cell/unit_cell.cpp
@@ -499,7 +499,7 @@ Atom_type& Unit_cell::add_atom_type(const std::string label__, const std::string
     }
 
     int id = next_atom_type_id(label__);
-    atom_types_.push_back(std::move(Atom_type(parameters_, id, label__, file_name__)));
+    atom_types_.push_back(Atom_type(parameters_, id, label__, file_name__));
     return atom_types_.back();
 }
 
@@ -517,7 +517,7 @@ void Unit_cell::add_atom(const std::string label, vector3d<double> position, vec
         TERMINATE(s);
     }
 
-    atoms_.push_back(std::move(Atom(atom_type(label), position, vector_field)));
+    atoms_.push_back(Atom(atom_type(label), position, vector_field));
     atom_type(label).add_atom_id(static_cast<int>(atoms_.size()) - 1);
 }
 
@@ -573,12 +573,12 @@ void Unit_cell::initialize()
     for (int iat = 0; iat < num_atom_types(); iat++) {
         int nat = atom_type(iat).num_atoms();
         if (nat > 0) {
-            atom_coord_.push_back(std::move(mdarray<double, 2>(nat, 3, memory_t::host)));
+            atom_coord_.push_back(mdarray<double, 2>(nat, 3, memory_t::host));
             if (parameters_.processing_unit() == device_t::GPU) {
                 atom_coord_.back().allocate(memory_t::device);
             }
         } else {
-            atom_coord_.push_back(std::move(mdarray<double, 2>()));
+            atom_coord_.push_back(mdarray<double, 2>());
         }
     }
     update();
@@ -630,7 +630,7 @@ void Unit_cell::get_symmetry()
         if (asc[i] == -1) {
             /* take next id */
             atom_class_id++;
-            atom_symmetry_classes_.push_back(std::move(Atom_symmetry_class(atom_class_id, atoms_[i].type())));
+            atom_symmetry_classes_.push_back(Atom_symmetry_class(atom_class_id, atoms_[i].type()));
 
             /* scan all atoms */
             for (int j = 0; j < num_atoms(); j++) {


### PR DESCRIPTION
Multiple small fixes:

- Removed static qualifier in residuals.cpp for functions with external linkage
- Fixed compilation with CUDA 9 by removing reference to unused fill type
- Fixed compilation with ROCm by disabling reference to CUBLASXT
- Removed redundant use of std::move which prevented copy elision 