### PR TITLE
cleanup number of cuda stream handles

### DIFF
--- a/src/sirius.hpp
+++ b/src/sirius.hpp
@@ -104,7 +104,7 @@ inline void initialize(bool call_mpi_init__ = true)
         /* create extensive amount of streams */
         /* some parts of the code rely on the number of streams not related to the
            number of OMP threads */
-        acc::create_streams(omp_get_max_threads() + 100);
+        acc::create_streams(std::max(omp_get_max_threads(), 6));
 #if defined(__GPU)
         accblas::create_stream_handles();
 #endif


### PR DESCRIPTION
Depending on the number of MPI ranks and type of NVIDIA cards using too many CUDA stream handles caused `cudaStreamCreate` to fail. 

Instead of creating `OMP_NUM_THREADS+100` cuda stream handles `max(OMP_NUM_THREADS, 6)` should be sufficient:

- wf_ortho is using 3*nspin (max = 6) streams independent on the number of omp threads
- wf_inner is using a hard coded value of 4, but applies `% num_streams` afterwards

This should fix #513.
