### PR TITLE
Downgraded cmake version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Spack
         run: rm -rf /user_repo/spack && cp -r ${GITHUB_WORKSPACE}/spack /user_repo/
       - name: Build SIRIUS
-        run: spack --color always -e ci dev-build --source-path ${GITHUB_WORKSPACE} sirius@develop %gcc@9.3.0 build_type=RelWithDebInfo +rocm ^spfft +rocm ^openblas threads=openmp ^openmpi
+        run: spack --color always -e ci dev-build --source-path ${GITHUB_WORKSPACE} sirius@develop %gcc@9.3.0 build_type=RelWithDebInfo +rocm ^spfft +rocm ^openblas ^openmpi
 
   build_cuda_10:
     runs-on: ubuntu-latest
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Spack
         run: rm -rf /user_repo/spack && cp -r ${GITHUB_WORKSPACE}/spack /user_repo/
       - name: Build SIRIUS
-        run: spack --color always -e ci dev-build --source-path ${GITHUB_WORKSPACE} sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +scalapack +cuda ^cuda@10.1.243 ^openblas threads=openmp ^mpich
+        run: spack --color always -e ci dev-build --source-path ${GITHUB_WORKSPACE} sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +scalapack +cuda ^cuda@10.1.243 ^openblas ^mpich
 
   build_cuda_11:
     runs-on: ubuntu-latest
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Spack
         run: rm -rf /user_repo/spack && cp -r ${GITHUB_WORKSPACE}/spack /user_repo/
       - name: Build SIRIUS
-        run: spack --color always -e ci dev-build --source-path ${GITHUB_WORKSPACE} sirius@develop %gcc@9.3.0 build_type=RelWithDebInfo +cuda ^cuda@:11 ^openblas threads=openmp ^mpich
+        run: spack --color always -e ci dev-build --source-path ${GITHUB_WORKSPACE} sirius@develop %gcc@9.3.0 build_type=RelWithDebInfo +cuda ^cuda@:11 ^openblas ^mpich
 
   build_elpa_mpich:
     runs-on: ubuntu-latest
@@ -71,7 +71,7 @@ jobs:
       - name: Setup Spack
         run: rm -rf /user_repo/spack && cp -r ${GITHUB_WORKSPACE}/spack /user_repo/
       - name: Build SIRIUS
-        run: spack --color always -e ci dev-build --source-path ${GITHUB_WORKSPACE} sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +elpa ^openblas threads=openmp ^mpich
+        run: spack --color always -e ci dev-build --source-path ${GITHUB_WORKSPACE} sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +elpa ^openblas ^mpich
 
   build_elpa_openmpi:
     runs-on: ubuntu-latest
@@ -81,4 +81,4 @@ jobs:
       - name: Setup Spack
         run: rm -rf /user_repo/spack && cp -r ${GITHUB_WORKSPACE}/spack /user_repo/
       - name: Build SIRIUS
-        run: spack --color always -e ci dev-build --source-path ${GITHUB_WORKSPACE} sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +elpa ^openblas threads=openmp ^openmpi
+        run: spack --color always -e ci dev-build --source-path ${GITHUB_WORKSPACE} sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +elpa ^openblas ^openmpi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup Spack
         run: rm -rf /user_repo/spack && cp -r ${GITHUB_WORKSPACE}/spack /user_repo/
+      - name: Show the spec
+        run: spack --color always -e ci spec -I sirius@develop %gcc@9.3.0 build_type=RelWithDebInfo +rocm ^spfft +rocm ^openblas ^openmpi
       - name: Build SIRIUS
         run: spack --color always -e ci dev-build --source-path ${GITHUB_WORKSPACE} sirius@develop %gcc@9.3.0 build_type=RelWithDebInfo +rocm ^spfft +rocm ^openblas ^openmpi
 
@@ -50,6 +52,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup Spack
         run: rm -rf /user_repo/spack && cp -r ${GITHUB_WORKSPACE}/spack /user_repo/
+      - name: Show the spec
+        run: spack --color always -e ci spec -I sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +scalapack +cuda ^cuda@10.1.243 ^openblas ^mpich
       - name: Build SIRIUS
         run: spack --color always -e ci dev-build --source-path ${GITHUB_WORKSPACE} sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +scalapack +cuda ^cuda@10.1.243 ^openblas ^mpich
 
@@ -60,6 +64,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup Spack
         run: rm -rf /user_repo/spack && cp -r ${GITHUB_WORKSPACE}/spack /user_repo/
+      - name: Show the spec
+        run: spack --color always -e ci spec -I sirius@develop %gcc@9.3.0 build_type=RelWithDebInfo +cuda ^cuda@:11 ^openblas ^mpich
       - name: Build SIRIUS
         run: spack --color always -e ci dev-build --source-path ${GITHUB_WORKSPACE} sirius@develop %gcc@9.3.0 build_type=RelWithDebInfo +cuda ^cuda@:11 ^openblas ^mpich
 
@@ -70,6 +76,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup Spack
         run: rm -rf /user_repo/spack && cp -r ${GITHUB_WORKSPACE}/spack /user_repo/
