### PR TITLE
Mirror to gitlab through github action, since it's faster

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,23 @@
+name: mirror
+
+on:
+  push:
+    branches:
+    - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: mirror
+      run: |
+          mkdir ~/.ssh
+          echo "${GIT_SSH_PRIVATE_KEY}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/id_rsa -o IdentitiesOnly=yes -o StrictHostKeyChecking=no"
+          git remote add mirror "${REMOTE}"
+          git push --tags --force --prune mirror 'refs/remotes/origin/*:refs/heads/*'
+      env:
+        REMOTE: git@gitlab.com:cscs-ci/electronic-structure/SIRIUS.git
+        GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_SSH_KEY }}


### PR DESCRIPTION
Gitlab takes 15 - 30 mins sometimes to actually sync with the github repo, which is a bit too much. Instead we can just push from a github action to trigger gitlab ci a bit faster.