### PR TITLE
Drop cmake@:3.14, use latest instead

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -21,7 +21,7 @@ stages:
 cuda_10.1:
   extends: .build_common
   variables:
-    SPEC: 'sirius@develop+nlcglib %gcc@7.5.0 cuda_arch=60 build_type=RelWithDebInfo +scalapack +cuda +tests +apps ^cuda@10.1.243 ^openblas ^mpich ^nlcglib+cuda+wrapper cuda_arch=60 ^kokkos+wrapper cuda_arch=60'
+    SPEC: 'sirius@develop %gcc@:7 build_type=RelWithDebInfo +tests +apps +nlcglib +scalapack +cuda cuda_arch=60 ^cuda@10.1.243 ^openblas ^mpich ^nlcglib +cuda +wrapper cuda_arch=60 ^kokkos +wrapper cuda_arch=60'
     ENVIRONMENT: ci/spack/cuda-10.yaml
     DEPLOY_BASE: ubuntu:18.04
     BUILD_BASE: stabbles/sirius-cuda-10

--- a/ci/spack/cuda-10.yaml
+++ b/ci/spack/cuda-10.yaml
@@ -1,6 +1,6 @@
 spack:
   specs:
-    - sirius@develop %gcc@:7 +tests +apps build_type=RelWithDebInfo +scalapack +cuda ^cuda@10.1.243 ^openblas ^mpich
+    - sirius@develop %gcc@:7 build_type=RelWithDebInfo +tests +apps +nlcglib +scalapack +cuda cuda_arch=60 ^cuda@10.1.243 ^openblas ^mpich ^nlcglib +cuda +wrapper cuda_arch=60 ^kokkos +wrapper cuda_arch=60
   view: false
 
   packages:
@@ -14,8 +14,9 @@ spack:
       externals:
       - spec: 'cuda@10.1.243'
         prefix: /usr/local/cuda
-    cmake:
-      version: [':3.14']
+    # TODO: nlcglib currently requires a newer cmake
+    # cmake:
+      # version: [':3.14']
     openblas:
       variants:
         - threads=openmp


### PR DESCRIPTION
nlcglib needs cmake 3.15+, so let's just use the latest cmake version.

Also add this to the spack environment, s.t. kokkos is cached