### PR TITLE
Restore computation of the hubbard contribution to the stress tensor

### DIFF
--- a/src/k_point/k_point.cpp
+++ b/src/k_point/k_point.cpp
@@ -173,6 +173,9 @@ K_point::initialize()
             hubbard_atomic_wave_functions_ = std::unique_ptr<Wave_functions>(
                    new Wave_functions(gkvec_partition(), r.first * ctx_.num_spinor_comp(),
                        ctx_.preferred_memory_t(), ctx_.num_spins()));
+            hubbard_atomic_wave_functions_orig_ = std::unique_ptr<Wave_functions>(
+                new Wave_functions(gkvec_partition(), r.first * ctx_.num_spinor_comp(),
+                                   ctx_.preferred_memory_t(), ctx_.num_spins()));
         }
     }
 
@@ -184,15 +187,15 @@ K_point::generate_hubbard_orbitals()
 {
     PROFILE("sirius::K_point::generate_hubbard_orbitals");
 
+    /* I do not like calling the original wave function orig !!! */
+    auto &phi = hubbard_atomic_wave_functions_orig();
+
     for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
         hubbard_wave_functions_->pw_coeffs(ispn).prime().zero();
         hubbard_atomic_wave_functions_->pw_coeffs(ispn).prime().zero();
     }
     /* total number of Hubbard orbitals */
     auto r = unit_cell_.num_hubbard_wf();
-
-    /* create temporary storage */
-    Wave_functions phi(gkvec_partition(), r.first * ctx_.num_spinor_comp(), ctx_.preferred_memory_t(), ctx_.num_spins());
 
     for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
         phi.pw_coeffs(ispn).prime().zero();
@@ -281,6 +284,7 @@ K_point::generate_hubbard_orbitals()
     //}
     hubbard_wave_functions_->dismiss(spin_range(ctx_.num_spins() == 2 ? 2 : 0), true);
     hubbard_atomic_wave_functions_->dismiss(spin_range(ctx_.num_spins() == 2 ? 2 : 0), true);
+    phi.dismiss(spin_range(ctx_.num_spins() == 2 ? 2 : 0), true);
 
     if (ctx_.control().print_checksum_) {
         hubbard_wave_functions_->print_checksum(device_t::CPU, "phi_hub", 0, hubbard_wave_functions_->num_wf());

--- a/src/k_point/k_point.hpp
+++ b/src/k_point/k_point.hpp
@@ -93,6 +93,9 @@ class K_point
     /// Two-component (spinor) hubbard wave functions constructed from atomic orbitals, where the S matrix is applied (if ppus).
     std::unique_ptr<Wave_functions> hubbard_atomic_wave_functions_{nullptr};
 
+    /// Two-component (spinor) hubbard wave functions constructed from atomic orbitals.
+    std::unique_ptr<Wave_functions> hubbard_atomic_wave_functions_orig_{nullptr};
+
     /// Band occupation numbers.
     sddk::mdarray<double, 2> band_occupancies_;
 
@@ -486,6 +489,18 @@ class K_point
     {
         assert(hubbard_atomic_wave_functions_ != nullptr);
         return *hubbard_atomic_wave_functions_;
+    }
+
+    inline Wave_functions& hubbard_atomic_wave_functions_orig()
+    {
+        assert(hubbard_atomic_wave_functions_ != nullptr);
+        return *hubbard_atomic_wave_functions_orig_;
+    }
+
+    inline Wave_functions const& hubbard_atomic_wave_functions_orig() const
+    {
+        assert(hubbard_atomic_wave_functions_orig_ != nullptr);
+        return *hubbard_atomic_wave_functions_orig_;
     }
 
     inline Wave_functions& singular_components()

--- a/src/k_point/k_point.hpp
+++ b/src/k_point/k_point.hpp
@@ -87,14 +87,14 @@ class K_point
     /// Two-component (spinor) wave functions describing the bands.
     std::shared_ptr<Wave_functions> spinor_wave_functions_{nullptr};
 
-    /// Two-component (spinor) hubbard wave functions where the S matrix is applied (if ppus).
+    /// Two-component (spinor) wave functions used to compute the hubbard corrections. They can be different from the atomic wave functions.
     std::unique_ptr<Wave_functions> hubbard_wave_functions_{nullptr};
 
-    /// Two-component (spinor) hubbard wave functions constructed from atomic orbitals, where the S matrix is applied (if ppus).
-    std::unique_ptr<Wave_functions> hubbard_atomic_wave_functions_{nullptr};
+    /// Two-component (spinor) atomic orbitals used to compute the hubbard wave functions
+    std::unique_ptr<Wave_functions> atomic_wave_functions_hub_{nullptr};
 
-    /// Two-component (spinor) hubbard wave functions constructed from atomic orbitals.
-    std::unique_ptr<Wave_functions> hubbard_atomic_wave_functions_orig_{nullptr};
+    /// Two-component (spinor) atomic orbitals (with the S operator applied for uspp) used to compute the hubbard wave functions
+    std::unique_ptr<Wave_functions> atomic_wave_functions_S_hub_{nullptr};
 
     /// Band occupation numbers.
     sddk::mdarray<double, 2> band_occupancies_;
@@ -479,28 +479,32 @@ class K_point
         return *hubbard_wave_functions_;
     }
 
-    inline Wave_functions& hubbard_atomic_wave_functions()
+    /// return the atomic wave functions used to compute the hubbard wave functions. The S operator is applied when uspp are used.
+    inline Wave_functions& atomic_wave_functions_S_hub()
     {
-        assert(hubbard_atomic_wave_functions_ != nullptr);
-        return *hubbard_atomic_wave_functions_;
+        assert(atomic_wave_functions_S_hub_ != nullptr);
+        return *atomic_wave_functions_S_hub_;
     }
 
-    inline Wave_functions const& hubbard_atomic_wave_functions() const
+    /// return the atomic wave functions used to compute the hubbard wave functions. The S operator is applied when uspp are used.
+    inline Wave_functions const& atomic_wave_functions_S_hub() const
     {
-        assert(hubbard_atomic_wave_functions_ != nullptr);
-        return *hubbard_atomic_wave_functions_;
+        assert(atomic_wave_functions_S_hub_ != nullptr);
+        return *atomic_wave_functions_S_hub_;
     }
 
-    inline Wave_functions& hubbard_atomic_wave_functions_orig()
+    /// return the atomic wave functions used to compute the hubbard wave functions.
+    inline Wave_functions & atomic_wave_functions_hub()
     {
-        assert(hubbard_atomic_wave_functions_ != nullptr);
-        return *hubbard_atomic_wave_functions_orig_;
+        assert(atomic_wave_functions_hub_ != nullptr);
+        return *atomic_wave_functions_hub_;
     }
 
-    inline Wave_functions const& hubbard_atomic_wave_functions_orig() const
+    /// return the atomic wave functions used to compute the hubbard wave functions.
+    inline Wave_functions const& atomic_wave_functions_hub() const
     {
-        assert(hubbard_atomic_wave_functions_orig_ != nullptr);
-        return *hubbard_atomic_wave_functions_orig_;
+        assert(atomic_wave_functions_hub_ != nullptr);
+        return *atomic_wave_functions_hub_;
     }
 
     inline Wave_functions& singular_components()


### PR DESCRIPTION
- added an element to k_point class containing the atomic orbitals before applying S

need a better naming for the original hubbard orbitals. I can add more comments as well.