### PR TITLE
Fix for the large number of MPI ranks

### DIFF
--- a/src/SDDK/memory.hpp
+++ b/src/SDDK/memory.hpp
@@ -657,18 +657,17 @@ void memory_pool_deleter::memory_pool_deleter_impl::free(void* ptr__)
 #ifdef NDEBUG
 #define mdarray_assert(condition__)
 #else
-#define mdarray_assert(condition__)                             \
-{                                                               \
-    if (!(condition__)) {                                       \
+#define mdarray_assert(condition__)                                  \
+{                                                                    \
+    if (!(condition__)) {                                            \
         std::printf("Assertion (%s) failed ", #condition__);         \
         std::printf("at line %i of file %s\n", __LINE__, __FILE__);  \
         std::printf("array label: %s\n", label_.c_str());            \
-        for (int i = 0; i < N; i++) {                           \
+        for (int i = 0; i < N; i++) {                                \
             std::printf("dim[%i].size = %li\n", i, dims_[i].size()); \
-        }                                                       \
-        raise(SIGTERM);                                         \
-        exit(-13);                                              \
-    }                                                           \
+        }                                                            \
+        raise(SIGABRT);                                              \
+    }                                                                \
 }
 #endif
 
@@ -807,7 +806,7 @@ class mdarray
         }
     }
 
