### PR TITLE
Fix broyden2

### DIFF
--- a/apps/tests/test_mixer.cpp
+++ b/apps/tests/test_mixer.cpp
@@ -118,7 +118,7 @@ int main(int argn, char** argv)
         false // exists
     };
 
-    for (auto const mixer_name : {"anderson", "anderson_stable", "linear", "broyden2"}) {
+    for (auto const mixer_name : {"anderson", "anderson_stable", "broyden2", "linear"}) {
         input.type_ = mixer_name;
 
         std::cout << "max history = " << input.max_history_

--- a/src/mixer/anderson_mixer.hpp
+++ b/src/mixer/anderson_mixer.hpp
@@ -53,7 +53,7 @@ namespace mixer {
  * \f]
  * 
  * such that the secant equations \f$ G_{n+1} \Delta F_n = \Delta X_n \f$ are satisfied for previous
- * iterations. Then \f$ G_n \f$ is taken \f$ -\beta I \f$. The Anderson class explicilty constructs
+ * iterations. Then \f$ G_n \f$ is taken \f$ -\beta I \f$. The Anderson class explicitly constructs
  * the Gram matrix \f$ \Delta F_n^T \Delta F_n \f$ to solve the least-squares problem. For more stability
  * use Anderson_stable, which comes at the cost of orthogonalizing \f$ \Delta F_n \f$.
  * 


### PR DESCRIPTION
This reimplements limited memory Broyden 2, since the current implementation seems to be incorrect.

The implementation does not really use the linked article in the comments. I think the current implementation is a bit simpler... Haven't seen it in literature exactly like this, but it is derived by simply expanding the recursion a few steps like this:

![Screenshot from 2020-11-16 12-12-20](https://user-images.githubusercontent.com/194764/99246194-2ffd2980-2805-11eb-93c8-9731fee1d902.png)