+      - name: Show the spec
+        run: spack --color always -e ci spec -I sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +elpa ^openblas ^mpich
       - name: Build SIRIUS
         run: spack --color always -e ci dev-build --source-path ${GITHUB_WORKSPACE} sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +elpa ^openblas ^mpich
 
@@ -80,5 +88,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup Spack
         run: rm -rf /user_repo/spack && cp -r ${GITHUB_WORKSPACE}/spack /user_repo/
+      - name: Show the spec
+        run: spack --color always -e ci spec -I sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +elpa ^openblas ^openmpi
       - name: Build SIRIUS
         run: spack --color always -e ci dev-build --source-path ${GITHUB_WORKSPACE} sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +elpa ^openblas ^openmpi

--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -21,7 +21,7 @@ stages:
 cuda_10.1:
   extends: .build_common
   variables:
-    SPEC: 'sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +scalapack +cuda ^cuda@10.1.243 ^openblas threads=openmp ^mpich'
+    SPEC: 'sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +scalapack +cuda ^cuda@10.1.243 ^openblas ^mpich'
     DEPLOY_BASE: ubuntu:18.04
     BUILD_BASE: stabbles/sirius-cuda-10
     IMAGE: $CI_REGISTRY_IMAGE/cuda_10.1:$CI_COMMIT_SHA

--- a/ci/spack/build.Dockerfile
+++ b/ci/spack/build.Dockerfile
@@ -42,10 +42,6 @@ RUN apt-get -yqq update \
  && pip3 install boto3 \
  && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /usr/local/cmake && \
-    curl -Ls https://github.com/Kitware/CMake/releases/download/v3.18.0/cmake-3.18.0-Linux-x86_64.tar.gz | tar --strip-components=1 -xz -C /usr/local/cmake
-
-
 # This is the spack version we want to have
 ARG SPACK_SHA
 ENV SPACK_SHA=$SPACK_SHA

--- a/ci/spack/cpu.yaml
+++ b/ci/spack/cpu.yaml
@@ -1,7 +1,7 @@
 spack:
   specs:
-    - sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +elpa ^openblas threads=openmp ^mpich
-    - sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +elpa ^openblas threads=openmp ^openmpi
+    - sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +elpa ^openblas ^mpich
+    - sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +elpa ^openblas ^openmpi
   view: false
 
   packages:
@@ -11,7 +11,8 @@ spack:
         - 'build_type=Release'
         - '+release'
     cmake:
-      buildable: False
-      externals:
-      - spec: 'cmake'
-        prefix: /usr/local/cmake
+      version: [':3.12']
+    openblas:
+      variants:
+        - threads=openmp
+

--- a/ci/spack/cuda-10.yaml
+++ b/ci/spack/cuda-10.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-    - sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +scalapack +cuda ^cuda@10.1.243 ^openblas threads=openmp ^mpich
+    - sirius@develop %gcc@7.5.0 build_type=RelWithDebInfo +scalapack +cuda ^cuda@10.1.243 ^openblas ^mpich
   view: false
 
   packages:
@@ -15,7 +15,7 @@ spack:
       - spec: 'cuda@10.1.243'
         prefix: /usr/local/cuda
     cmake:
-      buildable: False
-      externals:
-      - spec: 'cmake'
-        prefix: /usr/local/cmake
+      version: [':3.12']
+    openblas:
+      variants:
+        - threads=openmp

--- a/ci/spack/cuda-11.yaml
+++ b/ci/spack/cuda-11.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-    - sirius@develop %gcc@9.3.0 build_type=RelWithDebInfo +cuda ^cuda@:11 ^openblas threads=openmp ^mpich
+    - sirius@develop %gcc@9.3.0 build_type=RelWithDebInfo +cuda ^cuda@:11 ^openblas ^mpich
   view: false
 
   packages:
@@ -15,7 +15,7 @@ spack:
       - spec: 'cuda@:11'
         prefix: /usr/local/cuda
     cmake:
-      buildable: False
-      externals:
-      - spec: 'cmake'
-        prefix: /usr/local/cmake
+      version: [':3.12']
+    openblas:
+      variants:
+        - threads=openmp

--- a/ci/spack/rocm.yaml
+++ b/ci/spack/rocm.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-    - sirius@develop %gcc@9.3.0 +rocm ^spfft +rocm ^openmpi ^openblas threads=openmp
+    - sirius@develop %gcc@9.3.0 +rocm ^spfft +rocm ^openmpi ^openblas
   view: false
 
   packages:
@@ -11,7 +11,7 @@ spack:
         - '+release'
         - 'amdgpu_target=gfx906'
     cmake:
-      buildable: False
-      externals:
-      - spec: 'cmake'
-        prefix: /usr/local/cmake
+      version: [':3.12']
+    openblas:
+      variants:
+        - threads=openmp


### PR DESCRIPTION
In #542 there was an issue that just happened on an older version of CMake, so here I'm making spack install a specific version of CMake instead of installing it by hand. This also adds the `threads=openmp` variant to openblas by default, and adds a step in the github actions which prints the spec of what is going to be installed