### PR TITLE
cmake fixes

### DIFF
--- a/cmake/siriusConfig.cmake.in
+++ b/cmake/siriusConfig.cmake.in
@@ -30,7 +30,7 @@ if(NOT TARGET sirius::sirius)
     set(mode QUIET)
   endif()
 
-  find_package(MPI ${mode})
+  find_package(MPI ${mode} COMPONENTS CXX)
   find_package(GSL ${mode})
   find_package(LibXC 3.0.0 ${mode})
   find_package(LibSPG ${mode})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -160,7 +160,7 @@ install(TARGETS sirius
         ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
         INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/sirius"
-                             "${CMAKE_INSTALL_INCLUDEDIR}/sirius/SDDK")
+                             "${CMAKE_INSTALL_INCLUDEDIR}/sirius/src/SDDK")
 install(EXPORT sirius_targets
         FILE siriusTargets.cmake
         NAMESPACE sirius::


### PR DESCRIPTION
- correct path of SDDK include directory in installation
- find_package(MPI ... CXX)