### PR TITLE
Change memory assertion report to stderr to fix CI reporting

### DIFF
--- a/ci/.gitlab-ci.yml
+++ b/ci/.gitlab-ci.yml
@@ -39,7 +39,14 @@ notify_github_start:
   extends: .daint
   stage: test
   # only: ['master', 'develop', 'staging', 'trying']
-  script: cd /sources/spack-build && $TEST_COMMAND
+  script:
+    - cd /sources/spack-build
+    - |
+      if [ "$SLURM_PROCID" == "0" ]; then
+        $TEST_COMMAND -V
+      else
+        $TEST_COMMAND --output-on-failure
+      fi
   image: $CI_REGISTRY_IMAGE/cuda_10.1:$CI_COMMIT_SHA
   variables:
     CRAY_CUDA_MPS: 1
@@ -49,66 +56,62 @@ notify_github_start:
     SLURM_EXCLUSIVE: ''
     SLURM_HINT: nomultithread
     SLURM_JOB_NUM_NODES: 1
-    SLURM_STDOUTMODE: 0 # only get output from 1 rank
+    SLURM_UNBUFFEREDIO: ''
+    SLURM_WAIT: 0
 
 gpu serial:
   extends: .run_tests
   variables:
-    MPICH_MAX_THREAD_SAFETY: multiple
     OMP_NUM_THREADS: 12
     SLURM_CONSTRAINT: gpu
     SLURM_CPUS_PER_TASK: 12
     SLURM_NTASKS: 1
     SLURM_TIMELIMIT: "20:00"
-    TEST_COMMAND: ctest -L gpu_serial -V
+    TEST_COMMAND: ctest -L gpu_serial
 
 gpu band parallel:
   extends: .run_tests
   variables:
-    MPICH_MAX_THREAD_SAFETY: multiple
     OMP_NUM_THREADS: 3
     SLURM_CONSTRAINT: gpu
     SLURM_CPUS_PER_TASK: 3
     SLURM_NTASKS: 4
     SLURM_TIMELIMIT: "20:00"
-    TEST_COMMAND: ctest -L gpu_band_parallel -V
+    TEST_COMMAND: ctest -L gpu_band_parallel
     USE_MPI: 'YES'
 
 gpu k-point parallel:
   extends: .run_tests
   variables:
-    MPICH_MAX_THREAD_SAFETY: multiple
     OMP_NUM_THREADS: 3
     SLURM_CONSTRAINT: gpu
     SLURM_CPUS_PER_TASK: 3
     SLURM_NTASKS: 4
     SLURM_TIMELIMIT: "20:00"
-    TEST_COMMAND: ctest -L gpu_k_point_parallel -V
+    TEST_COMMAND: ctest -L gpu_k_point_parallel
     USE_MPI: 'YES'
 
 cpu single:
   extends: .run_tests
   variables:
-    MPICH_MAX_THREAD_SAFETY: multiple
     OMP_NUM_THREADS: 12
     SLURM_CONSTRAINT: gpu
     SLURM_CPU_BIND: sockets
     SLURM_CPUS_PER_TASK: 12
     SLURM_NTASKS: 1
     SLURM_TIMELIMIT: "20:00"
-    TEST_COMMAND: ctest -L cpu_serial -V
+    TEST_COMMAND: ctest -L cpu_serial
 
 cpu band parallel:
   extends: .run_tests
   variables:
-    MPICH_MAX_THREAD_SAFETY: multiple
     OMP_NUM_THREADS: 3
     SLURM_CONSTRAINT: gpu
     SLURM_CPU_BIND: sockets
     SLURM_CPUS_PER_TASK: 3
     SLURM_NTASKS: 4
     SLURM_TIMELIMIT: "20:00"
-    TEST_COMMAND: ctest -L cpu_band_parallel -V
+    TEST_COMMAND: ctest -L cpu_band_parallel
     USE_MPI: 'YES'
 
 notify_github_success:

--- a/src/SDDK/memory.hpp
+++ b/src/SDDK/memory.hpp
@@ -657,18 +657,19 @@ void memory_pool_deleter::memory_pool_deleter_impl::free(void* ptr__)
 #ifdef NDEBUG
 #define mdarray_assert(condition__)
 #else
-#define mdarray_assert(condition__)                                  \
-{                                                                    \
-    if (!(condition__)) {                                            \
-        std::printf("Assertion (%s) failed ", #condition__);         \
-        std::printf("at line %i of file %s\n", __LINE__, __FILE__);  \
-        std::printf("array label: %s\n", label_.c_str());            \
-        for (int i = 0; i < N; i++) {                                \
-            std::printf("dim[%i].size = %li\n", i, dims_[i].size()); \
-        }                                                            \
-        raise(SIGABRT);                                              \
-    }                                                                \
-}
+#define mdarray_assert(condition__)                                                                                    \
+    {                                                                                                                  \
+        if (!(condition__)) {                                                                                          \
+            std::fprintf(stderr, "Assertion (%s) failed ", #condition__);                                              \
+            std::fprintf(stderr, "at line %i of file %s\n", __LINE__, __FILE__);                                       \
+            std::fprintf(stderr, "array label: %s\n", label_.c_str());                                                 \
+            for (int i = 0; i < N; i++) {                                                                              \
+                std::fprintf(stderr, "dim[%i].size = %li\n", i, dims_[i].size());                                      \
+            }                                                                                                          \
+            std::fflush(stderr);                                                                                       \
+            raise(SIGABRT);                                                                                            \
+        }                                                                                                              \
+    }
 #endif
 
 /// Index descriptor of mdarray.


### PR DESCRIPTION
Added a test assertion, which should fail on one rank in CI. Will be removed before merge.