### PR TITLE
Replacing cublasxt gemm calls with spla

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,7 @@ set(_SOURSES
   "sirius_version.cpp"
   "mixer/mixer_functions.cpp"
   "linalg/eigensolver.cpp"
+  "linalg/linalg_spla.cpp"
   "nlcglib/adaptor.cpp"
   "input.cpp"
   )

--- a/src/density/occupation_matrix.cpp
+++ b/src/density/occupation_matrix.cpp
@@ -67,7 +67,7 @@ void Occupation_matrix::add_k_point_contribution(K_point& kp__)
         if (is_device_memory(ctx_.preferred_memory_t())) {
             la = linalg_t::gpublas;
         } else {
-            la = linalg_t::cublasxt;
+            la = linalg_t::spla;
         }
     }
 

--- a/src/geometry/force.cpp
+++ b/src/geometry/force.cpp
@@ -373,14 +373,8 @@ mdarray<double, 2> const& Force::calc_forces_us()
             break;
         }
         case device_t::GPU: {
-#ifdef __ROCM
-            // ROCm does not support cubblasxt functionality
-            mp = &ctx_.mem_pool(memory_t::host);
-            la = linalg_t::blas;
-#else
             mp = &ctx_.mem_pool(memory_t::host_pinned);
-            la = linalg_t::cublasxt;
-#endif
+            la = linalg_t::spla;
             break;
         }
     }

--- a/src/geometry/stress.cpp
+++ b/src/geometry/stress.cpp
@@ -332,16 +332,9 @@ matrix3d<double> Stress::calc_stress_us()
             break;
         }
         case device_t::GPU: {
-#ifdef __ROCM
-            // ROCm does not support cubblasxt functionality
             mp = &ctx_.mem_pool(memory_t::host_pinned);
-            la = linalg_t::blas;
-            qmem = memory_t::host;
-#else
-            mp = &ctx_.mem_pool(memory_t::host_pinned);
-            la = linalg_t::cublasxt;
+            la = linalg_t::spla;
             qmem = memory_t::device;
-#endif
             break;
         }
     }
@@ -353,13 +346,6 @@ matrix3d<double> Stress::calc_stress_us()
         }
 
         q_deriv.prepare(atom_type, ri, ri_dq);
-#ifdef __ROCM
-        // ROCm does not support cubblasxt functionality - data required on host
-        if (ctx_.processing_unit() == device_t::GPU) {
-            q_deriv.q_pw().allocate(memory_t::host);
-        }
-#endif
-
 
         int nbf = atom_type.mt_basis_size();
 
