### PR TITLE
Locking

### DIFF
--- a/src/band/band.cpp
+++ b/src/band/band.cpp
@@ -44,7 +44,7 @@ Band::Band(Simulation_context& ctx__)
 
 template <typename T>
 void
-Band::set_subspace_mtrx(int N__, int n__, Wave_functions& phi__, Wave_functions& op_phi__, dmatrix<T>& mtrx__,
+Band::set_subspace_mtrx(int N__, int n__, int num_locked, Wave_functions& phi__, Wave_functions& op_phi__, dmatrix<T>& mtrx__,
                         dmatrix<T>* mtrx_old__) const
 {
     PROFILE("sirius::Band::set_subspace_mtrx");
@@ -54,11 +54,11 @@ Band::set_subspace_mtrx(int N__, int n__, Wave_functions& phi__, Wave_functions&
         assert(&mtrx__.blacs_grid() == &mtrx_old__->blacs_grid());
     }
 
-    /* copy old N x N distributed matrix */
+    /* copy old N - num_locked x N - num_locked distributed matrix */
     if (N__ > 0) {
-        splindex<splindex_t::block_cyclic> spl_row(N__, mtrx__.blacs_grid().num_ranks_row(), mtrx__.blacs_grid().rank_row(),
+        splindex<splindex_t::block_cyclic> spl_row(N__ - num_locked, mtrx__.blacs_grid().num_ranks_row(), mtrx__.blacs_grid().rank_row(),
                                        mtrx__.bs_row());
-        splindex<splindex_t::block_cyclic> spl_col(N__, mtrx__.blacs_grid().num_ranks_col(), mtrx__.blacs_grid().rank_col(),
+        splindex<splindex_t::block_cyclic> spl_col(N__ - num_locked, mtrx__.blacs_grid().num_ranks_col(), mtrx__.blacs_grid().rank_col(),
                                        mtrx__.bs_col());
 
         if (mtrx_old__) {
@@ -83,27 +83,27 @@ Band::set_subspace_mtrx(int N__, int n__, Wave_functions& phi__, Wave_functions&
     }
 
     /* <{phi,phi_new}|Op|phi_new> */
-    inner(ctx_.preferred_memory_t(), ctx_.blas_linalg_t(), (ctx_.num_mag_dims() == 3) ? 2 : 0, phi__, 0, N__ + n__,
-          op_phi__, N__, n__, mtrx__, 0, N__);
+    inner(ctx_.preferred_memory_t(), ctx_.blas_linalg_t(), (ctx_.num_mag_dims() == 3) ? 2 : 0, phi__, num_locked, N__ + n__ - num_locked,
+          op_phi__, N__, n__, mtrx__, 0, N__ - num_locked);
 
     /* restore lower part */
     if (N__ > 0) {
         if (mtrx__.blacs_grid().comm().size() == 1) {
             #pragma omp parallel for
-            for (int i = 0; i < N__; i++) {
-                for (int j = N__; j < N__ + n__; j++) {
+            for (int i = 0; i < N__ - num_locked; i++) {
+                for (int j = N__ - num_locked; j < N__ + n__ - num_locked; j++) {
                     mtrx__(j, i) = utils::conj(mtrx__(i, j));
                 }
             }
         } else {
-            linalg(linalg_t::scalapack).tranc(n__, N__, mtrx__, 0, N__, mtrx__, N__, 0);
+            linalg(linalg_t::scalapack).tranc(n__, N__ - num_locked, mtrx__, 0, N__ - num_locked, mtrx__, N__ - num_locked, 0);
         }
     }
 
     if (ctx_.control().print_checksum_) {
-        splindex<splindex_t::block_cyclic> spl_row(N__ + n__, mtrx__.blacs_grid().num_ranks_row(),
+        splindex<splindex_t::block_cyclic> spl_row(N__ + n__ - num_locked, mtrx__.blacs_grid().num_ranks_row(),
                                                    mtrx__.blacs_grid().rank_row(), mtrx__.bs_row());
-        splindex<splindex_t::block_cyclic> spl_col(N__ + n__, mtrx__.blacs_grid().num_ranks_col(),
+        splindex<splindex_t::block_cyclic> spl_col(N__ + n__ - num_locked, mtrx__.blacs_grid().num_ranks_col(),
                                                    mtrx__.blacs_grid().rank_col(), mtrx__.bs_col());
         double_complex cs(0, 0);
         for (int i = 0; i < spl_col.local_size(); i++) {
@@ -118,13 +118,13 @@ Band::set_subspace_mtrx(int N__, int n__, Wave_functions& phi__, Wave_functions&
     }
 
     /* kill any numerical noise */
-    mtrx__.make_real_diag(N__ + n__);
+    mtrx__.make_real_diag(N__ + n__ - num_locked);
 
     /* save new matrix */
     if (mtrx_old__) {
-        splindex<splindex_t::block_cyclic> spl_row(N__ + n__, mtrx__.blacs_grid().num_ranks_row(),
+        splindex<splindex_t::block_cyclic> spl_row(N__ + n__ - num_locked, mtrx__.blacs_grid().num_ranks_row(),
                                                    mtrx__.blacs_grid().rank_row(), mtrx__.bs_row());
-        splindex<splindex_t::block_cyclic> spl_col(N__ + n__, mtrx__.blacs_grid().num_ranks_col(),
+        splindex<splindex_t::block_cyclic> spl_col(N__ + n__ - num_locked, mtrx__.blacs_grid().num_ranks_col(),
                                                    mtrx__.blacs_grid().rank_col(), mtrx__.bs_col());
 
         #pragma omp parallel for schedule(static)
@@ -315,7 +315,7 @@ void Band::initialize_subspace(Hamiltonian_k& Hk__, int num_ao__) const
         /* do some checks */
         if (ctx_.control().verification_ >= 1) {
 
-            set_subspace_mtrx<T>(0, num_phi_tot, phi, ophi, ovlp);
+            set_subspace_mtrx<T>(0, num_phi_tot, 0, phi, ophi, ovlp);
             if (ctx_.control().verification_ >= 2 && ctx_.control().verbosity_ >= 2) {
                 ovlp.serialize("overlap", num_phi_tot);
             }
@@ -340,8 +340,8 @@ void Band::initialize_subspace(Hamiltonian_k& Hk__, int num_ao__) const
         }
 
         /* setup eigen-value problem */
-        set_subspace_mtrx<T>(0, num_phi_tot, phi, hphi, hmlt);
-        set_subspace_mtrx<T>(0, num_phi_tot, phi, ophi, ovlp);
+        set_subspace_mtrx<T>(0, num_phi_tot, 0, phi, hphi, hmlt);
+        set_subspace_mtrx<T>(0, num_phi_tot, 0, phi, ophi, ovlp);
 
         if (ctx_.control().verification_ >= 2 && ctx_.control().verbosity_ >= 2) {
             hmlt.serialize("hmlt", num_phi_tot);
@@ -542,12 +542,12 @@ void Band::check_wave_functions(Hamiltonian_k& Hk__) const
 
 template
 void
-Band::set_subspace_mtrx<double>(int N__, int n__, Wave_functions& phi__, Wave_functions& op_phi__,
+Band::set_subspace_mtrx<double>(int N__, int n__, int num_locked, Wave_functions& phi__, Wave_functions& op_phi__,
                                 dmatrix<double>& mtrx__, dmatrix<double>* mtrx_old__) const;
 
 template
 void
-Band::set_subspace_mtrx<double_complex>(int N__, int n__, Wave_functions& phi__, Wave_functions& op_phi__,
+Band::set_subspace_mtrx<double_complex>(int N__, int n__, int num_locked, Wave_functions& phi__, Wave_functions& op_phi__,
                                         dmatrix<double_complex>& mtrx__, dmatrix<double_complex>* mtrx_old__) const;
 
 }

--- a/src/band/band.hpp
+++ b/src/band/band.hpp
@@ -92,7 +92,7 @@ class Band // TODO: Band class is lightweight and in principle can be converted 
      *  for the subspace spanned by the wave-functions \f$ \phi_i \f$. The matrix is always returned
      *  in the CPU pointer because most of the standard math libraries start from the CPU. */
     template <typename T>
-    void set_subspace_mtrx(int N__, int n__, sddk::Wave_functions& phi__, sddk::Wave_functions& op_phi__,
+    void set_subspace_mtrx(int N__, int n__, int num_locked, sddk::Wave_functions& phi__, sddk::Wave_functions& op_phi__,
                            sddk::dmatrix<T>& mtrx__, sddk::dmatrix<T>* mtrx_old__ = nullptr) const;
 
     /// Solve the band eigen-problem for pseudopotential case.

--- a/src/band/davidson.hpp
+++ b/src/band/davidson.hpp
@@ -194,10 +194,10 @@ davidson(Hamiltonian_k& Hk__, Wave_functions& psi__, int num_mag_dims__, int sub
         }
 
         /* setup eigen-value problem */
-        Band(ctx).set_subspace_mtrx<T>(0, num_bands, phi, hphi, hmlt, &hmlt_old);
+        Band(ctx).set_subspace_mtrx<T>(0, num_bands, 0, phi, hphi, hmlt, &hmlt_old);
         if (!keep_phi_orthogonal__) {
             /* setup overlap matrix */
-            Band(ctx).set_subspace_mtrx<T>(0, num_bands, phi, sphi, ovlp, &ovlp_old);
+            Band(ctx).set_subspace_mtrx<T>(0, num_bands, 0, phi, sphi, ovlp, &ovlp_old);
         }
 
         /* current subspace size */
@@ -318,7 +318,7 @@ davidson(Hamiltonian_k& Hk__, Wave_functions& psi__, int num_mag_dims__, int sub
             /* setup eigen-value problem
              * N is the number of previous basis functions
              * n is the number of new basis functions */
-            Band(ctx).set_subspace_mtrx<T>(N, n, phi, hphi, hmlt, &hmlt_old);
+            Band(ctx).set_subspace_mtrx<T>(N, n, 0, phi, hphi, hmlt, &hmlt_old);
 
             //if (ctx_.control().verification_ >= 1) {
             //    double max_diff = check_hermitian(hmlt, N + n);
@@ -331,7 +331,7 @@ davidson(Hamiltonian_k& Hk__, Wave_functions& psi__, int num_mag_dims__, int sub
 
             if (!keep_phi_orthogonal__) {
                 /* setup overlap matrix */
-                Band(ctx).set_subspace_mtrx<T>(N, n, phi, sphi, ovlp, &ovlp_old);
+                Band(ctx).set_subspace_mtrx<T>(N, n, 0, phi, sphi, ovlp, &ovlp_old);
 
                 //if (ctx_.control().verification_ >= 1) {
                 //    double max_diff = check_hermitian(ovlp, N + n);

--- a/src/band/diag_full_potential.cpp
+++ b/src/band/diag_full_potential.cpp
@@ -343,7 +343,7 @@ void Band::get_singular_components(Hamiltonian_k& Hk__, mdarray<double, 2>& o_di
         }
 
         if (ctx_.control().verification_ >= 1) {
-            set_subspace_mtrx(0, N + n, phi, ophi, ovlp);
+            set_subspace_mtrx(0, N + n, 0, phi, ophi, ovlp);
 
             if (ctx_.control().verification_ >= 2) {
                 ovlp.serialize("overlap", N + n);
@@ -362,7 +362,7 @@ void Band::get_singular_components(Hamiltonian_k& Hk__, mdarray<double, 2>& o_di
         /* setup eigen-value problem
          * N is the number of previous basis functions
          * n is the number of new basis functions */
-        set_subspace_mtrx(N, n, phi, ophi, ovlp, &ovlp_old);
+        set_subspace_mtrx(N, n, 0, phi, ophi, ovlp, &ovlp_old);
 
         if (ctx_.control().verification_ >= 1) {
             if (ctx_.control().verification_ >= 2) {
@@ -408,11 +408,11 @@ void Band::get_singular_components(Hamiltonian_k& Hk__, mdarray<double, 2>& o_di
         if (!last_iteration) {
             /* get new preconditionined residuals, and also opsi and psi as a by-product */
             auto result = sirius::residuals(ctx_.preferred_memory_t(), ctx_.blas_linalg_t(), 0,
-                                  N, ncomp, eval, evec, ophi, phi, opsi, psi, res, o_diag__, diag1,
+                                  N, ncomp, 0, eval, evec, ophi, phi, opsi, psi, res, o_diag__, diag1,
                                   itso.converge_by_energy_, itso.residual_tolerance_,
                                   [&](int i, int ispn){return std::abs(eval[i] - eval_old[i]) < itso.energy_tolerance_;});
-            n = result.first;
-            current_frobenius_norm = result.second;
+            n = result.unconverged_residuals;
+            current_frobenius_norm = result.frobenius_norm;
 
             /* set the relative tolerance convergence criterion */
             if (k == 0) {
@@ -642,7 +642,7 @@ void Band::diag_full_potential_first_variation_davidson(Hamiltonian_k& Hk__) con
         /* setup eigen-value problem
          * N is the number of previous basis functions
          * n is the number of new basis functions */
-        set_subspace_mtrx(N, n, phi, hphi, hmlt, &hmlt_old);
+        set_subspace_mtrx(N, n, 0, phi, hphi, hmlt, &hmlt_old);
 
         /* increase size of the variation space */
         N += n;
@@ -664,11 +664,11 @@ void Band::diag_full_potential_first_variation_davidson(Hamiltonian_k& Hk__) con
         if (!last_iteration) {
             /* get new preconditionined residuals, and also hpsi and opsi as a by-product */
             auto result = sirius::residuals(ctx_.preferred_memory_t(), ctx_.blas_linalg_t(), 0,
-                                  N, num_bands, eval, evec, hphi, ophi, hpsi, opsi, res, h_o_diag.first, h_o_diag.second,
+                                  N, num_bands, 0, eval, evec, hphi, ophi, hpsi, opsi, res, h_o_diag.first, h_o_diag.second,
                                   itso.converge_by_energy_, itso.residual_tolerance_,
                                   [&](int i, int ispn){return std::abs(eval[i] - eval_old[i]) < itso.energy_tolerance_;});
-            n = result.first;
-            current_frobenius_norm = result.second;
+            n = result.unconverged_residuals;
+            current_frobenius_norm = result.frobenius_norm;
 
             /* set the relative tolerance convergence criterion */
             if (k == 0) {

--- a/src/band/residuals.hpp
+++ b/src/band/residuals.hpp
@@ -32,6 +32,12 @@ class dmatrix;
 class Wave_functions;
 };
 
+struct residual_result {
+  int num_consecutive_smallest_converged;
+  int unconverged_residuals;
+  double frobenius_norm;
+};
+
 
 #if defined(__GPU)
 extern "C" void residuals_aux_gpu(int num_gvec_loc__,
@@ -76,8 +82,9 @@ namespace sirius {
     \f]
  */
 template <typename T>
-std::pair<int, double>
+residual_result
 residuals(sddk::memory_t mem_type__, sddk::linalg_t la_type__, int ispn__, int N__, int num_bands__,
+          int num_locked,
           sddk::mdarray<double, 1>& eval__, sddk::dmatrix<T>& evec__, sddk::Wave_functions& hphi__,
           sddk::Wave_functions& ophi__, sddk::Wave_functions& hpsi__,
           sddk::Wave_functions& opsi__, sddk::Wave_functions& res__, sddk::mdarray<double, 2> const& h_diag__,

--- a/src/input.hpp
+++ b/src/input.hpp
@@ -251,7 +251,10 @@ struct Iterative_solver_input
     int num_steps_{20};
 
     /// Size of the variational subspace is this number times the number of bands.
-    int subspace_size_{4};
+    int subspace_size_{2};
+
+    /// Lock eigenvectors of the smallest eigenvalues when they have converged at restart
+    bool use_locking_{false};
 
     /// Tolerance for the eigen-energy difference \f$ |\epsilon_i^{old} - \epsilon_i^{new} | \f$.
     /** This parameter is reduced during the SCF cycle to reach the high accuracy of the wave-functions. */
@@ -271,7 +274,7 @@ struct Iterative_solver_input
     /** If converge_by_energy is set to 0, then the residuals are estimated by their norm. If converge_by_energy
         is set to 1 then the residuals are estimated by the eigen-energy difference. This allows to estimate the
         unconverged residuals and then compute only the unconverged ones. */
-    int converge_by_energy_{1}; // TODO: rename, this is meaningless
+    int converge_by_energy_{0}; // TODO: rename, this is meaningless
 
     /// Minimum number of residuals to continue iterative diagonalization process.
     int min_num_res_{0};
@@ -299,6 +302,7 @@ struct Iterative_solver_input
             type_                   = section.value("type", type_);
             num_steps_              = section.value("num_steps", num_steps_);
             subspace_size_          = section.value("subspace_size", subspace_size_);
+            use_locking_            = section.value("locking", use_locking_);
             energy_tolerance_       = section.value("energy_tolerance", energy_tolerance_);
             residual_tolerance_     = section.value("residual_tolerance", residual_tolerance_);
             relative_tolerance_     = section.value("relative_tolerance", relative_tolerance_);
@@ -310,6 +314,11 @@ struct Iterative_solver_input
             init_eval_old_          = section.value("init_eval_old", init_eval_old_);
             init_subspace_          = section.value("init_subspace", init_subspace_);
             std::transform(init_subspace_.begin(), init_subspace_.end(), init_subspace_.begin(), ::tolower);
+
+            // locking implies orthogonalization, so let's just enforce it.
+            if (use_locking_) {
+                orthogonalize_ = true;
+            }
         }
     }
 };

--- a/src/linalg/eigenproblem.hpp
+++ b/src/linalg/eigenproblem.hpp
@@ -152,8 +152,7 @@ class Eigensolver_lapack : public Eigensolver
     }
 
     /// Solve a standard eigen-value problem for N lowest eigen-pairs.
-    int solve(ftn_int matrix_size__, ftn_int nev__, dmatrix<double_complex>& A__, double* eval__,
-              dmatrix<double_complex>& Z__)
+    int solve(ftn_int matrix_size__, ftn_int nev__, dmatrix<double_complex>& A__, double* eval__, dmatrix<double_complex>& Z__)
     {
         PROFILE("Eigensolver_lapack|zheevx");
 
@@ -730,8 +729,7 @@ class Eigensolver_scalapack : public Eigensolver
     }
 
     /// Solve a standard eigen-value problem for N lowest eigen-pairs.
-    int solve(ftn_int matrix_size__, ftn_int nev__, dmatrix<double_complex>& A__, double* eval__,
-              dmatrix<double_complex>& Z__)
+    int solve(ftn_int matrix_size__, ftn_int nev__, dmatrix<double_complex>& A__, double* eval__, dmatrix<double_complex>& Z__)
     {
         PROFILE("Eigensolver_scalapack|pzheevx");
 
@@ -1160,8 +1158,7 @@ class Eigensolver_magma: public Eigensolver
     }
 
     /// Solve a standard eigen-value problem for N lowest eigen-pairs.
-    int solve(ftn_int matrix_size__, ftn_int nev__, dmatrix<double_complex>& A__, double* eval__,
-              dmatrix<double_complex>& Z__)
+    int solve(ftn_int matrix_size__, ftn_int nev__, dmatrix<double_complex>& A__, double* eval__, dmatrix<double_complex>& Z__)
     {
         PROFILE("Eigensolver_magma|zheevdx");
 
@@ -1353,8 +1350,7 @@ class Eigensolver_magma_gpu: public Eigensolver
     //}
 
     /// Solve a standard eigen-value problem for N lowest eigen-pairs.
-    int solve(ftn_int matrix_size__, ftn_int nev__, dmatrix<double_complex>& A__, double* eval__,
-              dmatrix<double_complex>& Z__)
+    int solve(ftn_int matrix_size__, ftn_int nev__, dmatrix<double_complex>& A__, double* eval__, dmatrix<double_complex>& Z__)
     {
         PROFILE("Eigensolver_magma_gpu|zheevdx");
 
@@ -1398,7 +1394,7 @@ class Eigensolver_magma_gpu: public Eigensolver
             //    std::copy(A__.at(memory_t::host, 0, i), A__.at(memory_t::host, 0, i) + matrix_size__,
             //              Z__.at(memory_t::host, 0, i));
             //}
-            acc::copyout(Z__.at(memory_t::host, 0, 0), Z__.ld(), A__.at(memory_t::device, 0, 0), A__.ld(),
+            acc::copyout(Z__.at(memory_t::host), Z__.ld(), A__.at(memory_t::device), A__.ld(),
                          matrix_size__, nev__);
         }
 
@@ -1434,8 +1430,7 @@ class Eigensolver_cuda: public Eigensolver
     {
     }
 
-    int solve(ftn_int matrix_size__, int nev__, dmatrix<double_complex>& A__, double* eval__,
-              dmatrix<double_complex>& Z__)
+    int solve(ftn_int matrix_size__, int nev__, dmatrix<double_complex>& A__, double* eval__, dmatrix<double_complex>& Z__)
     {
         PROFILE("Eigensolver_cuda|zheevdx");
 
@@ -1472,13 +1467,7 @@ class Eigensolver_cuda: public Eigensolver
         return info;
     }
 
-    int solve(ftn_int matrix_size__, dmatrix<double_complex>& A__, double* eval__, dmatrix<double_complex>& Z__)
-    {
-        return solve(matrix_size__, matrix_size__, A__, eval__, Z__);
-    }
-
-    int solve(ftn_int matrix_size__, int nev__, dmatrix<double>& A__, double* eval__,
-              dmatrix<double>& Z__)
+    int solve(ftn_int matrix_size__, int nev__, dmatrix<double>& A__, double* eval__, dmatrix<double>& Z__)
     {
         PROFILE("Eigensolver_cuda|dsyevdx");
 
@@ -1511,11 +1500,6 @@ class Eigensolver_cuda: public Eigensolver
             acc::copyout(Z__.at(memory_t::host), Z__.ld(), A__.at(memory_t::device), A__.ld(), matrix_size__, nev__);
         }
         return info;
-    }
-
-    int solve(ftn_int matrix_size__, dmatrix<double>& A__, double* eval__, dmatrix<double>& Z__)
-    {
-        return solve(matrix_size__, matrix_size__, A__, eval__, Z__);
     }
 
     int solve(ftn_int matrix_size__, int nev__, dmatrix<double_complex>& A__, dmatrix<double_complex>& B__, double* eval__,

--- a/src/linalg/eigensolver.hpp
+++ b/src/linalg/eigensolver.hpp
@@ -127,6 +127,7 @@ class Eigensolver
         TERMINATE(error_msg_not_implemented);
         return -1;
     }
+
     /// Solve a standard eigen-value problem for all eigen-pairs.
     virtual int solve(ftn_int matrix_size__, sddk::dmatrix<double_complex>& A__, double* eval__,
                       sddk::dmatrix<double_complex>& Z__)
@@ -135,17 +136,15 @@ class Eigensolver
         return -1;
     }
 
-    /// Solve a standard eigen-value problem for N lowest eigen-pairs.
-    virtual int solve(ftn_int matrix_size__, ftn_int nev__, sddk::dmatrix<double>& A__, double* eval__,
-                      sddk::dmatrix<double>& Z__)
+    /// Solve a standard eigen-value problem of a sub-matrix for N lowest eigen-pairs
+    virtual int solve(ftn_int matrix_size__, ftn_int nev__, sddk::dmatrix<double>& A__, double* eval__, sddk::dmatrix<double>& Z__)
     {
         TERMINATE(error_msg_not_implemented);
         return -1;
     }
 
-    /// Solve a standard eigen-value problem for N lowest eigen-pairs.
-    virtual int solve(ftn_int matrix_size__, ftn_int nev__, sddk::dmatrix<double_complex>& A__, double* eval__,
-                      sddk::dmatrix<double_complex>& Z__)
+    /// Solve a standard eigen-value problem of a sub-matrix for N lowest eigen-pairs.
+    virtual int solve(ftn_int matrix_size__, ftn_int nev__, sddk::dmatrix<double_complex>& A__, double* eval__, sddk::dmatrix<double_complex>& Z__)
     {
         TERMINATE(error_msg_not_implemented);
         return -1;


### PR DESCRIPTION
This implements locking of converged vectors at restart. It should reduce the time spend on the dense eigensolver, and should work particularly well when the search subspace size is kept rather small (= more restarts), that is `subspace_size = 2` or so.

It introduces at least one new parameter `block_size`, which is currently hard-coded to be `num_bands / 2`. The idea being that you can do twice as many iterations per restart, s.t. it converges quicker to a subset of the eigenvectors, which can then be locked.

Currently only the smallest eigenpairs are locked. They should be theoretically first to converge anyways. Sometimes it happens though that interior eigenpairs converge first; they are just kept in the search subspace. We could do locking for them, but then potentially we have to permute eigenvectors later again, and potentially we might even need to remove an eigenpair later, when it turns out to have an eigenvalue larger than the `num_bands` smallest ones.

- [x] cuda / cpu version
- [x] flag to enable locking
- [x] implement some missing methods for magma / elpa (probably) for getting eigenvalues from a submatrix
- [x] make it a bit less memory hungry; currently  Hpsi, Spsi and res also allocate num_phi vectors, which is more than necessary, in my julia code only one of these is of size num_phi and the others are num_bands.
- [ ] this one is very bug-prone to implement :sweat_smile:, so I have reverted it at some point: when almost all vectors have converged except for a handful, convergence is very slow. It seems this is because the residuals are near 0 anyways, and the preconditioned residuals are poor quality because of large numerical errors (for instance, the diagonal of the cholesky decomp for interior orthogonalization contains many near 0 values). In my experience it's better to compute a few more residuals of eigenpairs with slightly larger eigenvalues, and converging towards them also improves convergence to the last targeted vecs -- this is because those residuals are not close to 0, so less numerical noise, and they contain components in the direction of smaller eigenvalues as well.
- [x] test it more with `converge_by_energy` enabled
- [ ] implement the same for the other davidson solvers in the SIRIUS code base