-    /// Return linear index in the range [0, size) by the N-dimensional indices.(i0, i1, ...)
+    /// Return linear index in the range [0, size) by the N-dimensional indices (i0, i1, ...)
     template <typename... Args>
     inline index_type idx(Args... args) const
     {

--- a/src/function3d/smooth_periodic_function.hpp
+++ b/src/function3d/smooth_periodic_function.hpp
@@ -209,17 +209,19 @@ class Smooth_periodic_function
 
         assert(gvecp_ != nullptr);
 
+        auto frg_ptr = (spfft_->local_slice_size() == 0) ? nullptr : &f_rg_[0];
+
         switch (direction__) {
             case 1: {
                 if (gvecp_->comm_ortho_fft().size() != 1) {
                     gather_f_pw_fft();
                 }
                 spfft_->backward(reinterpret_cast<double const*>(f_pw_fft_.at(sddk::memory_t::host)), SPFFT_PU_HOST);
-                spfft_output(*spfft_, &f_rg_[0]);
+                spfft_output(*spfft_, frg_ptr);
                 break;
             }
             case -1: {
-                spfft_input(*spfft_, &f_rg_[0]);
+                spfft_input(*spfft_, frg_ptr);
                 spfft_->forward(SPFFT_PU_HOST, reinterpret_cast<double*>(f_pw_fft_.at(sddk::memory_t::host)),
                                 SPFFT_FULL_SCALING);
                 if (gvecp_->comm_ortho_fft().size() != 1) {

--- a/src/potential/xc.cpp
+++ b/src/potential/xc.cpp
@@ -582,97 +582,98 @@ void Potential::xc_rg_nonmagnetic(Density const& density__)
         vsigma_tmp.zero();
     }
 
-    /* loop over XC functionals */
-    for (auto& ixc: xc_func_) {
-
-        /*
-          I need to split vdw from the parallel section since it involves a fft
-          for each grid point
-        */
-        if (ixc.is_vdw()) {
+    if (num_points) {
+        /* loop over XC functionals */
+        for (auto& ixc: xc_func_) {
+            /*
+              I need to split vdw from the parallel section since it involves a fft
+              for each grid point
+            */
+            if (ixc.is_vdw()) {
 #if defined(__USE_VDWXC)
-            /* Van der Walls correction */
-            std::vector<double> exc_t(num_points, 0.0);
-            std::vector<double> vrho_t(num_points, 0.0);
-            std::vector<double> vsigma_t(num_points, 0.0);
+                /* Van der Walls correction */
+                std::vector<double> exc_t(num_points, 0.0);
+                std::vector<double> vrho_t(num_points, 0.0);
+                std::vector<double> vsigma_t(num_points, 0.0);
 
-            ixc.get_vdw(&rho.f_rg(0),
-                        &grad_rho_grad_rho.f_rg(0),
-                        &vrho_t[0],
-                        &vsigma_t[0],
-                        &exc_t[0]);
-            #pragma omp parallel for
-            for (int i = 0; i < num_points; i++) {
-                /* add Exc contribution */
-                exc_tmp(i) += exc_t[i];
+                ixc.get_vdw(&rho.f_rg(0),
+                            &grad_rho_grad_rho.f_rg(0),
+                            &vrho_t[0],
+                            &vsigma_t[0],
+                            &exc_t[0]);
+                #pragma omp parallel for
+                for (int i = 0; i < num_points; i++) {
+                    /* add Exc contribution */
+                    exc_tmp(i) += exc_t[i];
 
-                /* directly add to Vxc available contributions */
-                //if (use_2nd_deriv) {
-                //    vxc_tmp(spl_np_t[i]) += (vrho_t[i] - 2 * vsigma_t[i] * lapl_rho.f_rg(spl_np_t[i]));
-                //} else {
-                //    vxc_tmp(spl_np_t[i]) += vrho_t[i];
-                //}
-                vxc_tmp(i) += vrho_t[i];
+                    /* directly add to Vxc available contributions */
+                    //if (use_2nd_deriv) {
+                    //    vxc_tmp(spl_np_t[i]) += (vrho_t[i] - 2 * vsigma_t[i] * lapl_rho.f_rg(spl_np_t[i]));
+                    //} else {
+                    //    vxc_tmp(spl_np_t[i]) += vrho_t[i];
+                    //}
+                    vxc_tmp(i) += vrho_t[i];
 
-                /* save the sigma derivative */
-                vsigma_tmp(i) += vsigma_t[i];
-            }
-#else
-            TERMINATE("You should not be there since SIRIUS is not compiled with libVDWXC support\n");
-#endif
-        } else {
-            #pragma omp parallel
-            {
-                /* split local size between threads */
-                splindex<splindex_t::block> spl_np_t(num_points, omp_get_num_threads(), omp_get_thread_num());
-
-                std::vector<double> exc_t(spl_np_t.local_size());
-
-                /* if this is an LDA functional */
-                if (ixc.is_lda()) {
-                    std::vector<double> vxc_t(spl_np_t.local_size());
-
-                    ixc.get_lda(spl_np_t.local_size(),
-                                &rho.f_rg(spl_np_t.global_offset()),
-                                &vxc_t[0],
-                                &exc_t[0]);
-
-                    for (int i = 0; i < spl_np_t.local_size(); i++) {
-                        /* add Exc contribution */
-                        exc_tmp(spl_np_t[i]) += exc_t[i];
-
-                        /* directly add to Vxc */
-                        vxc_tmp(spl_np_t[i]) += vxc_t[i];
-                    }
+                    /* save the sigma derivative */
+                    vsigma_tmp(i) += vsigma_t[i];
                 }
+#else
+                TERMINATE("You should not be there since SIRIUS is not compiled with libVDWXC support\n");
+#endif
+            } else {
+                #pragma omp parallel
+                {
+                    /* split local size between threads */
+                    splindex<splindex_t::block> spl_np_t(num_points, omp_get_num_threads(), omp_get_thread_num());
 
-                if (ixc.is_gga()) {
-                    std::vector<double> vrho_t(spl_np_t.local_size());
-                    std::vector<double> vsigma_t(spl_np_t.local_size());
+                    std::vector<double> exc_t(spl_np_t.local_size());
 
-                    ixc.get_gga(spl_np_t.local_size(),
-                                &rho.f_rg(spl_np_t.global_offset()),
-                                &grad_rho_grad_rho.f_rg(spl_np_t.global_offset()),
-                                &vrho_t[0],
-                                &vsigma_t[0],
-                                &exc_t[0]);
+                    /* if this is an LDA functional */
+                    if (ixc.is_lda()) {
+                        std::vector<double> vxc_t(spl_np_t.local_size());
 
-                    /* this is the same expression between gga and vdw corrections.
-                     * The functionals are different that's all */
-                    for (int i = 0; i < spl_np_t.local_size(); i++) {
-                        /* add Exc contribution */
-                        exc_tmp(spl_np_t[i]) += exc_t[i];
+                        ixc.get_lda(spl_np_t.local_size(),
+                                    &rho.f_rg(spl_np_t.global_offset()),
+                                    &vxc_t[0],
+                                    &exc_t[0]);
 
-                        /* directly add to Vxc available contributions */
-                        //if (use_2nd_deriv) {
-                        //    vxc_tmp(spl_np_t[i]) += (vrho_t[i] - 2 * vsigma_t[i] * lapl_rho.f_rg(spl_np_t[i]));
-                        //} else {
-                        //    vxc_tmp(spl_np_t[i]) += vrho_t[i];
-                        //}
-                        vxc_tmp(spl_np_t[i]) += vrho_t[i];
+                        for (int i = 0; i < spl_np_t.local_size(); i++) {
+                            /* add Exc contribution */
+                            exc_tmp(spl_np_t[i]) += exc_t[i];
 
-                        /* save the sigma derivative */
-                        vsigma_tmp(spl_np_t[i]) += vsigma_t[i];
+                            /* directly add to Vxc */
+                            vxc_tmp(spl_np_t[i]) += vxc_t[i];
+                        }
+                    }
+
+                    if (ixc.is_gga()) {
+                        std::vector<double> vrho_t(spl_np_t.local_size());
+                        std::vector<double> vsigma_t(spl_np_t.local_size());
+
+                        ixc.get_gga(spl_np_t.local_size(),
+                                    &rho.f_rg(spl_np_t.global_offset()),
+                                    &grad_rho_grad_rho.f_rg(spl_np_t.global_offset()),
+                                    &vrho_t[0],
+                                    &vsigma_t[0],
+                                    &exc_t[0]);
+
+                        /* this is the same expression between gga and vdw corrections.
+                         * The functionals are different that's all */
+                        for (int i = 0; i < spl_np_t.local_size(); i++) {
+                            /* add Exc contribution */
+                            exc_tmp(spl_np_t[i]) += exc_t[i];
+
+                            /* directly add to Vxc available contributions */
+                            //if (use_2nd_deriv) {
+                            //    vxc_tmp(spl_np_t[i]) += (vrho_t[i] - 2 * vsigma_t[i] * lapl_rho.f_rg(spl_np_t[i]));
+                            //} else {
+                            //    vxc_tmp(spl_np_t[i]) += vrho_t[i];
+                            //}
+                            vxc_tmp(spl_np_t[i]) += vrho_t[i];
+
+                            /* save the sigma derivative */
+                            vsigma_tmp(spl_np_t[i]) += vsigma_t[i];
+                        }
                     }
                 }
             }
@@ -871,110 +872,112 @@ void Potential::xc_rg_magnetic(Density const& density__)
     }
 
     PROFILE_START("sirius::Potential::xc_rg_magnetic|libxc");
-    /* loop over XC functionals */
-    for (auto& ixc: xc_func_) {
-        /* treat vdw correction outside the parallel region because it uses fft
-         * internaly */
+    if (num_points) {
+        /* loop over XC functionals */
+        for (auto& ixc: xc_func_) {
+            /* treat vdw correction outside the parallel region because it uses fft
+             * internaly */
 
-        if (ixc.is_vdw()) {
+            if (ixc.is_vdw()) {
 #if defined(__USE_VDWXC)
-            std::vector<double> vrho_up_t(num_points, 0.0);
-            std::vector<double> vrho_dn_t(num_points, 0.0);
-            std::vector<double> vsigma_uu_t(num_points, 0.0);
-//            std::vector<double> vsigma_ud_t(num_points, 0.0);
-            std::vector<double> vsigma_dd_t(num_points, 0.0);
-            std::vector<double> exc_t(num_points, 0.0);
+                std::vector<double> vrho_up_t(num_points, 0.0);
+                std::vector<double> vrho_dn_t(num_points, 0.0);
+                std::vector<double> vsigma_uu_t(num_points, 0.0);
+    //            std::vector<double> vsigma_ud_t(num_points, 0.0);
+                std::vector<double> vsigma_dd_t(num_points, 0.0);
+                std::vector<double> exc_t(num_points, 0.0);
 
-            ixc.get_vdw(&rho_up.f_rg(0),
-                        &rho_dn.f_rg(0),
-                        &grad_rho_up_grad_rho_up.f_rg(0),
-                        &grad_rho_dn_grad_rho_dn.f_rg(0),
-                        &vrho_up_t[0],
-                        &vrho_dn_t[0],
-                        &vsigma_uu_t[0],
-                        &vsigma_dd_t[0],
-                        &exc_t[0]);
+                ixc.get_vdw(&rho_up.f_rg(0),
+                            &rho_dn.f_rg(0),
+                            &grad_rho_up_grad_rho_up.f_rg(0),
+                            &grad_rho_dn_grad_rho_dn.f_rg(0),
+                            &vrho_up_t[0],
+                            &vrho_dn_t[0],
+                            &vsigma_uu_t[0],
+                            &vsigma_dd_t[0],
+                            &exc_t[0]);
 
-            #pragma omp parallel for
-            for (int i = 0; i < num_points; i++) {
-                /* add Exc contribution */
-                exc_tmp(i) += exc_t[i];
+                #pragma omp parallel for
+                for (int i = 0; i < num_points; i++) {
+                    /* add Exc contribution */
+                    exc_tmp(i) += exc_t[i];
 
-                /* directly add to Vxc available contributions */
-                vxc_up_tmp(i) += vrho_up_t[i];
-                vxc_dn_tmp(i) += vrho_dn_t[i];
+                    /* directly add to Vxc available contributions */
+                    vxc_up_tmp(i) += vrho_up_t[i];
+                    vxc_dn_tmp(i) += vrho_dn_t[i];
 
-                /* save the sigma derivative */
-                vsigma_uu_tmp(i) += vsigma_uu_t[i];
-                //              vsigma_ud_tmp(i) += vsigma_ud_t[i];
-                vsigma_dd_tmp(i) += vsigma_dd_t[i];
-            }
-#else
-            TERMINATE("You should not be there since sirius is not compiled with libVDWXC\n");
-#endif
-        } else {
-#pragma omp parallel
-            {
-                /* split local size between threads */
-                splindex<splindex_t::block> spl_t(num_points, omp_get_num_threads(), omp_get_thread_num());
-
-                std::vector<double> exc_t(spl_t.local_size());
-
-                /* if this is an LDA functional */
-                if (ixc.is_lda()) {
-                    std::vector<double> vxc_up_t(spl_t.local_size());
-                    std::vector<double> vxc_dn_t(spl_t.local_size());
-
-
-                    ixc.get_lda(spl_t.local_size(),
-                                &rho_up.f_rg(spl_t.global_offset()),
-                                &rho_dn.f_rg(spl_t.global_offset()),
-                                &vxc_up_t[0],
-                                &vxc_dn_t[0],
-                                &exc_t[0]);
-
-                    for (int i = 0; i < spl_t.local_size(); i++) {
-                        /* add Exc contribution */
-                        exc_tmp(spl_t[i]) += exc_t[i];
-
-                        /* directly add to Vxc */
-                        vxc_up_tmp(spl_t[i]) += vxc_up_t[i];
-                        vxc_dn_tmp(spl_t[i]) += vxc_dn_t[i];
-                    }
+                    /* save the sigma derivative */
+                    vsigma_uu_tmp(i) += vsigma_uu_t[i];
+                    //              vsigma_ud_tmp(i) += vsigma_ud_t[i];
+                    vsigma_dd_tmp(i) += vsigma_dd_t[i];
                 }
+#else
+                TERMINATE("You should not be there since sirius is not compiled with libVDWXC\n");
+#endif
+            } else {
+                #pragma omp parallel
+                {
+                    /* split local size between threads */
+                    splindex<splindex_t::block> spl_t(num_points, omp_get_num_threads(), omp_get_thread_num());
 
-                if (ixc.is_gga()) {
-                    std::vector<double> vrho_up_t(spl_t.local_size());
-                    std::vector<double> vrho_dn_t(spl_t.local_size());
-                    std::vector<double> vsigma_uu_t(spl_t.local_size());
-                    std::vector<double> vsigma_ud_t(spl_t.local_size());
-                    std::vector<double> vsigma_dd_t(spl_t.local_size());
+                    std::vector<double> exc_t(spl_t.local_size());
 
-                    ixc.get_gga(spl_t.local_size(),
-                                &rho_up.f_rg(spl_t.global_offset()),
-                                &rho_dn.f_rg(spl_t.global_offset()),
-                                &grad_rho_up_grad_rho_up.f_rg(spl_t.global_offset()),
-                                &grad_rho_up_grad_rho_dn.f_rg(spl_t.global_offset()),
-                                &grad_rho_dn_grad_rho_dn.f_rg(spl_t.global_offset()),
-                                &vrho_up_t[0],
-                                &vrho_dn_t[0],
-                                &vsigma_uu_t[0],
-                                &vsigma_ud_t[0],
-                                &vsigma_dd_t[0],
-                                &exc_t[0]);
+                    /* if this is an LDA functional */
+                    if (ixc.is_lda()) {
+                        std::vector<double> vxc_up_t(spl_t.local_size());
+                        std::vector<double> vxc_dn_t(spl_t.local_size());
 
-                    #pragma omp parallel for
-                    for (int i = 0; i < spl_t.local_size(); i++) {
-                        /* add Exc contribution */
-                        exc_tmp(spl_t[i]) += exc_t[i];
-                        /* directly add to Vxc available contributions */
-                        vxc_up_tmp(spl_t[i]) += vrho_up_t[i];
-                        vxc_dn_tmp(spl_t[i]) += vrho_dn_t[i];
 
-                        /* save the sigma derivative */
-                        vsigma_uu_tmp(spl_t[i]) += vsigma_uu_t[i];
-                        vsigma_ud_tmp(spl_t[i]) += vsigma_ud_t[i];
-                        vsigma_dd_tmp(spl_t[i]) += vsigma_dd_t[i];
+                        ixc.get_lda(spl_t.local_size(),
+                                    &rho_up.f_rg(spl_t.global_offset()),
+                                    &rho_dn.f_rg(spl_t.global_offset()),
+                                    &vxc_up_t[0],
+                                    &vxc_dn_t[0],
+                                    &exc_t[0]);
+
+                        for (int i = 0; i < spl_t.local_size(); i++) {
+                            /* add Exc contribution */
+                            exc_tmp(spl_t[i]) += exc_t[i];
+
+                            /* directly add to Vxc */
+                            vxc_up_tmp(spl_t[i]) += vxc_up_t[i];
+                            vxc_dn_tmp(spl_t[i]) += vxc_dn_t[i];
+                        }
+                    }
+
+                    if (ixc.is_gga()) {
+                        std::vector<double> vrho_up_t(spl_t.local_size());
+                        std::vector<double> vrho_dn_t(spl_t.local_size());
+                        std::vector<double> vsigma_uu_t(spl_t.local_size());
+                        std::vector<double> vsigma_ud_t(spl_t.local_size());
+                        std::vector<double> vsigma_dd_t(spl_t.local_size());
+
+                        ixc.get_gga(spl_t.local_size(),
+                                    &rho_up.f_rg(spl_t.global_offset()),
+                                    &rho_dn.f_rg(spl_t.global_offset()),
+                                    &grad_rho_up_grad_rho_up.f_rg(spl_t.global_offset()),
+                                    &grad_rho_up_grad_rho_dn.f_rg(spl_t.global_offset()),
+                                    &grad_rho_dn_grad_rho_dn.f_rg(spl_t.global_offset()),
+                                    &vrho_up_t[0],
+                                    &vrho_dn_t[0],
+                                    &vsigma_uu_t[0],
+                                    &vsigma_ud_t[0],
+                                    &vsigma_dd_t[0],
+                                    &exc_t[0]);
+
+                        #pragma omp parallel for
+                        for (int i = 0; i < spl_t.local_size(); i++) {
+                            /* add Exc contribution */
+                            exc_tmp(spl_t[i]) += exc_t[i];
+                            /* directly add to Vxc available contributions */
+                            vxc_up_tmp(spl_t[i]) += vrho_up_t[i];
+                            vxc_dn_tmp(spl_t[i]) += vrho_dn_t[i];
+
+                            /* save the sigma derivative */
+                            vsigma_uu_tmp(spl_t[i]) += vsigma_uu_t[i];
+                            vsigma_ud_tmp(spl_t[i]) += vsigma_ud_t[i];
+                            vsigma_dd_tmp(spl_t[i]) += vsigma_dd_t[i];
+                        }
                     }
                 }
             }

--- a/verification/run_tests.x
+++ b/verification/run_tests.x
@@ -5,13 +5,6 @@ then
     export SIRIUS_BINARIES=$(pwd)/../build/apps/dft_loop
 fi
 
-if [[ $(type -f srun 2> /dev/null) ]]; then
-    SRUN_CMD="srun -u"
-else
-    SRUN_CMD=""
-fi
-
-
 exe=${SIRIUS_BINARIES}/sirius.scf
 # check if path is correct
 type -f ${exe} || exit 1
@@ -19,17 +12,18 @@ type -f ${exe} || exit 1
 for f in ./*; do
   if [ -d "$f" ]; then
     echo "running '${f}'"
-    cd ${f}
-    ${SRUN_CMD} ${exe} --test_against=output_ref.json
-    err=$?
+    (
+        cd ${f}
+        ${exe} --test_against=output_ref.json --control.processing_unit=cpu
+        err=$?
 
-    if [ ${err} == 0 ]; then
-      echo "OK"
-    else
-      echo "'${f}' failed"
-      exit ${err}
-    fi
-    cd ../
+        if [ ${err} == 0 ]; then
+          echo "OK"
+        else
+          echo "'${f}' failed"
+          exit ${err}
+        fi
+    ) || exit ${err}
   fi
 done
 

--- a/verification/run_tests_gpu.x
+++ b/verification/run_tests_gpu.x
@@ -5,12 +5,6 @@ then
     export SIRIUS_BINARIES=$(pwd)/../build/apps/dft_loop
 fi
 
-if [[ $(type -f srun 2> /dev/null) ]]; then
-    SRUN_CMD="srun -u"
-else
-    SRUN_CMD=
-fi
-
 exe=${SIRIUS_BINARIES}/sirius.scf
 # check if path is correct
 type -f ${exe} || exit 1
@@ -19,7 +13,7 @@ for f in ./*; do
     if [ -d "$f" ]; then
         echo "running '${f}'"
         cd ${f}
-        ${SRUN_CMD} ${exe} --test_against=output_ref.json --control.processing_unit=gpu
+        ${exe} --test_against=output_ref.json --control.processing_unit=gpu
         err=$?
 
         if [ ${err} == 0 ]; then

--- a/verification/run_tests_parallel_k.x
+++ b/verification/run_tests_parallel_k.x
@@ -5,13 +5,6 @@ then
     export SIRIUS_BINARIES=$(pwd)/../build/apps/dft_loop
 fi
 
-if [[ $(type -f srun 2> /dev/null) ]]; then
-    SRUN_CMD="srun -u"
-else
-    SRUN_CMD="mpirun -np 2"
-fi
-
-
 exe=${SIRIUS_BINARIES}/sirius.scf
 # check if path is correct
 type -f ${exe} || exit 1
@@ -21,7 +14,7 @@ for f in ./*; do
         echo "running '${f}'"
         (
             cd ${f}
-            ${SRUN_CMD} ${exe} --test_against=output_ref.json
+            ${exe} --test_against=output_ref.json
             err=$?
 
             if [ ${err} == 0 ]; then


### PR DESCRIPTION
Debug mode was (correctly) failing on assertion when a null-pointer of the local FFT grid with zero slab-size was accessed.
This is fixed now.