### PR TITLE
[WIP] SCF correction to energy

### DIFF
--- a/src/SDDK/memory.hpp
+++ b/src/SDDK/memory.hpp
@@ -1557,6 +1557,19 @@ std::ostream& operator<<(std::ostream& out, mdarray<T, N>& v)
     return out;
 }
 
+template <typename T, int N>
+inline void copy(mdarray<T, N> const& src__, mdarray<T, N>& dest__)
+{
+    for (int i = 0; i < N; i++) {
+        if (dest__.dim(i).begin() != src__.dim(i).begin() || dest__.dim(i).end() != src__.dim(i).end()) {
+            std::stringstream s;
+            s << "error at line " << __LINE__ << " of file " << __FILE__ << " : array dimensions don't match";
+            throw std::runtime_error(s.str());
+        }
+    }
+    std::copy(&src__[0], &src__[0] + src__.size(), &dest__[0]);
+}
+
 }
 
 #endif  // __MEMORY_HPP__

--- a/src/density/density.hpp
+++ b/src/density/density.hpp
@@ -735,11 +735,6 @@ class Density : public Field4D
      */
     void symmetrize_density_matrix();
 
-    Simulation_context const& ctx() const
-    {
-        return ctx_;
-    }
-
     void print_info() const
     {
         auto result = this->rho().integrate();
@@ -828,6 +823,16 @@ class Density : public Field4D
         return *occupation_matrix_;
     }
 };
+
+inline void copy(Density const& src__, Density& dest__)
+{
+    for (int j = 0; j < src__.ctx().num_mag_dims() + 1; j++) {
+        copy(src__.component(j).f_pw_local(), dest__.component(j).f_pw_local());
+        copy(src__.component(j).f_rg(), dest__.component(j).f_rg());
+    }
+
+
+}
 
 } // namespace sirius
 

--- a/src/dft/dft_ground_state.cpp
+++ b/src/dft/dft_ground_state.cpp
@@ -323,7 +323,7 @@ void DFT_ground_state::print_info()
     double one_elec_en = evalsum1 - (evxc + evha);
 
     if (ctx_.electronic_structure_method() == electronic_structure_method_t::pseudopotential) {
-        one_elec_en -= potential_.PAW_one_elec_energy();
+        one_elec_en -= potential_.PAW_one_elec_energy(density_);
     }
 
     auto result = density_.rho().integrate();

--- a/src/dft/dft_ground_state.cpp
+++ b/src/dft/dft_ground_state.cpp
@@ -437,8 +437,8 @@ void DFT_ground_state::print_info()
             std::printf("PAW contribution          : %18.8f\n", potential_.PAW_total_energy());
         }
         if (ctx_.hubbard_correction()) {
-            std::printf("Hubbard energy            : %18.8f (Ha), %18.8f (Ry)\n", potential_.U().hubbard_energy(),
-                   potential_.U().hubbard_energy() * 2.0);
+            auto e = potential_.U().hubbard_energy(density_.occupation_matrix().data());
+            std::printf("Hubbard energy            : %18.8f (Ha), %18.8f (Ry)\n", e, e * 2.0);
         }
 
         std::printf("Total energy              : %18.8f (Ha), %18.8f (Ry)\n", etot, etot * 2);

--- a/src/dft/energy.cpp
+++ b/src/dft/energy.cpp
@@ -167,7 +167,7 @@ double total_energy(Simulation_context const& ctx, K_point_set const& kset, Dens
     }
 
     if (ctx.hubbard_correction()) {
-        tot_en += potential.U().hubbard_energy();
+        tot_en += potential.U().hubbard_energy(density.occupation_matrix().data());
     }
 
     return tot_en;
@@ -183,7 +183,7 @@ double energy_potential(Density const& density, Potential const& potential)
 {
     double e = energy_veff(density, potential) + energy_bxc(density, potential) + potential.PAW_one_elec_energy(density);
     if (potential.ctx().hubbard_correction()) {
-        e += potential.U().hubbard_energy();
+        e += potential.U().hubbard_energy(density.occupation_matrix().data());
     }
     return e;
 }

