### PR TITLE
revert Simulation_context(std::string) constructor

### DIFF
--- a/src/simulation_context.hpp
+++ b/src/simulation_context.hpp
@@ -318,8 +318,13 @@ class Simulation_context : public Simulation_parameters
 
     /// Create a simulation context with world communicator and load parameters from JSON string or JSON file.
     Simulation_context(std::string const& str__)
-        : Simulation_context(str__, Communicator::world())
-    { }
+        : comm_(Communicator::world())
+    {
+        unit_cell_ = std::make_unique<Unit_cell>(*this, comm_);
+        start();
+        import(str__);
+        unit_cell_->import(unit_cell_input_);
+    }
 
     /// Destructor.
     ~Simulation_context()


### PR DESCRIPTION
Implicit conversion from string to json breaks the python api, which instead of a filename often passes a parsed json as std::string. For some reason the json in SIRIUS ends up empty.

The nlohman/json docs mention that implicit conversion from string to json is not recommended:
https://github.com/nlohmann/json#implicit-conversions

@haampie: will this go along with your changes in the std::filesystem commit?