### PR TITLE
Tiny fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ and optionally any of the additional libraries:
  * [ELPA](https://elpa.mpcdf.mpg.de/software)
  * [MAGMA](https://icl.cs.utk.edu/magma/)
  * CUDA/ROCm
+ * [Boost Filesystem](https://www.boost.org/doc/libs/1_73_0/libs/filesystem/doc/index.htm)*
+
+\* Only required when `BUILD_APPS=On` and your compiler does not support `std::filesystem` or `std::experimental::filesystem`.
 
 Clone the repository and build as follows:
 
@@ -154,7 +157,9 @@ Use `-DCREATE_PYTHON_MODULE=On` to build the Python module. The SIRIUS Python mo
 `pybind11`, which need to be installed on your system.
 
 #### Additional options
-To link against Intel MKL use `-DUSE_MKL=On`. For Cray libsci use `-DUSE_CRAY_LIBSCI=On`. Building tests requires `-DBUILD_TESTS=On`.
+To link against Intel MKL use `-DUSE_MKL=On`. For Cray libsci use `-DUSE_CRAY_LIBSCI=On`. Building tests requires `-DBUILD_TESTING=On`.
+
+By default example applications are built. This can be turned off via `-DBUILD_APPS=Off`, which is recommended when just building Fortran bindings.
 
 ### Arch Linux
 Arch Linux users can find SIRIUS in the [AUR](https://aur.archlinux.org/packages/sirius-git/).

--- a/spack/packages/sirius/package.py
+++ b/spack/packages/sirius/package.py
@@ -44,7 +44,7 @@ class Sirius(CMakePackage, CudaPackage):
         'gfx1011', 'gfx1012'
     )
 
-    variant('shared', default=False, description="Build shared libraries")
+    variant('shared', default=True, description="Build shared libraries")
     variant('openmp', default=True, description="Build with OpenMP support")
     variant('boost_filesystem', default=False, description="Use boost filesystem")
     variant('fortran', default=False, description="Build Fortran bindings")
@@ -171,8 +171,7 @@ class Sirius(CMakePackage, CudaPackage):
             _def('+apps', 'BUILD_APPS'),
         ]
 
-        if '@:6.2.999' in self.spec:
-            args += [_def('+shared', 'BUILD_SHARED_LIBS')]
+        args += [_def('+shared', 'BUILD_SHARED_LIBS')]
 
         lapack = spec['lapack']
         blas = spec['blas']


### PR DESCRIPTION
- Some readme fixes about variables, document the optional boost filesystem dependency when `BUILD_APPS=On` & compiler is old.
- Adds @simonpintarelli's upstream changes to the spack package