--- a/src/dft/energy.cpp
+++ b/src/dft/energy.cpp
@@ -1,6 +1,31 @@
+// Copyright (c) 2013-2020 Anton Kozhevnikov, Thomas Schulthess
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that 
+// the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the 
+//    following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions 
+//    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED 
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR 
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/** \file energy.cpp
+ *
+ *  \brief Total energy terms.
+ */
+
 #include "energy.hpp"
 
 namespace sirius {
+
 double ewald_energy(const Simulation_context& ctx, const Gvec& gvec, const Unit_cell& unit_cell)
 {
     double alpha{ctx.ewald_lambda()};
@@ -134,7 +159,7 @@ double total_energy(Simulation_context const& ctx, K_point_set const& kset, Dens
 
         case electronic_structure_method_t::pseudopotential: {
             tot_en = (kset.valence_eval_sum() - energy_vxc(density, potential) -
-                      energy_bxc(density, potential) - potential.PAW_one_elec_energy()) -
+                      energy_bxc(density, potential) - potential.PAW_one_elec_energy(density)) -
                       0.5 * energy_vha(potential) + energy_exc(density, potential) + potential.PAW_total_energy() +
                       ewald_energy;
             break;
@@ -151,7 +176,16 @@ double total_energy(Simulation_context const& ctx, K_point_set const& kset, Dens
 double one_electron_energy(Density const& density, Potential const& potential)
 {
     return energy_vha(potential) + energy_vxc(density, potential) + energy_bxc(density, potential) +
-        potential.PAW_one_elec_energy();
+        potential.PAW_one_elec_energy(density);
+}
+
+double energy_potential(Density const& density, Potential const& potential)
+{
+    double e = energy_veff(density, potential) + energy_bxc(density, potential) + potential.PAW_one_elec_energy(density);
+    if (potential.ctx().hubbard_correction()) {
+        e += potential.U().hubbard_energy();
+    }
+    return e;
 }
 
 } // namespace sirius

--- a/src/dft/energy.hpp
+++ b/src/dft/energy.hpp
@@ -1,3 +1,27 @@
+// Copyright (c) 2013-2020 Anton Kozhevnikov, Thomas Schulthess
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that 
+// the following conditions are met:
+// 
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the 
+//    following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions 
+//    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED 
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A 
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR 
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, 
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR 
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/** \file energy.hpp
+ *
+ *  \brief Total energy terms.
+ */
+
 #ifndef __ENERGY_HPP__
 #define __ENERGY_HPP__
 
@@ -120,6 +144,8 @@ double energy_veff(Density const& density, Potential const& potential);
 /// Return kinetic energy
 double energy_kin(Simulation_context const& ctx, K_point_set const& kset, Density const& density,
                   Potential const& potential);
+
+double energy_potential(Density const& density, Potential const& potential);
 
 /// Total energy of the electronic subsystem.
 /** <b> Full potential total energy </b>

--- a/src/function3d/field4d.hpp
+++ b/src/function3d/field4d.hpp
@@ -109,6 +109,11 @@ class Field4D
         return ctx_;
     }
 
+    Simulation_context const& ctx() const
+    {
+        return ctx_;
+    }
+
     /// Symmetrize the scalar and vector components of the filed with crystall symmetries.
     void symmetrize()
     {

--- a/src/hubbard/hubbard.hpp
+++ b/src/hubbard/hubbard.hpp
@@ -54,13 +54,13 @@ class Hubbard
 
     int number_of_hubbard_orbitals_{0};
 
-    double hubbard_energy_{0.0};
-    double hubbard_energy_u_{0.0};
-    double hubbard_energy_dc_contribution_{0.0};
-    double hubbard_energy_noflip_{0.0};
-    double hubbard_energy_flip_{0.0};
+    //double hubbard_energy_{0.0};
+    //double hubbard_energy_u_{0.0};
+    //double hubbard_energy_dc_contribution_{0.0};
+    //double hubbard_energy_noflip_{0.0};
+    //double hubbard_energy_flip_{0.0};
 
-    mdarray<double_complex, 4> hubbard_potential_;
+    sddk::mdarray<double_complex, 4> hubbard_potential_;
 
     /// Type of hubbard correction to be considered.
     /** True if we consider a simple hubbard correction. Not valid if spin orbit coupling is included */
@@ -101,7 +101,51 @@ class Hubbard
     /// Constructor.
     Hubbard(Simulation_context& ctx__);
 
-    std::vector<int> offset_;
+    std::vector<int> offset_; // TODO: make this quick fix into proper solution
+
+    /// Apply the hubbard potential on wave functions
+    void apply_hubbard_potential(Wave_functions& hub_wf, spin_range spins__, const int idx, const int n,
+                                 Wave_functions& phi, Wave_functions& ophi);
+
+    void compute_occupancies_derivatives(K_point& kp, Q_operator& q_op, mdarray<double_complex, 6>& dn);
+
+    /// Compute derivatives of the occupancy matrix w.r.t.atomic displacement.
+    /** \param [in]  kp   K-point.
+     *  \param [in]  q_op Overlap operator.
+     *  \param [out] dn   Derivative of the occupation number compared to displacement of each atom.
+     */
+    void compute_occupancies_stress_derivatives(K_point& kp, Q_operator& q_op, sddk::mdarray<double_complex, 5>& dn);
+
+    //void calculate_hubbard_potential_and_energy_colinear_case(sddk::mdarray<double_complex, 4> const& om__);
+    //void calculate_hubbard_potential_and_energy_non_colinear_case(sddk::mdarray<double_complex, 4> const& om__);
+
+    double calculate_energy_collinear(sddk::mdarray<double_complex, 4> const& om__) const;
+
+    void generate_potential_collinear(sddk::mdarray<double_complex, 4> const& om__);
+
+    double calculate_energy_non_collinear(sddk::mdarray<double_complex, 4> const& om__) const;
+
+    void generate_potential_non_collinear(sddk::mdarray<double_complex, 4> const& om__);
+
+    void generate_potential(sddk::mdarray<double_complex, 4> const& om__)
+    {
+        //this->hubbard_energy_                 = 0.0;
+        //this->hubbard_energy_u_               = 0.0;
+        //this->hubbard_energy_dc_contribution_ = 0.0;
+        //this->hubbard_energy_noflip_          = 0.0;
+        //this->hubbard_energy_flip_            = 0.0;
+        // the hubbard potential has the same structure than the occupation
+        // numbers
+        this->hubbard_potential_.zero();
+
+        if (ctx_.num_mag_dims() != 3) {
+            generate_potential_collinear(om__);
+        } else {
+            generate_potential_non_collinear(om__);
+        }
+    }
+
+    void access_hubbard_potential(std::string const& what, double_complex* occ, int ld);
 
     void set_hubbard_U_plus_V()
     {
@@ -148,43 +192,13 @@ class Hubbard
         return normalize_orbitals_only_;
     }
 
-    /// Apply the hubbard potential on wave functions
-    void apply_hubbard_potential(Wave_functions& hub_wf, spin_range spins__, const int idx, const int n,
-                                 Wave_functions& phi, Wave_functions& ophi);
-
-    void compute_occupancies_derivatives(K_point& kp, Q_operator& q_op, mdarray<double_complex, 6>& dn);
-
-    /// Compute derivatives of the occupancy matrix w.r.t.atomic displacement.
-    /** \param [in]  kp   K-point.
-     *  \param [in]  q_op Overlap operator.
-     *  \param [out] dn   Derivative of the occupation number compared to displacement of each atom.
-     */
-    void compute_occupancies_stress_derivatives(K_point& kp, Q_operator& q_op, sddk::mdarray<double_complex, 5>& dn);
-
-    void calculate_hubbard_potential_and_energy_colinear_case(sddk::mdarray<double_complex, 4> const& om__);
-    void calculate_hubbard_potential_and_energy_non_colinear_case(sddk::mdarray<double_complex, 4> const& om__);
-
-    void calculate_hubbard_potential_and_energy(sddk::mdarray<double_complex, 4> const& om__)
+    inline double hubbard_energy(sddk::mdarray<double_complex, 4> const& om__) const
     {
-        this->hubbard_energy_                 = 0.0;
-        this->hubbard_energy_u_               = 0.0;
-        this->hubbard_energy_dc_contribution_ = 0.0;
-        this->hubbard_energy_noflip_          = 0.0;
-        this->hubbard_energy_flip_            = 0.0;
-        // the hubbard potential has the same structure than the occupation
-        // numbers
-        this->hubbard_potential_.zero();
-
         if (ctx_.num_mag_dims() != 3) {
-            calculate_hubbard_potential_and_energy_colinear_case(om__);
+            return calculate_energy_collinear(om__);
         } else {
-            calculate_hubbard_potential_and_energy_non_colinear_case(om__);
+            return calculate_energy_non_collinear(om__);
         }
-    }
-
-    inline double hubbard_energy() const
-    {
-        return this->hubbard_energy_;
     }
 
     inline int number_of_hubbard_orbitals() const
@@ -192,12 +206,10 @@ class Hubbard
         return number_of_hubbard_orbitals_;
     }
 
-    mdarray<double_complex, 4>& potential_matrix()
+    sddk::mdarray<double_complex, 4>& potential_matrix()
     {
         return hubbard_potential_;
     }
-
-    void access_hubbard_potential(std::string const& what, double_complex* occ, int ld);
 };
 
 } // namespace sirius

--- a/src/hubbard/hubbard_potential_energy.cpp
+++ b/src/hubbard/hubbard_potential_energy.cpp
@@ -23,13 +23,159 @@
  */
 
 #include "hubbard.hpp"
