### PR TITLE
[WIP] addig smearing functions

### DIFF
--- a/apps/tests/test_davidson.cpp
+++ b/apps/tests/test_davidson.cpp
@@ -40,7 +40,6 @@ void init_wf(K_point* kp__, Wave_functions& phi__, int num_bands__, int num_mag_
 
 void test_davidson(cmd_args const& args__)
 {
-    auto pu        = get_device_t(args__.value<std::string>("device", "CPU"));
     auto pw_cutoff = args__.value<double>("pw_cutoff", 30);
     auto gk_cutoff = args__.value<double>("gk_cutoff", 10);
     auto N         = args__.value<int>("N", 1);
@@ -143,7 +142,7 @@ void test_davidson(cmd_args const& args__)
     ctx.verbosity(2);
     ctx.pw_cutoff(pw_cutoff);
     ctx.gk_cutoff(gk_cutoff);
-    ctx.set_processing_unit(pu);
+    ctx.processing_unit(args__.value<std::string>("device", "CPU"));
     ctx.mpi_grid_dims(mpi_grid);
     ctx.gen_evp_solver_name(solver);
     ctx.std_evp_solver_name(solver);

--- a/apps/tests/test_hloc.cpp
+++ b/apps/tests/test_hloc.cpp
@@ -16,7 +16,12 @@ void test_hloc(std::vector<int> mpi_grid_dims__, double cutoff__, int num_bands_
     }
 
     Simulation_context params;
-    params.set_processing_unit(pu);
+    if (use_gpu__) {
+        params.processing_unit("GPU");
+    } else {
+        params.processing_unit("CPU");
+    }
+
     params.unit_cell().set_lattice_vectors(M);
     params.mpi_grid_dims(mpi_grid_dims__);
     params.pw_cutoff(cutoff__ + 1);

--- a/apps/tests/test_lapw_xc.cpp
+++ b/apps/tests/test_lapw_xc.cpp
@@ -4,7 +4,6 @@ using namespace sirius;
 
 void test_lapw_xc(cmd_args const& args__)
 {
-    auto pu        = get_device_t(args__.value<std::string>("device", "CPU"));
     auto pw_cutoff = args__.value<double>("pw_cutoff", 12);
     auto N         = args__.value<int>("N", 1);
 
@@ -68,7 +67,7 @@ void test_lapw_xc(cmd_args const& args__)
     /* initialize the context */
     ctx.verbosity(1);
     ctx.pw_cutoff(pw_cutoff);
-    ctx.set_processing_unit(pu);
+    ctx.processing_unit(args__.value<std::string>("device", "CPU"));
 
     ctx.initialize();
 

--- a/apps/tests/test_pppw_xc.cpp
+++ b/apps/tests/test_pppw_xc.cpp
@@ -4,7 +4,6 @@ using namespace sirius;
 
 void test_davidson(cmd_args const& args__)
 {
-    auto pu           = get_device_t(args__.value<std::string>("device", "CPU"));
     auto pw_cutoff    = args__.value<double>("pw_cutoff", 30);
     auto gk_cutoff    = args__.value<double>("gk_cutoff", 10);
     auto N            = args__.value<int>("N", 1);
@@ -109,7 +108,7 @@ void test_davidson(cmd_args const& args__)
     ctx.verbosity(2);
     ctx.pw_cutoff(pw_cutoff);
     ctx.gk_cutoff(gk_cutoff);
-    ctx.set_processing_unit(pu);
+    ctx.processing_unit(args__.value<std::string>("device", "CPU"));
     ctx.mpi_grid_dims(mpi_grid);
     ctx.gen_evp_solver_name(solver);
     ctx.std_evp_solver_name(solver);

--- a/src/SDDK/memory.hpp
+++ b/src/SDDK/memory.hpp
@@ -86,22 +86,20 @@ inline bool is_device_memory(memory_t mem__)
 inline memory_t get_memory_t(std::string name__)
 {
     std::transform(name__.begin(), name__.end(), name__.begin(), ::tolower);
-
-    std::map<std::string, memory_t> const map_to_type = {
-        {"none",        memory_t::none},
-        {"host",        memory_t::host},
+    std::map<std::string, memory_t> const m = {
+        {"none", memory_t::none},
+        {"host", memory_t::host},
         {"host_pinned", memory_t::host_pinned},
-        {"managed",     memory_t::managed},
-        {"device",      memory_t::device}
+        {"managed", memory_t::managed},
+        {"device", memory_t::device}
     };
 
-    if (map_to_type.count(name__) == 0) {
+    if (m.count(name__) == 0) {
         std::stringstream s;
-        s << "wrong label of memory type: " << name__;
+        s << "get_memory_t(): wrong label of the memory_t enumerator: " << name__;
         throw std::runtime_error(s.str());
-    }
-
-    return map_to_type.at(name__);
+     }
+     return m.at(name__);
 }
 
 /// Type of the main processing unit.
@@ -137,14 +135,17 @@ inline device_t get_device_t(memory_t mem__)
 inline device_t get_device_t(std::string name__)
 {
     std::transform(name__.begin(), name__.end(), name__.begin(), ::tolower);
-    if (name__ == "cpu") {
-        return device_t::CPU;
-    } else if (name__ == "gpu") {
-        return device_t::GPU;
-    } else {
-        throw std::runtime_error("get_device_t(): wrong processing unit");
-    }
-    return device_t::CPU; // make compiler happy
+    std::map<std::string, device_t> const m = {
+        {"cpu", device_t::CPU},
+        {"gpu", device_t::GPU}
+    };
+
+    if (m.count(name__) == 0) {
+        std::stringstream s;
+        s << "get_device_t(): wrong label of the device_t enumerator: " << name__;
+        throw std::runtime_error(s.str());
+     }
+     return m.at(name__);
 }
 
 /// Allocate n elements in a specified memory.

--- a/src/SDDK/memory.hpp
+++ b/src/SDDK/memory.hpp
@@ -1561,6 +1561,9 @@ std::ostream& operator<<(std::ostream& out, mdarray<T, N>& v)
 template <typename T, int N>
 inline void copy(mdarray<T, N> const& src__, mdarray<T, N>& dest__)
 {
+    if (src__.size() == 0) {
+        return;
+    }
     for (int i = 0; i < N; i++) {
         if (dest__.dim(i).begin() != src__.dim(i).begin() || dest__.dim(i).end() != src__.dim(i).end()) {
             std::stringstream s;

--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -577,10 +577,10 @@ void sirius_set_parameters(void*  const* handler__,
             sim_ctx.so_correction(*so_correction__);
         }
         if (valence_rel__ != nullptr) {
-            sim_ctx.set_valence_relativity(valence_rel__);
+            sim_ctx.valence_relativity(valence_rel__);
         }
         if (core_rel__ != nullptr) {
-            sim_ctx.set_core_relativity(core_rel__);
+            sim_ctx.core_relativity(core_rel__);
         }
         if (esm_bc__ != nullptr) {
             sim_ctx.esm_bc(std::string(esm_bc__));

--- a/src/density/density.hpp
+++ b/src/density/density.hpp
@@ -829,11 +829,14 @@ inline void copy(Density const& src__, Density& dest__)
     for (int j = 0; j < src__.ctx().num_mag_dims() + 1; j++) {
         copy(src__.component(j).f_pw_local(), dest__.component(j).f_pw_local());
         copy(src__.component(j).f_rg(), dest__.component(j).f_rg());
+        if (src__.ctx().full_potential()) {
+            for (int ialoc = 0; ialoc < src__.ctx().unit_cell().spl_num_atoms().local_size(); ialoc++) {
+                copy(src__.component(j).f_mt(ialoc), dest__.component(j).f_mt(ialoc));
+            }
+        }
     }
-
-    // TODO: copy density matrix, occupancy matrix, MT density
-
-
+    copy(src__.density_matrix(), dest__.density_matrix());
+    copy(src__.occupation_matrix(), dest__.occupation_matrix());
 }
 
 } // namespace sirius

--- a/src/density/occupation_matrix.hpp
+++ b/src/density/occupation_matrix.hpp
@@ -87,4 +87,9 @@ class Occupation_matrix {
     }
 };
 
+inline void copy(Occupation_matrix const& src__, Occupation_matrix& dest__)
+{
+    copy(src__.data(), dest__.data());
+}
+
 } // namespace

--- a/src/dft/dft_ground_state.cpp
+++ b/src/dft/dft_ground_state.cpp
@@ -83,7 +83,7 @@ double DFT_ground_state::energy_kin_sum_pw() const
 
 double DFT_ground_state::total_energy() const
 {
-    return sirius::total_energy(ctx_, kset_, density_, potential_, ewald_energy_);
+    return sirius::total_energy(ctx_, kset_, density_, potential_, ewald_energy_) + this->scf_energy_;
 }
 
 json DFT_ground_state::serialize()
@@ -257,9 +257,6 @@ json DFT_ground_state::find(double density_tol, double energy_tol, double initia
 
         /* compute new total energy for a new density */
         double etot = total_energy();
-        if (!ctx_.full_potential()) {
-            etot += this->scf_energy_;
-        }
 
         etot_hist.push_back(etot);
 

--- a/src/dft/smearing.hpp
+++ b/src/dft/smearing.hpp
@@ -29,10 +29,35 @@
 #include <functional>
 #include <string>
 #include <stdexcept>
+#include <map>
+#include <sstream>
+#include <algorithm>
 
 namespace smearing {
 
 const double pi = 3.1415926535897932385;
+
+enum class smearing_t
+{
+    gaussian,
+    fermi_dirac
+};
+
+inline smearing_t get_smearing_t(std::string name__)
+{
+    std::transform(name__.begin(), name__.end(), name__.begin(), ::tolower);
+    std::map<std::string, smearing_t> const m = {
+        {"gaussian", smearing_t::gaussian},
+        {"fermi_dirac", smearing_t::fermi_dirac}
+    };
+
+    if (m.count(name__) == 0) {
+        std::stringstream s;
+        s << "get_smearing_t(): wrong label of the smearing_t enumerator: " << name__;
+        throw std::runtime_error(s.str());
+     }
+     return m.at(name__);
+}
 
 namespace gaussian {
 
@@ -81,28 +106,34 @@ inline double entropy(double x__, double width__)
 
 } // namespace "fermi_dirac"
 
-inline std::function<double(double)> occupancy(std::string type__, double width__)
+inline std::function<double(double)> occupancy(smearing_t type__, double width__)
 {
-    if (type__ == "gaussian") {
-        return [width__](double x__){return gaussian::occupancy(x__, width__);};
-    } else if (type__ == "fermi_dirac") {
-        return [width__](double x__){return fermi_dirac::occupancy(x__, width__);};
-    } else {
-        throw std::runtime_error("wrong type of smearing function");
+    switch (type__) {
+        case smearing_t::gaussian: {
+            return [width__](double x__){return gaussian::occupancy(x__, width__);};
+        }
+        case smearing_t::fermi_dirac: {
+            return [width__](double x__){return fermi_dirac::occupancy(x__, width__);};
+        }
+        default: {
+            throw std::runtime_error("wrong type of smearing");
+        }
     }
-    return [width__](double x__){return 0.0;}; // make compiler happy
 }
 
-inline std::function<double(double)> entropy(std::string type__, double width__)
+inline std::function<double(double)> entropy(smearing_t type__, double width__)
 {
-    if (type__ == "gaussian") {
-        return [width__](double x__){return gaussian::entropy(x__, width__);};
-    } else if (type__ == "fermi_dirac") {
-        return [width__](double x__){return fermi_dirac::entropy(x__, width__);};
-    } else {
-        throw std::runtime_error("wrong type of smearing function");
+    switch (type__) {
+        case smearing_t::gaussian: {
+            return [width__](double x__){return gaussian::entropy(x__, width__);};
+        }
+        case smearing_t::fermi_dirac: {
+            return [width__](double x__){return fermi_dirac::entropy(x__, width__);};
+        }
+        default: {
+            throw std::runtime_error("wrong type of smearing");
+        }
     }
-    return [width__](double x__){return 0.0;}; // make compiler happy
 }
 
 

--- a/src/input.hpp
+++ b/src/input.hpp
@@ -484,6 +484,9 @@ struct Parameters_input
     /// Width of Gaussian smearing function in the units of [Ha].
     double smearing_width_{0.01};
 
+    /// Type of occupancy smearing.
+    std::string smearing_{"gaussian"};
+
     /// Cutoff for plane-waves (for density and potential expansion) in the units of [a.u.^-1].
     double pw_cutoff_{0.0};
 

--- a/src/input.hpp
+++ b/src/input.hpp
@@ -592,6 +592,7 @@ struct Parameters_input
 
             num_fv_states_  = section.value("num_fv_states", num_fv_states_);
             smearing_width_ = section.value("smearing_width", smearing_width_);
+            smearing_       = section.value("smearing", smearing_);
             pw_cutoff_      = section.value("pw_cutoff", pw_cutoff_);
             aw_cutoff_      = section.value("aw_cutoff", aw_cutoff_);
             gk_cutoff_      = section.value("gk_cutoff", gk_cutoff_);

--- a/src/k_point/k_point_set.cpp
+++ b/src/k_point/k_point_set.cpp
@@ -172,7 +172,7 @@ void K_point_set::find_band_occupancies()
         return;
     }
 
-    auto f = smearing::occupancy("gaussian", ctx_.smearing_width());
+    auto f = smearing::occupancy(ctx_.smearing(), ctx_.smearing_width());
 
     int step{0};
     /* calculate occupations */

--- a/src/k_point/k_point_set.cpp
+++ b/src/k_point/k_point_set.cpp
@@ -172,6 +172,8 @@ void K_point_set::find_band_occupancies()
         return;
     }
 
+    auto f = smearing::occupancy("gaussian", ctx_.smearing_width());
+
     int step{0};
     /* calculate occupations */
     while (std::abs(ne - ne_target) >= 1e-11) {
@@ -182,9 +184,7 @@ void K_point_set::find_band_occupancies()
         for (int ik = 0; ik < num_kpoints(); ik++) {
             for (int ispn = 0; ispn < ctx_.num_spinors(); ispn++) {
                 for (int j = 0; j < ctx_.num_bands(); j++) {
-                    bnd_occ(j, ispn, ik) =
-                        smearing::gaussian(ef - kpoints_[ik]->band_energy(j, ispn), ctx_.smearing_width()) *
-                        ctx_.max_occupancy();
+                    bnd_occ(j, ispn, ik) = f(ef - kpoints_[ik]->band_energy(j, ispn)) * ctx_.max_occupancy();
                     ne += bnd_occ(j, ispn, ik) * kpoints_[ik]->weight();
                 }
             }

--- a/src/k_point/k_point_set.hpp
+++ b/src/k_point/k_point_set.hpp
@@ -146,19 +146,19 @@ class K_point_set
     {
         double s_sum{0};
 
+        auto f = smearing::entropy("gaussian", ctx_.smearing_width());
+
         for (int ik = 0; ik < num_kpoints(); ik++) {
             auto const& kp = kpoints_[ik];
             double wk = kp->weight();
             for (int j = 0; j < ctx_.num_bands(); j++) {
                 for (int ispn = 0; ispn < ctx_.num_spinors(); ispn++) {
-                    s_sum += wk * ctx_.max_occupancy() *
-                        smearing::gaussian_entropy(energy_fermi_ - kp->band_energy(j, ispn), ctx_.smearing_width());
+                    s_sum += wk * ctx_.max_occupancy() * f(energy_fermi_ - kp->band_energy(j, ispn));
                 }
             }
         }
 
-        /* we computed TS, but the contribution to the total enery is -TS */
-        return -s_sum;
+        return s_sum;
     }
 
     /// Return maximum number of G+k vectors among all k-points.

--- a/src/k_point/k_point_set.hpp
+++ b/src/k_point/k_point_set.hpp
@@ -146,7 +146,7 @@ class K_point_set
     {
         double s_sum{0};
 
-        auto f = smearing::entropy("gaussian", ctx_.smearing_width());
+        auto f = smearing::entropy(ctx_.smearing(), ctx_.smearing_width());
 
         for (int ik = 0; ik < num_kpoints(); ik++) {
             auto const& kp = kpoints_[ik];

--- a/src/simulation_context.cpp
+++ b/src/simulation_context.cpp
@@ -258,8 +258,8 @@ void Simulation_context::initialize()
         TERMINATE("Simulation parameters are already initialized.");
     }
     electronic_structure_method(parameters_input().electronic_structure_method_);
-    set_core_relativity(parameters_input().core_relativity_);
-    set_valence_relativity(parameters_input().valence_relativity_);
+    core_relativity(parameters_input().core_relativity_);
+    valence_relativity(parameters_input().valence_relativity_);
 
     /* can't run fp-lapw with Gamma point trick */
     if (full_potential()) {
@@ -272,7 +272,7 @@ void Simulation_context::initialize()
     }
 
     /* set processing unit type */
-    set_processing_unit(control().processing_unit_);
+    processing_unit(control().processing_unit_);
 
     /* check if we can use a GPU device */
     if (processing_unit() == device_t::GPU) {
@@ -591,6 +591,9 @@ void Simulation_context::initialize()
 
     this->print_memory_usage(__FILE__, __LINE__);
 
+    /* set the smearing */
+    smearing(parameters_input().smearing_);
+
     if (control().verbosity_ >= 1 && comm().rank() == 0) {
         print_info();
     }
@@ -675,6 +678,7 @@ void Simulation_context::print_info() const
     std::printf("lmax_rho                           : %i\n", lmax_rho());
     std::printf("lmax_pot                           : %i\n", lmax_pot());
     std::printf("lmax_rf                            : %i\n", unit_cell().lmax());
+    std::printf("smearing type                      : %s\n", parameters_input().smearing_.c_str());
     std::printf("smearing width                     : %f\n", smearing_width());
     std::printf("cyclic block size                  : %i\n", cyclic_block_size());
     std::printf("|G+k| cutoff                       : %f\n", gk_cutoff());

--- a/src/simulation_parameters.cpp
+++ b/src/simulation_parameters.cpp
@@ -78,41 +78,20 @@ void Simulation_parameters::import(cmd_args const& args__)
     mixer_input_.type_ = args__.value("mixer.type", mixer_input_.type_);
 }
 
-void Simulation_parameters::set_core_relativity(std::string name__)
+void Simulation_parameters::core_relativity(std::string name__)
 {
     parameters_input_.core_relativity_ = name__;
-
-    std::map<std::string, relativity_t> const m = {{"none", relativity_t::none}, {"dirac", relativity_t::dirac}};
-
-    if (m.count(name__) == 0) {
-        std::stringstream s;
-        s << "wrong type of core relativity: " << name__;
-        TERMINATE(s);
-    }
-    core_relativity_ = m.at(name__);
+    core_relativity_ = get_relativity_t(name__);
 }
 
-void Simulation_parameters::set_valence_relativity(std::string name__)
+void Simulation_parameters::valence_relativity(std::string name__)
 {
     parameters_input_.valence_relativity_ = name__;
-
-    std::map<std::string, relativity_t> const m = {{"none", relativity_t::none},
-                                                   {"zora", relativity_t::zora},
-                                                   {"iora", relativity_t::iora},
-                                                   {"koelling_harmon", relativity_t::koelling_harmon}};
-
-    if (m.count(name__) == 0) {
-        std::stringstream s;
-        s << "wrong type of valence relativity: " << name__;
-        TERMINATE(s);
-    }
-    valence_relativity_ = m.at(name__);
+    valence_relativity_ = get_relativity_t(name__);
 }
 
-void Simulation_parameters::set_processing_unit(std::string name__)
+void Simulation_parameters::processing_unit(std::string name__)
 {
-    std::transform(name__.begin(), name__.end(), name__.begin(), ::tolower);
-
     /* set the default value */
     if (name__ == "") {
         if (acc::num_devices() > 0) {
@@ -122,34 +101,13 @@ void Simulation_parameters::set_processing_unit(std::string name__)
         }
     }
     control_input_.processing_unit_ = name__;
-    if (name__ == "cpu") {
-        this->set_processing_unit(device_t::CPU);
-    } else if (name__ == "gpu") {
-        this->set_processing_unit(device_t::GPU);
-    } else {
-        std::stringstream s;
-        s << "wrong processing unit name: " << name__;
-        TERMINATE(s);
-    }
+    processing_unit_ = get_device_t(name__);
 }
 
-void Simulation_parameters::set_processing_unit(device_t pu__)
+void Simulation_parameters::smearing(std::string name__)
 {
-    if (acc::num_devices() == 0) {
-        processing_unit_                = device_t::CPU;
-        control_input_.processing_unit_ = "cpu";
-    } else {
-        processing_unit_ = pu__;
-        if (pu__ == device_t::CPU) {
-            control_input_.processing_unit_ = "cpu";
-        } else if (pu__ == device_t::GPU) {
-            control_input_.processing_unit_ = "gpu";
-        } else {
-            std::stringstream s;
-            s << "wrong processing unit type";
-            TERMINATE(s);
-        }
-    }
+    parameters_input_.smearing_ = name__;
+    smearing_ = smearing::get_smearing_t(name__);
 }
 
 void Simulation_parameters::print_options() const

--- a/src/simulation_parameters.hpp
+++ b/src/simulation_parameters.hpp
@@ -31,6 +31,7 @@
 #include "utils/cmd_args.hpp"
 #include "utils/utils.hpp"
 #include "memory.hpp"
+#include "dft/smearing.hpp"
 
 using namespace sddk;
 
@@ -65,6 +66,9 @@ class Simulation_parameters
 
     /// Type of electronic structure method.
     electronic_structure_method_t electronic_structure_method_{electronic_structure_method_t::full_potential_lapwlo};
+
+    /// Type of occupation numbers smearing.
+    smearing::smearing_t smearing_{smearing::smearing_t::gaussian};
 
     /// Parameters of the iterative solver.
     Iterative_solver_input iterative_solver_input_;
@@ -182,13 +186,20 @@ class Simulation_parameters
         return electronic_structure_method_;
     }
 
-    void set_core_relativity(std::string name__);
+    /// Set core relativity for the LAPW method.
+    void core_relativity(std::string name__);
 
-    void set_valence_relativity(std::string name__);
+    /// Set valence relativity for the LAPW method.
+    void valence_relativity(std::string name__);
 
-    void set_processing_unit(std::string name__);
+    void processing_unit(std::string name__);
 
-    void set_processing_unit(device_t pu__);
+    void smearing(std::string name__);
+
+    smearing::smearing_t smearing() const
+    {
+        return smearing_;
+    }
 
     void set_molecule(bool molecule__)
     {
@@ -398,9 +409,10 @@ class Simulation_parameters
         return parameters_input_.smearing_width_;
     }
 
-    void set_smearing_width(double smearing_width__)
+    double smearing_width(double smearing_width__)
     {
         parameters_input_.smearing_width_ = smearing_width__;
+        return parameters_input_.smearing_width_;
     }
 
     void set_auto_rmt(int auto_rmt__)

--- a/src/typedefs.hpp
+++ b/src/typedefs.hpp
@@ -31,6 +31,8 @@
 #include <vector>
 #include <array>
 #include <limits>
+#include <map>
+#include <algorithm>
 
 using double_complex = std::complex<double>;
 
@@ -85,6 +87,25 @@ enum class relativity_t
 
     dirac
 };
+
+inline relativity_t get_relativity_t(std::string name__)
+{
+    std::transform(name__.begin(), name__.end(), name__.begin(), ::tolower);
+    std::map<std::string, relativity_t> const m = {
+        {"none", relativity_t::none},
+        {"koelling_harmon", relativity_t::koelling_harmon},
+        {"zora", relativity_t::zora},
+        {"iora", relativity_t::iora},
+        {"dirac", relativity_t::dirac}
+    };
+
+    if (m.count(name__) == 0) {
+        std::stringstream s;
+        s << "get_relativity_t(): wrong label of the relativity_t enumerator: " << name__;
+        throw std::runtime_error(s.str());
+     }
+     return m.at(name__);
+}
 
 /// Describes radial solution.
 struct radial_solution_descriptor

--- a/verification/test16/sirius.json
+++ b/verification/test16/sirius.json
@@ -34,7 +34,7 @@
         "lmax_pot" : 6,
         "lmax_rho" : 6,
 
-        "density_tol" : 1e-8,
+        "density_tol" : 1e-6,
         "energy_tol" : 1e-8
     },
     


### PR DESCRIPTION
I'm starting to add smearing functions to the code. For any kind of smearing, three functions should be defined: delta(x) function for the substitution of the real delta-function, occupancy function, which is `\int_{-\inf}^{x} delta(t)dt` and entropy functions, which is `\int_{-\inf}^{x} delta(t) t dt`. In the current implementation I use lambda-function mechanism to select the smearing functions. The same can be done with the base abstract class and overloading. @AdhocMan @simonpintarelli what do you think, which way is better? May be there exists yet another approach?