### PR TITLE
Do more aggressive restarts in Davidson

### DIFF
--- a/apps/dft_loop/sirius.scf.cpp
+++ b/apps/dft_loop/sirius.scf.cpp
@@ -405,6 +405,7 @@ int main(int argn, char** argv)
     args.register_key("--parameters.gamma_point=", "");
     args.register_key("--parameters.pw_cutoff=", "");
     args.register_key("--iterative_solver.orthogonalize=", "");
+    args.register_key("--iterative_solver.early_restart=", "{double} value between 0 and 1 to control the early restart ratio in Davidson");
 
     args.parse_args(argn, argv);
     if (args.exist("help")) {

--- a/src/band/diag_pseudo_potential.cpp
+++ b/src/band/diag_pseudo_potential.cpp
@@ -524,7 +524,7 @@ Band::diag_pseudo_potential_davidson(Hamiltonian_k& Hk__) const
             /* Todo: num_unconverged might be very small at some point slowing down convergence
                      can we add more? */
             int expand_with = std::min(num_unconverged, block_size);
-            bool should_restart = N + expand_with > num_phi || (num_lockable > 5 && num_unconverged < 0.5 * num_lockable);
+            bool should_restart = N + expand_with > num_phi || (num_lockable > 5 && num_unconverged < itso.early_restart_ * num_lockable);
 
             kp.message(3, __function_name__, "Restart = %s. Locked = %d. Converged = %d. Wanted = %d. Lockable = %d.i "
                        "Num ritz = %d. Expansion size = %d\n", should_restart ? "yes" : "no", num_locked,

--- a/src/band/diag_pseudo_potential.cpp
+++ b/src/band/diag_pseudo_potential.cpp
@@ -524,7 +524,7 @@ Band::diag_pseudo_potential_davidson(Hamiltonian_k& Hk__) const
             /* Todo: num_unconverged might be very small at some point slowing down convergence
                      can we add more? */
             int expand_with = std::min(num_unconverged, block_size);
-            bool should_restart = N + expand_with > num_phi;
+            bool should_restart = N + expand_with > num_phi || (num_lockable > 5 && num_unconverged < 0.5 * num_lockable);
 
             kp.message(3, __function_name__, "Restart = %s. Locked = %d. Converged = %d. Wanted = %d. Lockable = %d.i "
                        "Num ritz = %d. Expansion size = %d\n", should_restart ? "yes" : "no", num_locked,

--- a/src/input.hpp
+++ b/src/input.hpp
@@ -256,6 +256,12 @@ struct Iterative_solver_input
     /// Lock eigenvectors of the smallest eigenvalues when they have converged at restart
     bool locking_{true};
 
+    /// Restart early when the ratio unconverged vs lockable vectors drops below this threshold
+    /** When there's just a few vectors left unconverged, it can be more efficient to lock the converged
+        ones, such that the dense eigenproblem solved in each Davidson iteration has lower dimension.
+        Restarting has some overhead in that it requires updating wave functions **/
+    double early_restart_{0.5};
+
     /// Tolerance for the eigen-energy difference \f$ |\epsilon_i^{old} - \epsilon_i^{new} | \f$.
     /** This parameter is reduced during the SCF cycle to reach the high accuracy of the wave-functions. */
     double energy_tolerance_{1e-2};
@@ -307,6 +313,7 @@ struct Iterative_solver_input
             num_singular_           = section.value("num_singular", num_singular_);
             init_eval_old_          = section.value("init_eval_old", init_eval_old_);
             init_subspace_          = section.value("init_subspace", init_subspace_);
+            early_restart_          = section.value("early_restart", early_restart_);
             std::transform(init_subspace_.begin(), init_subspace_.end(), init_subspace_.begin(), ::tolower);
         }
     }

--- a/src/simulation_context.cpp
+++ b/src/simulation_context.cpp
@@ -762,6 +762,7 @@ void Simulation_context::print_info() const
     std::printf("iterative solver                   : %s\n", iterative_solver_input_.type_.c_str());
     std::printf("number of steps                    : %i\n", iterative_solver_input_.num_steps_);
     std::printf("subspace size                      : %i\n", iterative_solver_input_.subspace_size_);
+    std::printf("early restart ratio                : %.2f\n", iterative_solver_input_.early_restart_);
 
     std::printf("\n");
     std::printf("spglib version: %d.%d.%d\n", spg_get_major_version(), spg_get_minor_version(), spg_get_micro_version());

--- a/src/simulation_parameters.cpp
+++ b/src/simulation_parameters.cpp
@@ -72,6 +72,8 @@ void Simulation_parameters::import(cmd_args const& args__)
     parameters_input_.ngridk_      = args__.value("parameters.ngridk", parameters_input_.ngridk_);
     parameters_input_.gamma_point_ = args__.value("parameters.gamma_point", parameters_input_.gamma_point_);
     parameters_input_.pw_cutoff_   = args__.value("parameters.pw_cutoff", parameters_input_.pw_cutoff_);
+
+    iterative_solver_input_.early_restart_ = args__.value("iterative_solver.early_restart", iterative_solver_input_.early_restart_);
 }
 
 void Simulation_parameters::set_core_relativity(std::string name__)


### PR DESCRIPTION
The idea is to restart as soon as the number of lockable eigenvectors is relatively large w.r.t. to the number of unconverged eigenpairs. Early restarts would reduce the size of the dense eigenproblem.

Currently the new restarting criterion is hard-coded, but we could introduce a new parameter and figure out what would be sensible.