+
 namespace sirius {
+
 void
-Hubbard::calculate_hubbard_potential_and_energy_colinear_case(sddk::mdarray<double_complex, 4> const& om__)
+Hubbard::generate_potential_collinear(sddk::mdarray<double_complex, 4> const& om__)
 {
-    this->hubbard_energy_u_               = 0.0;
-    this->hubbard_energy_dc_contribution_ = 0.0;
     this->hubbard_potential_.zero();
+
+    if (this->approximation_ == 1) {
+        for (int ia = 0; ia < this->unit_cell_.num_atoms(); ia++) {
+            auto const& atom = this->unit_cell_.atom(ia);
+            if (!atom.type().hubbard_correction()) {
+                continue;
+            }
+            double U_effective = 0.0;
+
+            int const lmax_at = 2 * atom.type().lo_descriptor_hub(0).l + 1;
+
+            if ((atom.type().lo_descriptor_hub(0).Hubbard_U() != 0.0) ||
+                (atom.type().lo_descriptor_hub(0).Hubbard_alpha() != 0.0)) {
+
+                U_effective = atom.type().lo_descriptor_hub(0).Hubbard_U();
+
+                if (std::abs(atom.type().lo_descriptor_hub(0).Hubbard_J0()) > 1e-8) {
+                    U_effective -= atom.type().lo_descriptor_hub(0).Hubbard_J0();
+                }
+
+                for (int is = 0; is < ctx_.num_spins(); is++) {
+
+                    // is = 0 up-up
+                    // is = 1 down-down
+
+                    for (int m1 = 0; m1 < lmax_at; m1++) {
+                        this->hubbard_potential_(m1, m1, is, ia) +=
+                            (atom.type().lo_descriptor_hub(0).Hubbard_alpha() + 0.5 * U_effective);
+
+                        for (int m2 = 0; m2 < lmax_at; m2++) {
+                            this->hubbard_potential_(m1, m2, is, ia) -= U_effective * om__(m2, m1, is, ia);
+                        }
+                    }
+                }
+            }
+
+            if ((std::abs(atom.type().lo_descriptor_hub(0).Hubbard_J0()) > 1e-8) ||
+                (std::abs(atom.type().lo_descriptor_hub(0).Hubbard_beta()) > 1e-8)) {
+                for (int is = 0; is < ctx_.num_spins(); is++) {
+
+                    // s = 0 -> s_opposite = 1
+                    // s = 1 -> s_opposite = 0
+                    int const s_opposite = (is + 1) % 2;
+
+                    double const sign = (is == 0) - (is == 1);
+
+                    for (int m1 = 0; m1 < lmax_at; m1++) {
+
+                        this->U(m1, m1, is, ia) += sign * atom.type().lo_descriptor_hub(0).Hubbard_beta();
+
+                        for (int m2 = 0; m2 < 2 * atom.type().lo_descriptor_hub(0).l + 1; m2++) {
+                            this->U(m1, m2, is, ia) += atom.type().lo_descriptor_hub(0).Hubbard_J0() *
+                                om__(m2, m1, s_opposite, ia);
+                        }
+                    }
+                }
+            }
+        }
+    } else {
+        /* full hubbard correction */
+        for (int ia = 0; ia < this->unit_cell_.num_atoms(); ia++) {
+
+            auto const& atom = this->unit_cell_.atom(ia);
+
+            if (!atom.type().hubbard_correction()) {
+                continue;
+            }
+
+            // total N and M^2 for the double counting problem
+
+            double n_total = 0.0;
+            // n_up and n_down spins
+            double n_updown[2] = {0.0, 0.0};
+
+            int const lmax_at = 2 * atom.type().lo_descriptor_hub(0).l + 1;
+
+            for (int s = 0; s < ctx_.num_spins(); s++) {
+                for (int m = 0; m < lmax_at; m++) {
+                    n_total += om__(m, m, s, ia).real();
+                }
+
+                for (int m = 0; m < lmax_at; m++) {
+                    n_updown[s] += om__(m, m, s, ia).real();
+                }
+            }
+            double magnetization = 0.0;
+
+            if (ctx_.num_mag_dims() == 0) {
+                n_total *= 2.0; // factor two here because the occupations are <= 1
+            } else {
+                for (int m = 0; m < lmax_at; m++) {
+                    magnetization += (om__(m, m, 0, ia) - om__(m, m, 1, ia)).real();
+                }
+                magnetization *= magnetization;
+            }
+
+
+            // now hubbard contribution
+
+            for (int is = 0; is < ctx_.num_spins(); is++) {
+                for (int m1 = 0; m1 < 2 * atom.type().lo_descriptor_hub(0).l + 1; m1++) {
+
+                    // dc contribution
+                    this->U(m1, m1, is, ia) += atom.type().lo_descriptor_hub(0).Hubbard_J() * n_updown[is] +
+                                               0.5 * (atom.type().lo_descriptor_hub(0).Hubbard_U() -
+                                                      atom.type().lo_descriptor_hub(0).Hubbard_J()) -
+                                               atom.type().lo_descriptor_hub(0).Hubbard_U() * n_total;
+
+                    // the u contributions
+                    for (int m2 = 0; m2 < 2 * atom.type().lo_descriptor_hub(0).l + 1; m2++) {
+                        for (int m3 = 0; m3 < 2 * atom.type().lo_descriptor_hub(0).l + 1; m3++) {
+                            for (int m4 = 0; m4 < 2 * atom.type().lo_descriptor_hub(0).l + 1; m4++) {
+
+                                // why should we consider the spinless case
+
+                                if (ctx_.num_mag_dims() == 0) {
+                                    this->U(m1, m2, is, ia) +=
+                                        2.0 * atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m3, m2, m4) *
+                                        om__(m3, m4, is, ia);
+                                } else {
+                                    // colinear case
+                                    for (int is2 = 0; is2 < 2; is2++) {
+                                        this->U(m1, m2, is, ia) +=
+                                            atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m3, m2, m4) *
+                                            om__(m3, m4, is2, ia);
+                                    }
+                                }
+
+                                this->U(m1, m2, is, ia) -=
+                                    atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m3, m4, m2) * om__(m3, m4, is, ia);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+double
+Hubbard::calculate_energy_collinear(sddk::mdarray<double_complex, 4> const& om__) const
+{
+    double hubbard_energy{0};
+    double hubbard_energy_u{0};
+    double hubbard_energy_dc_contribution{0};
+
     if (this->approximation_ == 1) {
         for (int ia = 0; ia < this->unit_cell_.num_atoms(); ia++) {
             const auto& atom = this->unit_cell_.atom(ia);
@@ -40,8 +186,9 @@ Hubbard::calculate_hubbard_potential_and_energy_colinear_case(sddk::mdarray<doub
 
                     U_effective = atom.type().lo_descriptor_hub(0).Hubbard_U();
 
-                    if (fabs(atom.type().lo_descriptor_hub(0).Hubbard_J0()) > 1e-8)
+                    if (std::abs(atom.type().lo_descriptor_hub(0).Hubbard_J0()) > 1e-8) {
                         U_effective -= atom.type().lo_descriptor_hub(0).Hubbard_J0();
+                    }
 
                     for (int is = 0; is < ctx_.num_spins(); is++) {
 
@@ -49,18 +196,13 @@ Hubbard::calculate_hubbard_potential_and_energy_colinear_case(sddk::mdarray<doub
                         // is = 1 down-down
 
                         for (int m1 = 0; m1 < lmax_at; m1++) {
-                            this->hubbard_energy_ +=
+                            hubbard_energy +=
                                 (atom.type().lo_descriptor_hub(0).Hubbard_alpha() + 0.5 * U_effective) * om__(m1, m1, is, ia).real();
-                            this->hubbard_potential_(m1, m1, is, ia) += (atom.type().lo_descriptor_hub(0).Hubbard_alpha() + 0.5 * U_effective);
 
                             for (int m2 = 0; m2 < lmax_at; m2++) {
 
-                                this->hubbard_energy_ -=
-                                    0.5 * U_effective *
-                                    (om__(m1, m2, is, ia) * om__(m2, m1, is, ia)).real();
-
-                                // POTENTIAL
-                                this->hubbard_potential_(m1, m2, is, ia) -= U_effective * om__(m2, m1, is, ia);
+                                hubbard_energy -=
+                                    0.5 * U_effective * (om__(m1, m2, is, ia) * om__(m2, m1, is, ia)).real();
                             }
                         }
                     }
@@ -78,19 +220,14 @@ Hubbard::calculate_hubbard_potential_and_energy_colinear_case(sddk::mdarray<doub
 
                         for (int m1 = 0; m1 < lmax_at; m1++) {
 
-                            this->hubbard_energy_ += sign * atom.type().lo_descriptor_hub(0).Hubbard_beta() *
+                            hubbard_energy += sign * atom.type().lo_descriptor_hub(0).Hubbard_beta() *
                                                      om__(m1, m1, is, ia).real();
 
-                            this->U(m1, m1, is, ia) += sign * atom.type().lo_descriptor_hub(0).Hubbard_beta();
-
                             for (int m2 = 0; m2 < 2 * atom.type().lo_descriptor_hub(0).l + 1; m2++) {
-                                this->hubbard_energy_ +=
+                                hubbard_energy +=
                                     0.5 * atom.type().lo_descriptor_hub(0).Hubbard_J0() *
                                     (om__(m2, m1, is, ia) *
                                      om__(m1, m2, s_opposite, ia)).real();
-
-                                this->U(m1, m2, is, ia) += atom.type().lo_descriptor_hub(0).Hubbard_J0() *
-                                    om__(m2, m1, s_opposite, ia);
                             }
                         }
                     }
@@ -98,9 +235,9 @@ Hubbard::calculate_hubbard_potential_and_energy_colinear_case(sddk::mdarray<doub
             }
         }
 
-        // boring DFT.
-        if (ctx_.num_mag_dims() != 1)
-            this->hubbard_energy_ *= 2.0;
+        if (ctx_.num_mag_dims() != 1) {
+            hubbard_energy *= 2.0;
+        }
 
     } else {
         // full hubbard correction
@@ -140,7 +277,7 @@ Hubbard::calculate_hubbard_potential_and_energy_colinear_case(sddk::mdarray<doub
                 magnetization *= magnetization;
             }
 
-            this->hubbard_energy_dc_contribution_ +=
+            hubbard_energy_dc_contribution +=
                 0.5 * (atom.type().lo_descriptor_hub(0).Hubbard_U() * n_total * (n_total - 1.0) - atom.type().lo_descriptor_hub(0).Hubbard_J() * n_total * (0.5 * n_total - 1.0) -
                        0.5 * atom.type().lo_descriptor_hub(0).Hubbard_J() * magnetization);
 
@@ -149,11 +286,6 @@ Hubbard::calculate_hubbard_potential_and_energy_colinear_case(sddk::mdarray<doub
             for (int is = 0; is < ctx_.num_spins(); is++) {
                 for (int m1 = 0; m1 < 2 * atom.type().lo_descriptor_hub(0).l + 1; m1++) {
 
-                    // dc contribution
-                    this->U(m1, m1, is, ia) += atom.type().lo_descriptor_hub(0).Hubbard_J() * n_updown[is] +
-                                               0.5 * (atom.type().lo_descriptor_hub(0).Hubbard_U() - atom.type().lo_descriptor_hub(0).Hubbard_J()) -
-                                               atom.type().lo_descriptor_hub(0).Hubbard_U() * n_total;
-
                     // the u contributions
                     for (int m2 = 0; m2 < 2 * atom.type().lo_descriptor_hub(0).l + 1; m2++) {
                         for (int m3 = 0; m3 < 2 * atom.type().lo_descriptor_hub(0).l + 1; m3++) {
@@ -161,23 +293,7 @@ Hubbard::calculate_hubbard_potential_and_energy_colinear_case(sddk::mdarray<doub
 
                                 // why should we consider the spinless case
 
-                                if (ctx_.num_mag_dims() == 0) {
-                                    this->U(m1, m2, is, ia) +=
-                                        2.0 * atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m3, m2, m4) *
-                                        om__(m3, m4, is, ia);
-                                } else {
-                                    // colinear case
-                                    for (int is2 = 0; is2 < 2; is2++) {
-                                        this->U(m1, m2, is, ia) +=
-                                            atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m3, m2, m4) *
-                                            om__(m3, m4, is2, ia);
-                                    }
-                                }
-
-                                this->U(m1, m2, is, ia) -=
-                                    atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m3, m4, m2) * om__(m3, m4, is, ia);
-
-                                this->hubbard_energy_u_ +=
+                                hubbard_energy_u +=
                                     0.5 * ((atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m2, m3, m4) - atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m2, m4, m3)) *
                                                om__(m1, m3, is, ia) * om__(m2, m4, is, ia) +
                                            atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m2, m3, m4) * om__(m1, m3, is, ia) *
@@ -190,25 +306,199 @@ Hubbard::calculate_hubbard_potential_and_energy_colinear_case(sddk::mdarray<doub
             }
         }
 
-        // boring DFT
         if (ctx_.num_mag_dims() == 0) {
-            this->hubbard_energy_u_ *= 2.0;
+            hubbard_energy_u *= 2.0;
         }
-        this->hubbard_energy_ = this->hubbard_energy_u_ - this->hubbard_energy_dc_contribution_;
+        hubbard_energy = hubbard_energy_u - hubbard_energy_dc_contribution;
     }
 
     if ((ctx_.control().verbosity_ >= 1) && (ctx_.comm().rank() == 0)) {
-        std::printf("\n hub Energy (total) %.5lf  (dc) %.5lf\n", this->hubbard_energy_, this->hubbard_energy_dc_contribution_);
+        std::printf("\n hub Energy (total) %.5lf  (dc) %.5lf\n", hubbard_energy, hubbard_energy_dc_contribution);
     }
+    return hubbard_energy;
 }
 
+//void
+//Hubbard::calculate_hubbard_potential_and_energy_colinear_case(sddk::mdarray<double_complex, 4> const& om__)
+//{
+//    this->hubbard_energy_u_               = 0.0;
+//    this->hubbard_energy_dc_contribution_ = 0.0;
+//    this->hubbard_potential_.zero();
+//    if (this->approximation_ == 1) {
+//        for (int ia = 0; ia < this->unit_cell_.num_atoms(); ia++) {
+//            const auto& atom = this->unit_cell_.atom(ia);
+//            if (atom.type().hubbard_correction()) {
+//                double    U_effective = 0.0;
+//                const int lmax_at     = 2 * atom.type().lo_descriptor_hub(0).l + 1;
+//                if ((atom.type().lo_descriptor_hub(0).Hubbard_U() != 0.0) || (atom.type().lo_descriptor_hub(0).Hubbard_alpha() != 0.0)) {
+//
+//                    U_effective = atom.type().lo_descriptor_hub(0).Hubbard_U();
+//
+//                    if (fabs(atom.type().lo_descriptor_hub(0).Hubbard_J0()) > 1e-8)
+//                        U_effective -= atom.type().lo_descriptor_hub(0).Hubbard_J0();
+//
+//                    for (int is = 0; is < ctx_.num_spins(); is++) {
+//
+//                        // is = 0 up-up
+//                        // is = 1 down-down
+//
+//                        for (int m1 = 0; m1 < lmax_at; m1++) {
+//                            this->hubbard_energy_ +=
+//                                (atom.type().lo_descriptor_hub(0).Hubbard_alpha() + 0.5 * U_effective) * om__(m1, m1, is, ia).real();
+//                            this->hubbard_potential_(m1, m1, is, ia) += (atom.type().lo_descriptor_hub(0).Hubbard_alpha() + 0.5 * U_effective);
+//
+//                            for (int m2 = 0; m2 < lmax_at; m2++) {
+//
+//                                this->hubbard_energy_ -=
+//                                    0.5 * U_effective *
+//                                    (om__(m1, m2, is, ia) * om__(m2, m1, is, ia)).real();
+//
+//                                // POTENTIAL
+//                                this->hubbard_potential_(m1, m2, is, ia) -= U_effective * om__(m2, m1, is, ia);
+//                            }
+//                        }
+//                    }
+//                }
+//
+//                if ((std::abs(atom.type().lo_descriptor_hub(0).Hubbard_J0()) > 1e-8) ||
+//                    (std::abs(atom.type().lo_descriptor_hub(0).Hubbard_beta()) > 1e-8)) {
+//                    for (int is = 0; is < ctx_.num_spins(); is++) {
+//
+//                        // s = 0 -> s_opposite = 1
+//                        // s= 1 -> s_opposite = 0
+//                        const int s_opposite = (is + 1) % 2;
+//
+//                        const double sign = (is == 0) - (is == 1);
+//
+//                        for (int m1 = 0; m1 < lmax_at; m1++) {
+//
+//                            this->hubbard_energy_ += sign * atom.type().lo_descriptor_hub(0).Hubbard_beta() *
+//                                                     om__(m1, m1, is, ia).real();
+//
+//                            this->U(m1, m1, is, ia) += sign * atom.type().lo_descriptor_hub(0).Hubbard_beta();
+//
+//                            for (int m2 = 0; m2 < 2 * atom.type().lo_descriptor_hub(0).l + 1; m2++) {
+//                                this->hubbard_energy_ +=
+//                                    0.5 * atom.type().lo_descriptor_hub(0).Hubbard_J0() *
+//                                    (om__(m2, m1, is, ia) *
+//                                     om__(m1, m2, s_opposite, ia)).real();
+//
+//                                this->U(m1, m2, is, ia) += atom.type().lo_descriptor_hub(0).Hubbard_J0() *
+//                                    om__(m2, m1, s_opposite, ia);
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//
+//        // boring DFT.
+//        if (ctx_.num_mag_dims() != 1)
+//            this->hubbard_energy_ *= 2.0;
+//
+//    } else {
+//        // full hubbard correction
+//        for (int ia = 0; ia < this->unit_cell_.num_atoms(); ia++) {
+//
+//            auto& atom = this->unit_cell_.atom(ia);
+//
+//            if (!atom.type().hubbard_correction()) {
+//                continue;
+//            }
+//
+//            // total N and M^2 for the double counting problem
+//
+//            double n_total = 0.0;
+//            // n_up and n_down spins
+//            double n_updown[2] = {0.0, 0.0};
+//
+//            const int lmax_at = 2 * atom.type().lo_descriptor_hub(0).l + 1;
+//
+//            for (int s = 0; s < ctx_.num_spins(); s++) {
+//                for (int m = 0; m < lmax_at; m++) {
+//                    n_total += om__(m, m, s, ia).real();
+//                }
+//
+//                for (int m = 0; m < lmax_at; m++) {
+//                    n_updown[s] += om__(m, m, s, ia).real();
+//                }
+//            }
+//            double magnetization = 0.0;
+//
+//            if (ctx_.num_mag_dims() == 0) {
+//                n_total *= 2.0; // factor two here because the occupations are <= 1
+//            } else {
+//                for (int m = 0; m < lmax_at; m++) {
+//                    magnetization += (om__(m, m, 0, ia) - om__(m, m, 1, ia)).real();
+//                }
+//                magnetization *= magnetization;
+//            }
+//
+//            this->hubbard_energy_dc_contribution_ +=
+//                0.5 * (atom.type().lo_descriptor_hub(0).Hubbard_U() * n_total * (n_total - 1.0) - atom.type().lo_descriptor_hub(0).Hubbard_J() * n_total * (0.5 * n_total - 1.0) -
+//                       0.5 * atom.type().lo_descriptor_hub(0).Hubbard_J() * magnetization);
+//
+//            // now hubbard contribution
+//
+//            for (int is = 0; is < ctx_.num_spins(); is++) {
+//                for (int m1 = 0; m1 < 2 * atom.type().lo_descriptor_hub(0).l + 1; m1++) {
+//
+//                    // dc contribution
+//                    this->U(m1, m1, is, ia) += atom.type().lo_descriptor_hub(0).Hubbard_J() * n_updown[is] +
+//                                               0.5 * (atom.type().lo_descriptor_hub(0).Hubbard_U() - atom.type().lo_descriptor_hub(0).Hubbard_J()) -
+//                                               atom.type().lo_descriptor_hub(0).Hubbard_U() * n_total;
+//
+//                    // the u contributions
+//                    for (int m2 = 0; m2 < 2 * atom.type().lo_descriptor_hub(0).l + 1; m2++) {
+//                        for (int m3 = 0; m3 < 2 * atom.type().lo_descriptor_hub(0).l + 1; m3++) {
+//                            for (int m4 = 0; m4 < 2 * atom.type().lo_descriptor_hub(0).l + 1; m4++) {
+//
+//                                // why should we consider the spinless case
+//
+//                                if (ctx_.num_mag_dims() == 0) {
+//                                    this->U(m1, m2, is, ia) +=
+//                                        2.0 * atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m3, m2, m4) *
+//                                        om__(m3, m4, is, ia);
+//                                } else {
+//                                    // colinear case
+//                                    for (int is2 = 0; is2 < 2; is2++) {
+//                                        this->U(m1, m2, is, ia) +=
+//                                            atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m3, m2, m4) *
+//                                            om__(m3, m4, is2, ia);
+//                                    }
+//                                }
+//
+//                                this->U(m1, m2, is, ia) -=
+//                                    atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m3, m4, m2) * om__(m3, m4, is, ia);
+//
+//                                this->hubbard_energy_u_ +=
+//                                    0.5 * ((atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m2, m3, m4) - atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m2, m4, m3)) *
+//                                               om__(m1, m3, is, ia) * om__(m2, m4, is, ia) +
+//                                           atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m2, m3, m4) * om__(m1, m3, is, ia) *
+//                                               om__(m2, m4, (ctx_.num_mag_dims() == 1) ? ((is + 1) % 2) : (0), ia))
+//                                              .real();
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//
+//        // boring DFT
+//        if (ctx_.num_mag_dims() == 0) {
+//            this->hubbard_energy_u_ *= 2.0;
+//        }
+//        this->hubbard_energy_ = this->hubbard_energy_u_ - this->hubbard_energy_dc_contribution_;
+//    }
+//
+//    if ((ctx_.control().verbosity_ >= 1) && (ctx_.comm().rank() == 0)) {
+//        std::printf("\n hub Energy (total) %.5lf  (dc) %.5lf\n", this->hubbard_energy_, this->hubbard_energy_dc_contribution_);
+//    }
+//}
+
 void
-Hubbard::calculate_hubbard_potential_and_energy_non_colinear_case(sddk::mdarray<double_complex, 4> const& om__)
+Hubbard::generate_potential_non_collinear(sddk::mdarray<double_complex, 4> const& om__)
 {
-    this->hubbard_potential_.zero();
-    this->hubbard_energy_dc_contribution_ = 0.0;
-    this->hubbard_energy_noflip_          = 0.0;
-    this->hubbard_energy_flip_            = 0.0;
     this->hubbard_potential_.zero();
     for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
         auto& atom = unit_cell_.atom(ia);
@@ -236,12 +526,7 @@ Hubbard::calculate_hubbard_potential_and_energy_non_colinear_case(sddk::mdarray<
                 my += (om__(m, m, 2, ia) - om__(m, m, 3, ia)).imag();
             }
 
-            double magnetization = mz * mz + mx * mx + my * my;
-
             mx = n_total.real();
-            this->hubbard_energy_dc_contribution_ +=
-                0.5 * (atom.type().lo_descriptor_hub(0).Hubbard_U() * mx * (mx - 1.0) - atom.type().lo_descriptor_hub(0).Hubbard_J() * mx * (0.5 * mx - 1.0) -
-                       0.5 * atom.type().lo_descriptor_hub(0).Hubbard_J() * magnetization);
 
             for (int is = 0; is < 4; is++) {
 
@@ -259,41 +544,6 @@ Hubbard::calculate_hubbard_potential_and_energy_non_colinear_case(sddk::mdarray<
                     default:
                         is1 = is;
                         break;
-                }
-
-                if (is1 == is) {
-                    // non spin flip contributions for the hubbard energy
-                    for (int m1 = 0; m1 < lmax_at; ++m1) {
-                        for (int m2 = 0; m2 < lmax_at; ++m2) {
-                            for (int m3 = 0; m3 < lmax_at; ++m3) {
-                                for (int m4 = 0; m4 < lmax_at; ++m4) {
-                                    // 2 - is - 1 = 0 if is = 1
-                                    //            = 1 if is = 0
-
-                                    this->hubbard_energy_noflip_ +=
-                                        0.5 * ((atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m2, m3, m4) - atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m2, m4, m3)) *
-                                                   om__(m1, m3, is, ia) * om__(m2, m4, is, ia) +
-                                               atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m2, m3, m4) * om__(m1, m3, is, ia) *
-                                                   om__(m2, m4, (is + 1) % 2, ia))
-                                                  .real();
-                                }
-                            }
-                        }
-                    }
-                } else {
-                    // spin flip contributions
-                    for (int m1 = 0; m1 < lmax_at; ++m1) {
-                        for (int m2 = 0; m2 < lmax_at; ++m2) {
-                            for (int m3 = 0; m3 < lmax_at; ++m3) {
-                                for (int m4 = 0; m4 < lmax_at; ++m4) {
-                                    this->hubbard_energy_flip_ -=
-                                        0.5 * (atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m2, m4, m3) * om__(m1, m3, is, ia) *
-                                               om__(m2, m4, is1, ia))
-                                                  .real();
-                                }
-                            }
-                        }
-                    }
                 }
 
                 // same thing for the hubbard potential
@@ -343,13 +593,119 @@ Hubbard::calculate_hubbard_potential_and_energy_non_colinear_case(sddk::mdarray<
             }
         }
     }
+}
 
-    this->hubbard_energy_ = this->hubbard_energy_noflip_ + this->hubbard_energy_flip_ - this->hubbard_energy_dc_contribution_;
+double
+Hubbard::calculate_energy_non_collinear(sddk::mdarray<double_complex, 4> const& om__) const
+{
+    double hubbard_energy_dc_contribution{0};
+    double hubbard_energy_noflip{0};
+    double hubbard_energy_flip{0};
+    double hubbard_energy{0};
+
+    for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
+        auto& atom = unit_cell_.atom(ia);
+        if (atom.type().hubbard_correction()) {
+
+            const int lmax_at = 2 * atom.type().lo_descriptor_hub(0).l + 1;
+
+            // compute the charge and magnetization of the hubbard bands for
+            // calculation of the double counting term in the hubbard correction
+
+            double_complex n_total;
+            double         mx;
+            double         my;
+            double         mz;
+
+            n_total = om__(0, 0, 0, ia) + om__(0, 0, 1, ia);
+            mz      = (om__(0, 0, 0, ia) - om__(0, 0, 1, ia)).real();
+            mx      = (om__(0, 0, 2, ia) + om__(0, 0, 3, ia)).real();
+            my      = (om__(0, 0, 2, ia) - om__(0, 0, 3, ia)).imag();
+
+            for (int m = 1; m < lmax_at; m++) {
+                n_total += om__(m, m, 0, ia) + om__(m, m, 1, ia);
+                mz += (om__(m, m, 0, ia) - om__(m, m, 1, ia)).real();
+                mx += (om__(m, m, 2, ia) + om__(m, m, 3, ia)).real();
+                my += (om__(m, m, 2, ia) - om__(m, m, 3, ia)).imag();
+            }
+
+            double magnetization = mz * mz + mx * mx + my * my;
+
+            mx = n_total.real();
+            hubbard_energy_dc_contribution +=
+                0.5 * (atom.type().lo_descriptor_hub(0).Hubbard_U() * mx * (mx - 1.0) - atom.type().lo_descriptor_hub(0).Hubbard_J() * mx * (0.5 * mx - 1.0) -
+                       0.5 * atom.type().lo_descriptor_hub(0).Hubbard_J() * magnetization);
+
+            for (int is = 0; is < 4; is++) {
+
+                // diagonal elements of n^{\sigma\sigma'}
+
+                int is1 = -1;
+
+                switch (is) {
+                    case 2:
+                        is1 = 3;
+                        break;
+                    case 3:
+                        is1 = 2;
+                        break;
+                    default:
+                        is1 = is;
+                        break;
+                }
+
+                if (is1 == is) {
+                    // non spin flip contributions for the hubbard energy
+                    for (int m1 = 0; m1 < lmax_at; ++m1) {
+                        for (int m2 = 0; m2 < lmax_at; ++m2) {
+                            for (int m3 = 0; m3 < lmax_at; ++m3) {
+                                for (int m4 = 0; m4 < lmax_at; ++m4) {
+                                    // 2 - is - 1 = 0 if is = 1
+                                    //            = 1 if is = 0
+
+                                    hubbard_energy_noflip +=
+                                        0.5 * ((atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m2, m3, m4) -
+                                                atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m2, m4, m3)) *
+                                                   om__(m1, m3, is, ia) * om__(m2, m4, is, ia) +
+                                               atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m2, m3, m4) *
+                                                   om__(m1, m3, is, ia) * om__(m2, m4, (is + 1) % 2, ia)).real();
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    // spin flip contributions
+                    for (int m1 = 0; m1 < lmax_at; ++m1) {
+                        for (int m2 = 0; m2 < lmax_at; ++m2) {
+                            for (int m3 = 0; m3 < lmax_at; ++m3) {
+                                for (int m4 = 0; m4 < lmax_at; ++m4) {
+                                    hubbard_energy_flip -=
+                                        0.5 * (atom.type().lo_descriptor_hub(0).hubbard_matrix(m1, m2, m4, m3) *
+                                            om__(m1, m3, is, ia) * om__(m2, m4, is1, ia)).real();
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // double counting contribution
+
+                double_complex n_aux = 0.0;
+                for (int m1 = 0; m1 < lmax_at; m1++) {
+                    n_aux += om__(m1, m1, is1, ia);
+                }
+            }
+        }
+    }
+
+    hubbard_energy = hubbard_energy_noflip + hubbard_energy_flip - hubbard_energy_dc_contribution;
 
     if ((ctx_.control().verbosity_ >= 1) && (ctx_.comm().rank() == 0)) {
-        std::printf("\n hub Energy (total) %.5lf (no-flip) %.5lf (flip) %.5lf (dc) %.5lf\n", this->hubbard_energy_, this->hubbard_energy_noflip_,
-               this->hubbard_energy_flip_, this->hubbard_energy_dc_contribution_);
+        std::printf("\n hub Energy (total) %.5lf (no-flip) %.5lf (flip) %.5lf (dc) %.5lf\n",
+            hubbard_energy, hubbard_energy_noflip, hubbard_energy_flip, hubbard_energy_dc_contribution);
     }
+
+    return hubbard_energy;
 }
 
 /**

--- a/src/potential/paw_potential.cpp
+++ b/src/potential/paw_potential.cpp
@@ -106,7 +106,7 @@ void Potential::generate_PAW_effective_potential(Density const& density)
     for (int i = 0; i < unit_cell_.spl_num_paw_atoms().local_size(); i++) {
         calc_PAW_local_Dij(paw_potential_data_[i], paw_dij_);
 
-        calc_PAW_one_elec_energy(paw_potential_data_[i], density.density_matrix(), paw_dij_);
+        //calc_PAW_one_elec_energy(paw_potential_data_[i], density.density_matrix(), paw_dij_);
     }
 
     // collect Dij and add to atom d_mtrx
@@ -126,7 +126,7 @@ void Potential::generate_PAW_effective_potential(Density const& density)
     for (int ia = 0; ia < unit_cell_.spl_num_paw_atoms().local_size(); ia++) {
         energies[0] += paw_potential_data_[ia].hartree_energy_;
         energies[1] += paw_potential_data_[ia].xc_energy_;
-        energies[2] += paw_potential_data_[ia].one_elec_energy_;
+        //energies[2] += paw_potential_data_[ia].one_elec_energy_;
         energies[3] += paw_potential_data_[ia].core_energy_; // it is light operation
     }
 
@@ -134,7 +134,7 @@ void Potential::generate_PAW_effective_potential(Density const& density)
 
     paw_hartree_total_energy_ = energies[0];
     paw_xc_total_energy_      = energies[1];
-    paw_one_elec_energy_      = energies[2];
+    //paw_one_elec_energy_      = energies[2];
     paw_total_core_energy_    = energies[3];
 }
 
@@ -176,194 +176,6 @@ double xc_mt_paw(std::vector<XC_functional*> xc_func__, int lmax__, int num_mag_
     return inner(exclm, rho0);
 }
 
-//double Potential::xc_mt_PAW_nonmagnetic(sf& full_potential, sf const& full_density, std::vector<double> const& rho_core)
-//{
-//    int lmmax = static_cast<int>(full_density.size(0));
-//
-//    auto const& rgrid = full_density.radial_grid();
-//
-//    /* new array to store core and valence densities */
-//    sf full_rho_lm_sf_new(lmmax, rgrid);
-//
-//    full_rho_lm_sf_new.zero();
-//    full_rho_lm_sf_new += full_density;
-//
-//    double invY00 = 1.0 / y00;
-//
-//    /* adding core part */
-//    for (int ir = 0; ir < rgrid.num_points(); ir++) {
-//        full_rho_lm_sf_new(0, ir) += invY00 * rho_core[ir];
-//    }
-//
-//    auto full_rho_tp_sf = transform(*sht_, full_rho_lm_sf_new);
-//
-//    /* create potential in theta phi */
-//    Spheric_function<function_domain_t::spatial, double> vxc_tp_sf(sht_->num_points(), rgrid);
-//
-//    /* create energy in theta phi */
-//    Spheric_function<function_domain_t::spatial, double> exc_tp_sf(sht_->num_points(), rgrid);
-//
-//    double exc{0};
-//    double tmp{0};
-//    double tmp1{0};
-//    for (auto& ixc: xc_func_) {
-//        xc_mt_nonmagnetic(rgrid, ixc, full_rho_lm_sf_new, full_rho_tp_sf, vxc_tp_sf, exc_tp_sf);
-//        auto flm = transform(*sht_, vxc_tp_sf);
-//        tmp1 += flm(0,0);
-//        full_potential += flm; //transform(*sht_, vxc_tp_sf);
-//        /* calculate energy */
-//        auto exc_lm_sf = transform(*sht_, exc_tp_sf);
-//        exc += inner(exc_lm_sf, full_rho_lm_sf_new);
-//        tmp += exc_lm_sf(0, 0);
-//    }
-//    std::cout << "[xc_mt_PAW_nonmagnetic] exc: " << tmp << std::endl;
-//    std::cout << "[xc_mt_PAW_nonmagnetic] vxc: " << tmp1 << " " << full_potential(0, 0) << std::endl;
-//
-//    return exc;
-//}
-//
-//double Potential::xc_mt_PAW_collinear(std::vector<sf>& potential, std::vector<sf const*> density,
-//                                      std::vector<double> const& rho_core)
-//{
-//    int lmsize_rho = static_cast<int>(density[0]->size(0));
-//
-//    Radial_grid<double> const& rgrid = density[0]->radial_grid();
-//
-//    /* new array to store core and valence densities */
-//    sf full_rho_lm_sf_new(lmsize_rho, rgrid);
-//
-//    full_rho_lm_sf_new.zero();
-//    full_rho_lm_sf_new += (*density[0]);
-//
-//    double invY00 = 1 / y00;
-//
-//    /* adding core part */
-//    for (int ir = 0; ir < rgrid.num_points(); ir++) {
-//        full_rho_lm_sf_new(0, ir) += invY00 * rho_core[ir];
-//    }
-//
-//    /* calculate spin up spin down density components in lm components */
-//    /* up = 1/2 ( rho + magn );  down = 1/2 ( rho - magn ) */
-//    auto rho_u_lm_sf = 0.5 * (full_rho_lm_sf_new + (*density[1]));
-//    auto rho_d_lm_sf = 0.5 * (full_rho_lm_sf_new - (*density[1]));
-//
-//    // transform density to theta phi components
-//    auto rho_u_tp_sf = transform(*sht_, rho_u_lm_sf);
-//    auto rho_d_tp_sf = transform(*sht_, rho_d_lm_sf);
-//
-//    // create potential in theta phi
-//    Spheric_function<function_domain_t::spatial, double> vxc_u_tp_sf(sht_->num_points(), rgrid);
-//    Spheric_function<function_domain_t::spatial, double> vxc_d_tp_sf(sht_->num_points(), rgrid);
-//
-//    // create energy in theta phi
-//    Spheric_function<function_domain_t::spatial, double> exc_tp_sf(sht_->num_points(), rgrid);
-//
-//    double exc{0};
-//    /* calculate XC */
-//    for (auto& ixc: xc_func_) {
-//        xc_mt_magnetic(rgrid, ixc, rho_u_lm_sf, rho_u_tp_sf, rho_d_lm_sf, rho_d_tp_sf, vxc_u_tp_sf, vxc_d_tp_sf,
-//                       exc_tp_sf);
-//        /* transform back in lm */
-//        potential[0] += transform(*sht_, 0.5 * (vxc_u_tp_sf + vxc_d_tp_sf));
-//        potential[1] += transform(*sht_, 0.5 * (vxc_u_tp_sf - vxc_d_tp_sf));
-//        //------------------------
-//        //--- calculate energy ---
-//        //------------------------
-//        Spheric_function<function_domain_t::spectral, double> exc_lm_sf = transform(*sht_, exc_tp_sf);
-//        exc += inner(exc_lm_sf, full_rho_lm_sf_new);
-//    }
-//
-//    return exc;
-//}
-//
-//double Potential::xc_mt_PAW_noncollinear(std::vector<sf>& potential, std::vector<sf const*> density,
-//                                         std::vector<double> const& rho_core)
-//{
-//    if (density.size() != 4 || potential.size() != 4) {
-//        TERMINATE("xc_mt_PAW_noncollinear FATAL ERROR!")
-//    }
-//
-//    auto const& rgrid = density[0]->radial_grid();
-//
-//    /* transform density to theta phi components */
-//    std::vector<Spheric_function<function_domain_t::spatial, double>> rho_tp(4);
-//
-//    for (size_t i = 0; i < 4; i++) {
-//        rho_tp[i] = transform(*sht_, *density[i]);
-//    }
-//
-//    /* transform 4D magnetization to spin-up, spin-down form (correct for LSDA)  rho ± |magn| */
-//    Spheric_function<function_domain_t::spatial, double> rho_u_tp(sht_->num_points(), rgrid);
-//    Spheric_function<function_domain_t::spatial, double> rho_d_tp(sht_->num_points(), rgrid);
-//
-//    for (int ir = 0; ir < rgrid.num_points(); ir++) {
-//        for (int itp = 0; itp < sht_->num_points(); itp++) {
-//            vector3d<double> magn(rho_tp[2](itp, ir), rho_tp[3](itp, ir), rho_tp[1](itp, ir));
-//            double m_len = magn.length();
-//
-//            rho_u_tp(itp, ir) = 0.5 * (rho_tp[0](itp, ir) + rho_core[ir] + m_len);
-//            rho_d_tp(itp, ir) = 0.5 * (rho_tp[0](itp, ir) + rho_core[ir] - m_len);
-//        }
-//    }
-//
-//    /* in lm representation */
-//    auto rho_u_lm = transform(*sht_, rho_u_tp);
-//    auto rho_d_lm = transform(*sht_, rho_d_tp);
-//
-//    /* allocate potential in theta phi */
-//    Spheric_function<function_domain_t::spatial, double> vxc_u_tp(sht_->num_points(), rgrid);
-//    Spheric_function<function_domain_t::spatial, double> vxc_d_tp(sht_->num_points(), rgrid);
-//
-//    // allocate energy in theta phi
-//    Spheric_function<function_domain_t::spatial, double> exc_tp(sht_->num_points(), rgrid);
-//
-//    /* allocate 4D potential in theta phi components */
-//    std::vector<Spheric_function<function_domain_t::spatial, double>> vxc_tp;
-//
-//    /* allocate the rest */
-//    for (size_t i = 0; i < 4; i++) {
-//        vxc_tp.push_back(Spheric_function<function_domain_t::spatial, double>(sht_->num_points(), rgrid));
-//    }
-//
-//    /* calculate XC */
-//    double exc{0};
-//    for (auto ixc: xc_func_) {
-//        xc_mt_magnetic(rgrid, ixc, rho_u_lm, rho_u_tp, rho_d_lm, rho_d_tp, vxc_u_tp, vxc_d_tp, exc_tp);
-//
-//        /* transform back potential from up/down to 4D form*/
-//        for (int ir = 0; ir < rgrid.num_points(); ir++) {
-//            for (int itp = 0; itp < sht_->num_points(); itp++) {
-//                /* get total potential and field abs value*/
-//                double pot   = 0.5 * (vxc_u_tp(itp, ir) + vxc_d_tp(itp, ir));
-//                double field = 0.5 * (vxc_u_tp(itp, ir) - vxc_d_tp(itp, ir));
-//
-//                /* get unit magnetization vector*/
-//                vector3d<double> magn(rho_tp[2](itp, ir), rho_tp[3](itp, ir), rho_tp[1](itp, ir));
-//                double norm = magn.length();
-//                magn        = magn * (norm > 0.0 ? field / norm : 0.0);
-//
-//                /* add total potential and effective field values at current point */
-//                vxc_tp[0](itp, ir) = pot;
-//                for (int i : {0, 1, 2}) {
-//                    vxc_tp[i + 1](itp, ir) = magn[i];
-//                }
-//            }
-//        }
-//
-//        /* transform back to lm- domain */
-//        for (size_t i = 0; i < 4; i++) {
-//            potential[i] += transform(*sht_, vxc_tp[i]);
-//        }
-//
-//        /* transform to lm- domain */
-//        auto exc_lm = transform(*sht_, exc_tp);
-//
-//        exc += inner(exc_lm, rho_u_lm + rho_d_lm);
-//    }
-//
-//    return exc;
-//}
-
 double Potential::calc_PAW_hartree_potential(Atom& atom, sf const& full_density, sf& full_potential)
 {
     int lmsize_rho = static_cast<int>(full_density.size(0));
@@ -402,8 +214,8 @@ double Potential::calc_PAW_hartree_potential(Atom& atom, sf const& full_density,
     return hartree_energy;
 }
 
-void Potential::calc_PAW_local_potential(
-    paw_potential_data_t& ppd, std::vector<Spheric_function<function_domain_t::spectral, double> const*> ae_density,
+void Potential::calc_PAW_local_potential(paw_potential_data_t& ppd,
+    std::vector<Spheric_function<function_domain_t::spectral, double> const*> ae_density,
     std::vector<Spheric_function<function_domain_t::spectral, double> const*> ps_density)
 {
     /* calculation of Hartree potential */
@@ -422,35 +234,8 @@ void Potential::calc_PAW_local_potential(
     auto& ps_core = ppd.atom_->type().ps_core_charge_density();
     auto& ae_core = ppd.atom_->type().paw_ae_core_charge_density();
 
-    //double ae_xc_energy = 0.0;
-    //double ps_xc_energy = 0.0;
-
     auto& rgrid = ppd.atom_->type().radial_grid();
     int l_max = 2 * ppd.atom_->type().indexr().lmax_lo();
-
-    //switch (ctx_.num_mag_dims()) {
-    //    case 0: {
-    //        ae_xc_energy = xc_mt_PAW_nonmagnetic(ppd.ae_potential_[0], *ae_density[0], ae_core);
-    //        ps_xc_energy = xc_mt_PAW_nonmagnetic(ppd.ps_potential_[0], *ps_density[0], ps_core);
-    //        break;
-    //    }
-
-    //    case 1: {
-    //        ae_xc_energy = xc_mt_PAW_collinear(ppd.ae_potential_, ae_density, ae_core);
-    //        ps_xc_energy = xc_mt_PAW_collinear(ppd.ps_potential_, ps_density, ps_core);
-    //        break;
-    //    }
-
-    //    case 3: {
-    //        ae_xc_energy = xc_mt_PAW_noncollinear(ppd.ae_potential_, ae_density, ae_core);
-    //        ps_xc_energy = xc_mt_PAW_noncollinear(ppd.ps_potential_, ps_density, ps_core);
-    //        break;
-    //    }
-
-    //    default: {
-    //        TERMINATE("PAW local potential error! Wrong number of spins!")
-    //    }
-    //}
 
     std::vector<Flm> vxc;
     for (int j = 0; j < ctx_.num_mag_dims() + 1; j++) {
@@ -564,8 +349,8 @@ void Potential::calc_PAW_local_Dij(paw_potential_data_t& pdd, mdarray<double, 4>
     }
 }
 
-double Potential::calc_PAW_one_elec_energy(paw_potential_data_t& pdd, const mdarray<double_complex, 4>& density_matrix,
-                                           const mdarray<double, 4>& paw_dij)
+double Potential::calc_PAW_one_elec_energy(paw_potential_data_t const& pdd, const mdarray<double_complex, 4>& density_matrix,
+                                           const mdarray<double, 4>& paw_dij) const
 {
     int ia      = pdd.ia;
     int paw_ind = pdd.ia_paw;
@@ -605,8 +390,6 @@ double Potential::calc_PAW_one_elec_energy(paw_potential_data_t& pdd, const mdar
         s << "PAW energy is not real: " << energy;
         TERMINATE(s.str());
     }
-
-    pdd.one_elec_energy_ = energy.real();
 
     return energy.real();
 }

--- a/src/potential/potential.hpp
+++ b/src/potential/potential.hpp
@@ -131,7 +131,7 @@ class Potential : public Field4D
         double hartree_energy_{0.0};
         double xc_energy_{0.0};
         double core_energy_{0.0};
-        double one_elec_energy_{0.0};
+        //double one_elec_energy_{0.0};
     };
 
     std::vector<double> paw_hartree_energies_;
@@ -142,7 +142,7 @@ class Potential : public Field4D
     double paw_hartree_total_energy_{0.0};
     double paw_xc_total_energy_{0.0};
     double paw_total_core_energy_{0.0};
-    double paw_one_elec_energy_{0.0};
+    //double paw_one_elec_energy_{0.0};
 
     std::vector<paw_potential_data_t> paw_potential_data_;
 
@@ -172,8 +172,8 @@ class Potential : public Field4D
 
     double calc_PAW_hartree_potential(Atom& atom, sf const& full_density, sf& full_potential);
 
-    double calc_PAW_one_elec_energy(paw_potential_data_t& pdd, mdarray<double_complex, 4> const& density_matrix,
-                                    mdarray<double, 4> const& paw_dij);
+    double calc_PAW_one_elec_energy(paw_potential_data_t const& pdd, mdarray<double_complex, 4> const& density_matrix,
+                                    mdarray<double, 4> const& paw_dij) const;
 
     void add_paw_Dij_to_atom_Dmtrx();
 
@@ -824,26 +824,6 @@ class Potential : public Field4D
 
     void generate_PAW_effective_potential(Density const& density);
 
-    std::vector<double> const& PAW_hartree_energies() const
-    {
-        return paw_hartree_energies_;
-    }
-
-    std::vector<double> const& PAW_xc_energies() const
-    {
-        return paw_xc_energies_;
-    }
-
-    std::vector<double> const& PAW_core_energies() const
-    {
-        return paw_core_energies_;
-    }
-
-    std::vector<double> const& PAW_one_elec_energies() const
-    {
-        return paw_one_elec_energies_;
-    }
-
     double PAW_hartree_total_energy() const
     {
         return paw_hartree_total_energy_;
@@ -864,9 +844,15 @@ class Potential : public Field4D
         return paw_hartree_total_energy_ + paw_xc_total_energy_;
     }
 
-    double PAW_one_elec_energy() const
+    double PAW_one_elec_energy(Density const& density__) const
     {
-        return paw_one_elec_energy_;
+        double e{0};
+        #pragma omp parallel for reduction(+:e)
+        for (int i = 0; i < unit_cell_.spl_num_paw_atoms().local_size(); i++) {
+            e += calc_PAW_one_elec_energy(paw_potential_data_[i], density__.density_matrix(), paw_dij_);
+        }
+        comm_.allreduce(&e, 1);
+        return e;
     }
 
     void check_potential_continuity_at_mt();

--- a/src/potential/potential.hpp
+++ b/src/potential/potential.hpp
@@ -695,7 +695,7 @@ class Potential : public Field4D
         }
 
         if (ctx_.hubbard_correction()) {
-            this->U().calculate_hubbard_potential_and_energy(density__.occupation_matrix().data());
+            this->U().generate_potential(density__.occupation_matrix().data());
         }
 
         if (ctx_.parameters_input().reduce_aux_bf_ > 0 && ctx_.parameters_input().reduce_aux_bf_ < 1) {

--- a/src/potential/xc.cpp
+++ b/src/potential/xc.cpp
@@ -72,7 +72,7 @@ void xc_mt_nonmagnetic(Radial_grid<double> const& rgrid__, SHT const& sht__, std
         assert(rho_tp__.size() == vsigma_tp.size());
         if (use_lapl) {
             /* backward transform Laplacian from Rlm to (theta, phi) */
-            auto lapl_rho_tp = transform(sht__, laplacian(rho_lm__));
+            lapl_rho_tp = transform(sht__, laplacian(rho_lm__));
             assert(lapl_rho_tp.size() == rho_tp__.size());
         }
     }

--- a/verification/test20/sirius.json
+++ b/verification/test20/sirius.json
@@ -52,12 +52,12 @@
             "n" : 3,
             "hubbard_orbital": "3d",
             "occupancy" : 5,
-            "initial_occupancy" : [0.8, 0.8, 0.8, 0.5, 0.5,  0.2, 0.2, 0.2, 0.5, 0.5]
+            "initial_occupancy" : [0.8, 0.8, 0.8, 0.35, 0.35,  0.2, 0.2, 0.2, 0.1, 0.1]
         }
     },
 
     "mixer" : {
-        "beta" : 0.85,
+        "beta" : 0.75,
         "type" : "anderson",
         "max_history" : 8
     }


### PR DESCRIPTION
We need to compute <rho_new - rho_old | v[rho_new] >. For this, several features have to be implemented:
* save a copy of the density before going into mixer
* compute contributions to <rho|V> for arbitrary combination of V and rho, not only for V=V[rho]
 