### PR TITLE
Add profiler sections to NVTX output

### DIFF
--- a/src/utils/nvtx_profiler.hpp
+++ b/src/utils/nvtx_profiler.hpp
@@ -1,0 +1,52 @@
+#ifndef NVTX_PROFILER_H
+#define NVTX_PROFILER_H
+
+#if defined(__CUDA_NVTX)
+
+#include "nvToolsExt.h"
+#include <unordered_map>
+
+namespace nvtxprofiler {
+
+class Timer {
+public:
+  void start(std::string const &str) {
+    timers_[str] = nvtxRangeStartA(str.c_str());
+  }
+
+  void stop(std::string const &str) {
+    auto result = timers_.find(str);
+    if (result == timers_.end()) return;
+    nvtxRangeEnd(result->second);
+    timers_.erase(result);
+  }
+
+private:
+  std::unordered_map<std::string, nvtxRangeId_t> timers_;
+};
+
+class ScopedTiming {
+public:
+  ScopedTiming(std::string identifier, Timer &timer) :
+    identifier_(identifier), timer_(timer) {
+    timer.start(identifier_);
+  }
+
+  ScopedTiming(const ScopedTiming&) = delete;
+  ScopedTiming(ScopedTiming&&) = delete;
+  auto operator=(const ScopedTiming&) -> ScopedTiming& = delete;
+  auto operator=(ScopedTiming &&) -> ScopedTiming& = delete;
+
+  ~ScopedTiming() {
+    timer_.stop(identifier_);
+  }
+
+private:
+  std::string identifier_;
+  Timer& timer_;
+};
+
+}
+
+#endif
+#endif

--- a/src/utils/profiler.cpp
+++ b/src/utils/profiler.cpp
@@ -26,4 +26,8 @@
 
 namespace utils {
 ::rt_graph::Timer global_rtgraph_timer;
+
+#if defined(__CUDA_NVTX)
+::nvtxprofiler::Timer global_nvtx_timer;
+#endif
 }


### PR DESCRIPTION
Requires the cmake `-DUSE_NVTX=ON` flag to be enabled. In `nsys-ui` the results look like this:

![Screenshot from 2020-07-22 15-46-41](https://user-images.githubusercontent.com/194764/88184104-99dc3c80-cc32-11ea-8972-bb10148d909e.png)


