### PR TITLE
Use AND generator expression for HAVE_HIP

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -135,7 +135,7 @@ target_compile_definitions(sirius PUBLIC
   $<$<BOOL:${USE_ROCM}>:__GPU __ROCM>
   $<$<BOOL:${USE_VDWXC}>:__USE_VDWXC>
   $<$<BOOL:${HAVE_LIBVDW_WITH_MPI}>:__HAVE_VDWXC_MPI>
-  $<$<BOOL:${USE_MAGMA} AND ${USE_ROCM}>:HAVE_HIP> # Required for magma headers
+  $<$<AND:$<BOOL:${USE_MAGMA}>,$<BOOL:${USE_ROCM}>>:HAVE_HIP> # Required for magma headers
 )
 
 set_target_properties(sirius PROPERTIES POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
`-DHAVE_HIP` is currently always set, I believe this is the correct way to using AND in generator expressions