### PR TITLE
Do not use gpu in elpa in cpu mode

### DIFF
--- a/src/linalg/eigenproblem.hpp
+++ b/src/linalg/eigenproblem.hpp
@@ -583,7 +583,10 @@ class Eigensolver_elpa : public Eigensolver
         //if (error != ELPA_OK) {
         //    TERMINATE("can't set elpa threads");
         //}
-        elpa_set_integer(handle, "gpu", 1, &error);
+
+        if (acc::num_devices() != 0) {
+            elpa_set_integer(handle, "gpu", 1, &error);
+        }
 
         if (stage_ == 1) {
             elpa_set_integer(handle, "solver", ELPA_SOLVER_1STAGE, &error);
@@ -642,7 +645,10 @@ class Eigensolver_elpa : public Eigensolver
         //if (error != ELPA_OK) {
         //    TERMINATE("can't set elpa threads");
         //}
-        elpa_set_integer(handle, "gpu", 1, &error);
+
+        if (acc::num_devices() != 0) {
+            elpa_set_integer(handle, "gpu", 1, &error);
+        }
 
         if (stage_ == 1) {
             elpa_set_integer(handle, "solver", ELPA_SOLVER_1STAGE, &error);


### PR DESCRIPTION
elpa insists on using the GPU after calling `elpa_set_integer(handle, "gpu", 1, &error);` even when compiled without GPU support