@@ -385,12 +371,6 @@ matrix3d<double> Stress::calc_stress_us()
         for (int ispin = 0; ispin < ctx_.num_mag_dims() + 1; ispin++) {
             for (int nu = 0; nu < 3; nu++) {
                 q_deriv.generate_pw_coeffs(atom_type, nu);
-#ifdef __ROCM
-                // ROCm does not support cubblasxt functionality - data required on host
-                if (ctx_.processing_unit() == device_t::GPU) {
-                    q_deriv.q_pw().copy_to(memory_t::host);
-                }
-#endif
 
                 for (int mu = 0; mu < 3; mu++) {
                     PROFILE_START("sirius::Stress|us|prepare");

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -300,12 +300,7 @@ Hamiltonian_k::set_fv_h_o(sddk::dmatrix<double_complex>& h__, sddk::dmatrix<doub
     /* maximum number of apw coefficients in the block of atoms */
     int max_mt_aw = num_atoms_in_block * uc.max_mt_aw_basis_size();
     /* current processing unit */
-#if defined(__ROCM)
-    // ROCm does not support cublasxt
-    auto pu = device_t::CPU;
-#else
     auto pu = H0_.ctx().processing_unit();
-#endif
 
     auto la = linalg_t::none;
     auto mt = memory_t::none;
@@ -320,7 +315,7 @@ Hamiltonian_k::set_fv_h_o(sddk::dmatrix<double_complex>& h__, sddk::dmatrix<doub
             break;
         }
         case device_t::GPU: {
-            la = linalg_t::cublasxt;
+            la = linalg_t::spla;
             mt = memory_t::host_pinned;
             mt1 = memory_t::device;
             nb = 1;

--- a/src/linalg/linalg.hpp
+++ b/src/linalg/linalg.hpp
@@ -36,6 +36,7 @@
 #include "memory.hpp"
 #include "dmatrix.hpp"
 #include "gpu/acc.hpp"
+#include "linalg_spla.hpp"
 
 namespace sddk {
 
@@ -240,6 +241,10 @@ inline void linalg::gemm<ftn_double>(char transa, char transb, ftn_int m, ftn_in
             break;
 
         }
+        case linalg_t::spla: {
+            splablas::dgemm(transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+            break;
+        }
         default: {
             throw std::runtime_error(linalg_msg_wrong_type);
             break;
@@ -290,6 +295,10 @@ inline void linalg::gemm<ftn_double_complex>(char transa, char transb, ftn_int m
 #endif
             break;
 
+        }
+        case linalg_t::spla: {
+            splablas::zgemm(transa, transb, m, n, k, alpha, A, lda, B, ldb, beta, C, ldc);
+            break;
         }
         default: {
             throw std::runtime_error(linalg_msg_wrong_type);

--- a/src/linalg/linalg_base.hpp
+++ b/src/linalg/linalg_base.hpp
@@ -74,7 +74,9 @@ enum class linalg_t
     /// cuBlasXt (cuBlas with CPU pointers and large matrices support)
     cublasxt,
     /// MAGMA with CPU pointers
-    magma
+    magma,
+    /// SPLA library. Can take CPU and device pointers
+    spla
 };
 
 inline linalg_t get_linalg_t(std::string name__)
@@ -129,6 +131,10 @@ inline std::string to_string(linalg_t la__)
         }
         case linalg_t::magma: {
             return "magma";
+            break;
+        }
+        case linalg_t::spla: {
+            return "spla";
             break;
         }
     }

--- a/src/linalg/linalg_spla.cpp
+++ b/src/linalg/linalg_spla.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2013-2020 Anton Kozhevnikov, Thomas Schulthess
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+// the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+//    following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include <memory>
+#include <spla/spla.hpp>
+#include "linalg_spla.hpp"
+
+namespace splablas {
+
+std::shared_ptr<::spla::Context>&
+get_handle_ptr()
+{
+  static std::shared_ptr<::spla::Context> handle{new ::spla::Context{SPLA_PU_HOST}};
+  return handle;
+}
+
+}

--- a/src/linalg/linalg_spla.hpp
+++ b/src/linalg/linalg_spla.hpp
@@ -1,0 +1,89 @@
+// Copyright (c) 2013-2020 Anton Kozhevnikov, Thomas Schulthess
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+// the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+//    following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/** \file linalg_spla.hpp
+ *
+ *  \brief Interface to SPLA library
+ */
+
+#ifndef __LINALG_SPLA_HPP__
+#define __LINALG_SPLA_HPP__
+
+#include <memory>
+#include <spla/spla.hpp>
+#include "blas_lapack.h"
+
+namespace splablas {
+
+inline SplaOperation
+get_spla_operation(char c)
+{
+    switch (c) {
+        case 'n':
+        case 'N': {
+            return SPLA_OP_NONE;
+        }
+        case 't':
+        case 'T': {
+            return SPLA_OP_TRANSPOSE;
+        }
+        case 'c':
+        case 'C': {
+            return SPLA_OP_CONJ_TRANSPOSE;
+        }
+        default: {
+            throw std::runtime_error("get_spla_operation(): wrong operation");
+        }
+    }
+    return SPLA_OP_NONE; // make compiler happy
+}
+
+std::shared_ptr<::spla::Context>& get_handle_ptr();
+
+inline void
+set_handle_ptr(std::shared_ptr<::spla::Context> ptr)
+{
+    get_handle_ptr() = std::move(ptr);
+}
+
+inline void
+reset_handle(SplaProcessingUnit op = SPLA_PU_HOST)
+{
+    get_handle_ptr().reset(new ::spla::Context{op});
+}
+
+inline void
+dgemm(char transa, char transb, ftn_int m, ftn_int n, ftn_int k, ftn_double const* alpha, ftn_double const* A,
+      ftn_int lda, ftn_double const* B, ftn_int ldb, ftn_double const* beta, ftn_double* C, ftn_int ldc)
+{
+    ::spla::gemm(get_spla_operation(transa), get_spla_operation(transb), m, n, k, *alpha, A, lda, B, ldb, *beta, C, ldc,
+                 *get_handle_ptr());
+}
+
+inline void
+zgemm(char transa, char transb, ftn_int m, ftn_int n, ftn_int k, ftn_double_complex const* alpha,
+      ftn_double_complex const* A, ftn_int lda, ftn_double_complex const* B, ftn_int ldb,
+      ftn_double_complex const* beta, ftn_double_complex* C, ftn_int ldc)
+{
+    ::spla::gemm(get_spla_operation(transa), get_spla_operation(transb), m, n, k, *alpha, A, lda, B, ldb, *beta, C, ldc,
+                 *get_handle_ptr());
+}
+} // namespace splablas
+
+#endif // __LINALG_SPLA_HPP__

--- a/src/simulation_context.hpp
+++ b/src/simulation_context.hpp
@@ -26,6 +26,7 @@
 #define __SIMULATION_CONTEXT_HPP__
 
 #include <algorithm>
+#include <memory>
 #include <spla/spla.hpp>
 
 #include "simulation_parameters.hpp"
@@ -234,7 +235,7 @@ class Simulation_context : public Simulation_parameters
     std::function<void(void)> band_occ_callback_{nullptr};
 
     // Spla context
-    spla::Context spla_ctx_ = spla::Context(SPLA_PU_HOST);
+    std::shared_ptr<::spla::Context> spla_ctx_{new ::spla::Context{SPLA_PU_HOST}};
 
     mutable double evp_work_count_{0};
     mutable int num_loc_op_applied_{0};
@@ -780,12 +781,12 @@ class Simulation_context : public Simulation_parameters
 
     spla::Context const& spla_context() const
     {
-        return spla_ctx_;
+        return *spla_ctx_;
     }
 
     spla::Context& spla_context()
     {
-        return spla_ctx_;
+        return *spla_ctx_;
     }
 
     inline double evp_work_count(double w__ = 0) const

--- a/src/sirius.hpp
+++ b/src/sirius.hpp
@@ -33,6 +33,7 @@
 #if defined(__GPU) && defined(__CUDA)
 #include "gpu/cusolver.hpp"
 #endif
+#include "linalg/linalg_spla.hpp"
 #if defined(__ELPA)
 #include "linalg/elpa.hpp"
 #endif
@@ -113,6 +114,8 @@ inline void initialize(bool call_mpi_init__ = true)
         cusolver::create_handle();
 #endif
     }
+    splablas::reset_handle();
+
 #if defined(__MAGMA)
     magma::init();
 #endif
@@ -147,6 +150,9 @@ inline void finalize(bool call_mpi_fin__ = true, bool reset_device__ = true, boo
 #if defined(__LIBSCI_ACC)
     libsci_acc_finalize();
 #endif
+
+    // must be called before device is reset
+    splablas::reset_handle();
 
     if (acc::num_devices()) {
 #if defined(__GPU)


### PR DESCRIPTION
SPLA is introduced as a linalg option for local gemm computations. To avoid big changes, there is a global context similar to the cublasxt integration. However, to save resources, the context is stored in a shared pointer and shared with the spla context in the simulation context class.