### PR TITLE
Emit warnings for unrecognized config params

### DIFF
--- a/examples/fp-lapw/Eu6C60/sirius.json
+++ b/examples/fp-lapw/Eu6C60/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 16,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack"
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack"
     },
 
     "parameters" : {

--- a/examples/fp-lapw/Fe_square/sirius.json
+++ b/examples/fp-lapw/Fe_square/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 2,
         "processing_unit" : "cpu",
-        "!std_evp_solver_type" : "lapack",
-        "!gen_evp_solver_type" : "lapack",
+        "!std_evp_solver_name" : "lapack",
+        "!gen_evp_solver_name" : "lapack",
         "verbosity" : 3,
         "print_checksum" : false,
         "verification" : 0

--- a/examples/fp-lapw/NiO/sirius.json
+++ b/examples/fp-lapw/NiO/sirius.json
@@ -3,8 +3,8 @@
         "cyclic_block_size" : 16,
         "processing_unit" : "cpu",
     
-        "!std_evp_solver_type" : "lapack",
-        "!gen_evp_solver_type" : "lapack",
+        "!std_evp_solver_name" : "lapack",
+        "!gen_evp_solver_name" : "lapack",
         "verbosity" : 2
     },
 

--- a/examples/fp-lapw/Si/sirius.json
+++ b/examples/fp-lapw/Si/sirius.json
@@ -3,8 +3,8 @@
         "cyclic_block_size" : 16,
         "!processing_unit" : "cpu",
     
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "verbosity" : 2,
         "verification" : 1
     },

--- a/examples/fp-lapw/SrTiO3:Cr/sirius.json
+++ b/examples/fp-lapw/SrTiO3:Cr/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 128,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "scalapack",
-        "gen_evp_solver_type" : "scalapack",
+        "std_evp_solver_name" : "scalapack",
+        "gen_evp_solver_name" : "scalapack",
         "verbosity" : 2
     },
 

--- a/examples/old/10.H2O/sirius.json
+++ b/examples/old/10.H2O/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 16,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "verbosity" : 2
     },
 

--- a/examples/old/11.Tb-molecule/sirius.json
+++ b/examples/old/11.Tb-molecule/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 16,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "scalapack",
-        "gen_evp_solver_type" : "scalapack"
+        "std_evp_solver_name" : "scalapack",
+        "gen_evp_solver_name" : "scalapack"
     },
 
     "parameters" : {

--- a/examples/old/2.SrVO3_fp/sirius.json
+++ b/examples/old/2.SrVO3_fp/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 16,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "scalapack",
-        "gen_evp_solver_type" : "scalapack",
+        "std_evp_solver_name" : "scalapack",
+        "gen_evp_solver_name" : "scalapack",
         "verbosity" : 2
     },
 

--- a/examples/old/2.SrVO3_lapw_only/sirius.json
+++ b/examples/old/2.SrVO3_lapw_only/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 16,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack"
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack"
     },
 
     "parameters" : {

--- a/examples/old/3.GeSi63_uspp/sirius.json
+++ b/examples/old/3.GeSi63_uspp/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 32,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "fft_mode" : "serial"
     },
     

--- a/examples/old/4.Au_surf_uspp/sirius.json
+++ b/examples/old/4.Au_surf_uspp/sirius.json
@@ -1,8 +1,8 @@
 {
     "cyclic_block_size" : 32,
     "processing_unit" : "cpu",
-    "std_evp_solver_type" : "lapack",
-    "gen_evp_solver_type" : "lapack",
+    "std_evp_solver_name" : "lapack",
+    "gen_evp_solver_name" : "lapack",
     "num_fv_states" : 800,
     "electronic_structure_method" : "ultrasoft_pseudopotential",
     

--- a/examples/old/6.GeSi511_uspp/sirius.json
+++ b/examples/old/6.GeSi511_uspp/sirius.json
@@ -1,8 +1,8 @@
 {
     "cyclic_block_size" : 32,
     "processing_unit" : "cpu",
-    "std_evp_solver_type" : "scalapack",
-    "gen_evp_solver_type" : "elpa2",
+    "std_evp_solver_name" : "scalapack",
+    "gen_evp_solver_name" : "elpa2",
     "electronic_structure_method" : "ultrasoft_pseudopotential",
 
     "fft_mode" : "serial",

--- a/examples/old/8.GeSi7_ncpp/sirius.json
+++ b/examples/old/8.GeSi7_ncpp/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 16,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "fft_mode" : "serial",
         "reduce_gvec" : true
     },

--- a/examples/old/9.He/sirius.json
+++ b/examples/old/9.He/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 2,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack"
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack"
     },
 
     "parameters" : {

--- a/examples/old/CaFe2P2/SIRIUS/sirius.json
+++ b/examples/old/CaFe2P2/SIRIUS/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 16,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "reduce_gvec" : true
     },
 

--- a/examples/old/Cu_chain_paw/sirius.json
+++ b/examples/old/Cu_chain_paw/sirius.json
@@ -1,8 +1,8 @@
 {
     "cyclic_block_size" : 16,
     "processing_unit" : "cpu",
-    "std_evp_solver_type" : "lapack",
-    "gen_evp_solver_type" : "lapack",
+    "std_evp_solver_name" : "lapack",
+    "gen_evp_solver_name" : "lapack",
     "!num_fv_states" : 40,
     "electronic_structure_method" : "paw_pseudopotential",
 

--- a/examples/old/Cu_paw/sirius.json
+++ b/examples/old/Cu_paw/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "!std_evp_solver_type" : "lapack",
-      "!gen_evp_solver_type" : "lapack",
+      "!std_evp_solver_name" : "lapack",
+      "!gen_evp_solver_name" : "lapack",
 	  "verbosity": 1
   },
 

--- a/examples/old/Cu_paw_magn/sirius.json
+++ b/examples/old/Cu_paw_magn/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack"
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack"
   },
 
   "parameters" : {

--- a/examples/old/Cu_uspp/sirius.json
+++ b/examples/old/Cu_uspp/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack",
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack",
       "verbosity": 2
   },
 

--- a/examples/old/FORCES/LiF_paw/sirius.json
+++ b/examples/old/FORCES/LiF_paw/sirius.json
@@ -3,8 +3,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "!std_evp_solver_type" : "lapack",
-      "!gen_evp_solver_type" : "lapack",
+      "!std_evp_solver_name" : "lapack",
+      "!gen_evp_solver_name" : "lapack",
       "reduce_gvec": true,
 	  "verbosity": 2
   },

--- a/examples/old/FORCES/LiF_paw_16/sirius.json
+++ b/examples/old/FORCES/LiF_paw_16/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "!std_evp_solver_type" : "scalapack",
-      "!gen_evp_solver_type" : "scalapack",
+      "!std_evp_solver_name" : "scalapack",
+      "!gen_evp_solver_name" : "scalapack",
       "verbosity": 1,
       "num_bands_to_print": 100,
       "verification" : 0,

--- a/examples/old/H_cubic_ncpp/sirius.json
+++ b/examples/old/H_cubic_ncpp/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 16,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack"
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack"
     },
 
     "parameters" : {

--- a/examples/old/H_metal/sirius.json
+++ b/examples/old/H_metal/sirius.json
@@ -1,8 +1,8 @@
 {
     "cyclic_block_size" : 16,
     "processing_unit" : "cpu",
-    "std_evp_solver_type" : "lapack",
-    "gen_evp_solver_type" : "lapack",
+    "std_evp_solver_name" : "lapack",
+    "gen_evp_solver_name" : "lapack",
     "num_fv_states" : 1,
     "electronic_structure_method" : "paw_pseudopotential",
 

--- a/examples/old/He_in_box/sirius.json
+++ b/examples/old/He_in_box/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 2,
         "processing_unit" : "gpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "verbosity" : 2
     },
 

--- a/examples/old/LiF_paw+uspp/sirius.json
+++ b/examples/old/LiF_paw+uspp/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack"
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack"
   },
 
   "parameters" : {

--- a/examples/old/LiF_paw/sirius.json
+++ b/examples/old/LiF_paw/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack",
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack",
 	  "verbosity": 2
   },
 

--- a/examples/old/LiF_paw_magn/sirius.json
+++ b/examples/old/LiF_paw_magn/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack"
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack"
   },
 
   "parameters" : {

--- a/examples/old/LiF_supercell/16/sirius.json
+++ b/examples/old/LiF_supercell/16/sirius.json
@@ -3,8 +3,8 @@
       "!mpi_grid_dims" : [2],
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack",
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack",
       "verbosity" : 2
   },
 

--- a/examples/old/LiF_supercell/16_paw+uspp/sirius.json
+++ b/examples/old/LiF_supercell/16_paw+uspp/sirius.json
@@ -3,8 +3,8 @@
       "!mpi_grid_dims" : [4],
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack"
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack"
   },
 
   "parameters" : {

--- a/examples/old/LiF_supercell/31_deffect/sirius.json
+++ b/examples/old/LiF_supercell/31_deffect/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack"
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack"
   },
 
   "parameters" : {

--- a/examples/old/LiF_supercell/32/sirius.json
+++ b/examples/old/LiF_supercell/32/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack"
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack"
   },
 
   "parameters" : {

--- a/examples/old/LiF_supercell/48/sirius.json
+++ b/examples/old/LiF_supercell/48/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack"
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack"
   },
 
   "parameters" : {

--- a/examples/old/LiF_supercell/vacancy_15/sirius.json
+++ b/examples/old/LiF_supercell/vacancy_15/sirius.json
@@ -3,8 +3,8 @@
       "mpi_grid_dims" : [2],
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack"
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack"
   },
 
   "parameters" : {

--- a/examples/old/LiF_uspp/sirius.json
+++ b/examples/old/LiF_uspp/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack"
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack"
   },
 
   "parameters" : {

--- a/examples/old/LiF_uspp_magn/sirius.json
+++ b/examples/old/LiF_uspp_magn/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack"
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack"
   },
 
   "parameters" : {

--- a/examples/old/Li_cubic_ncpp/sirius.json
+++ b/examples/old/Li_cubic_ncpp/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 16,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack"
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack"
     },
 
     "parameters" : {

--- a/examples/old/Li_paw/sirius.json
+++ b/examples/old/Li_paw/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 16,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "verbosity" : 2,
         "verification" : 1,
         "print_checksum" : true

--- a/examples/old/MgO/sirius.json
+++ b/examples/old/MgO/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack"
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack"
   },
 
   "parameters" : {

--- a/examples/old/QE+Sirius/LiF_paw_15at/sirius.json
+++ b/examples/old/QE+Sirius/LiF_paw_15at/sirius.json
@@ -3,8 +3,8 @@
       "!mpi_grid_dims" : [2],
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack"
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack"
   },
 
   "parameters" : {

--- a/examples/pp-pw/C12H4GaO8_300_atoms/sirius.json
+++ b/examples/pp-pw/C12H4GaO8_300_atoms/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 64,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "scalapack",
-        "gen_evp_solver_type" : "scalapack",
+        "std_evp_solver_name" : "scalapack",
+        "gen_evp_solver_name" : "scalapack",
         "verbosity" : 1,
         "verification" : 0,
         "print_memory_usage" : false,

--- a/examples/pp-pw/C42H58ClNO2Si_420_atoms/sirius.json
+++ b/examples/pp-pw/C42H58ClNO2Si_420_atoms/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 32,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "elpa1",
-      "gen_evp_solver_type" : "elpa1",
+      "std_evp_solver_name" : "elpa1",
+      "gen_evp_solver_name" : "elpa1",
       "verbosity" : 1
   },
 

--- a/examples/pp-pw/Fe_paw/sirius.json
+++ b/examples/pp-pw/Fe_paw/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack",
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack",
       "print_forces" : true,
       "print_stress" : true
   },

--- a/examples/pp-pw/STRESS/Cu_paw/sirius.json
+++ b/examples/pp-pw/STRESS/Cu_paw/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "!std_evp_solver_type" : "lapack",
-      "!gen_evp_solver_type" : "lapack",
+      "!std_evp_solver_name" : "lapack",
+      "!gen_evp_solver_name" : "lapack",
 	  "verbosity": 1,
 	"reduce_gvec": true,
         "print_stress" : true,

--- a/examples/pp-pw/STRESS/LiF_paw/sirius.json
+++ b/examples/pp-pw/STRESS/LiF_paw/sirius.json
@@ -3,8 +3,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "!std_evp_solver_type" : "lapack",
-      "!gen_evp_solver_type" : "lapack",
+      "!std_evp_solver_name" : "lapack",
+      "!gen_evp_solver_name" : "lapack",
       "reduce_gvec": true,
 	  "verbosity": 0,
       "print_stress": true,

--- a/examples/pp-pw/STRESS/LiF_paw_GGA/sirius.json
+++ b/examples/pp-pw/STRESS/LiF_paw_GGA/sirius.json
@@ -3,8 +3,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "!std_evp_solver_type" : "lapack",
-      "!gen_evp_solver_type" : "lapack",
+      "!std_evp_solver_name" : "lapack",
+      "!gen_evp_solver_name" : "lapack",
       "reduce_gvec": true,
 	  "verbosity": 1,
       "print_stress": true,

--- a/examples/pp-pw/STRESS/LiF_paw_vc-relax/sirius.json
+++ b/examples/pp-pw/STRESS/LiF_paw_vc-relax/sirius.json
@@ -3,8 +3,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "!std_evp_solver_type" : "lapack",
-      "!gen_evp_solver_type" : "lapack",
+      "!std_evp_solver_name" : "lapack",
+      "!gen_evp_solver_name" : "lapack",
       "reduce_gvec": true,
 	  "verbosity": 2
   },

--- a/examples/pp-pw/Si7Ge/sirius.json
+++ b/examples/pp-pw/Si7Ge/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "!cyclic_block_size" : 16,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "verbosity" : 3,
         "verification" : 1,
         "print_memory_usage" : false,

--- a/examples/pp-pw/SrTi1-xCrxO3/1/sirius.json
+++ b/examples/pp-pw/SrTi1-xCrxO3/1/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "!processing_unit" : "gpu",
-        "!std_evp_solver_type" : "scalapack",
-        "!gen_evp_solver_type" : "scalapack",
+        "!std_evp_solver_name" : "scalapack",
+        "!gen_evp_solver_name" : "scalapack",
         "verbosity" : 2,
         "verification" : 0,
         "print_memory_usage" : false,

--- a/examples/pp-pw/SrTi1-xCrxO3/125/sirius.json
+++ b/examples/pp-pw/SrTi1-xCrxO3/125/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "!processing_unit" : "gpu",
-        "!std_evp_solver_type" : "scalapack",
-        "!gen_evp_solver_type" : "scalapack",
+        "!std_evp_solver_name" : "scalapack",
+        "!gen_evp_solver_name" : "scalapack",
         "verbosity" : 2,
         "verification" : 0,
         "print_memory_usage" : false,

--- a/examples/pp-pw/SrTi1-xCrxO3/216/sirius.json
+++ b/examples/pp-pw/SrTi1-xCrxO3/216/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "!processing_unit" : "gpu",
-        "!std_evp_solver_type" : "scalapack",
-        "!gen_evp_solver_type" : "scalapack",
+        "!std_evp_solver_name" : "scalapack",
+        "!gen_evp_solver_name" : "scalapack",
         "verbosity" : 2,
         "verification" : 0,
         "print_memory_usage" : false,

--- a/examples/pp-pw/SrTi1-xCrxO3/27/sirius.json
+++ b/examples/pp-pw/SrTi1-xCrxO3/27/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "!processing_unit" : "gpu",
-        "!std_evp_solver_type" : "scalapack",
-        "!gen_evp_solver_type" : "scalapack",
+        "!std_evp_solver_name" : "scalapack",
+        "!gen_evp_solver_name" : "scalapack",
         "verbosity" : 2,
         "verification" : 0,
         "print_memory_usage" : false,

--- a/examples/pp-pw/SrTi1-xCrxO3/512/sirius.json
+++ b/examples/pp-pw/SrTi1-xCrxO3/512/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "!processing_unit" : "gpu",
-        "!std_evp_solver_type" : "scalapack",
-        "!gen_evp_solver_type" : "scalapack",
+        "!std_evp_solver_name" : "scalapack",
+        "!gen_evp_solver_name" : "scalapack",
         "verbosity" : 2,
         "verification" : 0,
         "print_memory_usage" : false,

--- a/examples/pp-pw/SrTi1-xCrxO3/64/sirius.json
+++ b/examples/pp-pw/SrTi1-xCrxO3/64/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "!processing_unit" : "gpu",
-        "!std_evp_solver_type" : "scalapack",
-        "!gen_evp_solver_type" : "scalapack",
+        "!std_evp_solver_name" : "scalapack",
+        "!gen_evp_solver_name" : "scalapack",
         "verbosity" : 2,
         "verification" : 0,
         "print_memory_usage" : false,

--- a/examples/pp-pw/SrTi1-xCrxO3/8/sirius.json
+++ b/examples/pp-pw/SrTi1-xCrxO3/8/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "!processing_unit" : "gpu",
-        "!std_evp_solver_type" : "scalapack",
-        "!gen_evp_solver_type" : "scalapack",
+        "!std_evp_solver_name" : "scalapack",
+        "!gen_evp_solver_name" : "scalapack",
         "verbosity" : 2,
         "verification" : 0,
         "print_memory_usage" : false,

--- a/examples/pp-pw/SrVO3_paw/sirius.json
+++ b/examples/pp-pw/SrVO3_paw/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 16,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "print_stress" : true,
         "print_forces" : true
     },

--- a/examples/pp-pw/SrVO3_uspp/sirius.json
+++ b/examples/pp-pw/SrVO3_uspp/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 16,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "verbosity" : 2,
         "verification" : 0,
         "print_memory_usage" : false,

--- a/examples/pp-pw/SrVO3_uspp_dist/sirius.json
+++ b/examples/pp-pw/SrVO3_uspp_dist/sirius.json
@@ -2,8 +2,8 @@
     "control" : {
         "cyclic_block_size" : 16,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "verbosity" : 1,
         "verification" : 0,
         "print_memory_usage" : false,

--- a/validation/Au-surf/sirius.json
+++ b/validation/Au-surf/sirius.json
@@ -1,8 +1,8 @@
 {
   "control" : {
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack",
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack",
       "verbosity" : 1,
       "print_forces" : true,
       "print_stress" : true

--- a/validation/Si63Ge/sirius.json
+++ b/validation/Si63Ge/sirius.json
@@ -2,7 +2,7 @@
     "control" : {
         "!cyclic_block_size" : 32,
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
         "en_evp_solver_type" : "lapack",
         "verbosity" : 2
     },

--- a/validation/SiO2-ANA/sirius.json
+++ b/validation/SiO2-ANA/sirius.json
@@ -1,7 +1,7 @@
 {
     "control" : {
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
         "en_evp_solver_type" : "lapack",
         "verbosity" : 2
     },

--- a/verification/test01/sirius.json
+++ b/verification/test01/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
-        "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "processing_unit" : "gpu",
+        "std_evp_solver_name" : "cusolver",
+        "gen_evp_solver_name" : "cusolver",
         "verbosity" : 1,
         "print_forces" : true,
         "print_stress" : true

--- a/verification/test01/sirius.json
+++ b/verification/test01/sirius.json
@@ -1,6 +1,6 @@
 {
     "control" : {
-        "processing_unit" : "gpu",
+        "processing_unit" : "cpu",
         "std_evp_solver_name" : "cusolver",
         "gen_evp_solver_name" : "cusolver",
         "verbosity" : 1,

--- a/verification/test01/sirius.json
+++ b/verification/test01/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "processing_unit" : "cpu",
-        "std_evp_solver_name" : "cusolver",
-        "gen_evp_solver_name" : "cusolver",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "verbosity" : 1,
         "print_forces" : true,
         "print_stress" : true

--- a/verification/test02/sirius.json
+++ b/verification/test02/sirius.json
@@ -30,14 +30,17 @@
         "molecule"     : true
     },
 
+    "settings" : {
+        "min_occupancy" : 0
+    },
+
     "iterative_solver" : {
         "energy_tolerance" : 1e-4,
         "residual_tolerance" : 1e-5,
         "num_steps" : 8,
         "subspace_size" : 8,
         "type" : "davidson",
-        "converge_by_energy" : 0,
-        "min_occupancy" : 0
+        "converge_by_energy" : 0
     },
 
     "unit_cell" : {

--- a/verification/test02/sirius.json
+++ b/verification/test02/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "verbosity" : 1,
         "print_forces" : false,
         "print_stress" : false,

--- a/verification/test03/sirius.json
+++ b/verification/test03/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "verbosity" : 1,
         "verification" : 0,
         "rmt_max": 2.0

--- a/verification/test04/sirius.json
+++ b/verification/test04/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "!cyclic_block_size" : 2,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack",
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack",
       "print_forces" : true,
       "print_stress" : true,
       "verbosity" : 1

--- a/verification/test05/sirius.json
+++ b/verification/test05/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 2,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack",
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack",
       "verbosity" : 1,
       "print_forces" : true,
       "print_stress" : true

--- a/verification/test06/sirius.json
+++ b/verification/test06/sirius.json
@@ -1,8 +1,8 @@
 {
   "control" : {
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack",
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack",
       "verbosity" : 1,
       "print_forces" : true,
       "print_stress" : true

--- a/verification/test07/sirius.json
+++ b/verification/test07/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack",
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack",
       "verbosity" : 1,
       "print_forces" : true,
       "print_stress" : true

--- a/verification/test08/sirius.json
+++ b/verification/test08/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "verbosity" : 1,
         "verification" : 0,
         "print_memory_usage" : false,

--- a/verification/test09/sirius.json
+++ b/verification/test09/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "cyclic_block_size" : 16,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack",
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack",
       "verbosity" : 1,
       "print_forces" : true,
       "print_stress" : true

--- a/verification/test10/sirius.json
+++ b/verification/test10/sirius.json
@@ -6,7 +6,7 @@
         "verbosity" : 1,
         "print_checksum" : false,
         "verification" : 0,
-        "cyclic block size" : 2,
+        "cyclic_block_size" : 32,
         "print_forces" : false,
         "print_stress" : false
     },
@@ -20,7 +20,6 @@
     },
 
     "parameters" : {
-        "cyclic_block_size" : 32,
         "electronic_structure_method" : "pseudopotential",
 
         "xc_functionals" : ["XC_LDA_X", "XC_LDA_C_PZ"],
@@ -30,7 +29,7 @@
         "use_symmetry" : false,
 
         "num_mag_dims" : 3,
-        "spin_orbit" : true,
+        "so_correction" : true,
         "gk_cutoff" : 5.0,
         "pw_cutoff" : 20.0,
 

--- a/verification/test10/sirius.json
+++ b/verification/test10/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "processing_unit" : "cpu",
-        "!std_evp_solver_type" : "lapack",
-        "!gen_evp_solver_type" : "lapack",
+        "!std_evp_solver_name" : "lapack",
+        "!gen_evp_solver_name" : "lapack",
         "verbosity" : 1,
         "print_checksum" : false,
         "verification" : 0,

--- a/verification/test11/sirius.json
+++ b/verification/test11/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "verbosity" : 1,
         "!print_checksum" : true,
         "!verification" : 1,

--- a/verification/test11/sirius.json
+++ b/verification/test11/sirius.json
@@ -7,7 +7,8 @@
         "!print_checksum" : true,
         "!verification" : 1,
         "print_forces" : false,
-        "print_stress" : false
+        "print_stress" : false,
+        "cyclic_block_size" : 32
     },
     "iterative_solver" : {
         "!tolerance" : 1e-12,
@@ -19,7 +20,6 @@
     },
 
     "parameters" : {
-        "cyclic_block_size" : 32,
         "electronic_structure_method" : "pseudopotential",
 
         "xc_functionals" : ["XC_LDA_X", "XC_LDA_C_PZ"],
@@ -28,7 +28,7 @@
 
         "use_symmetry" : false,
         "num_mag_dims" : 3,
-        "spin_orbit" : true,
+        "so_correction" : true,
         "gk_cutoff" : 8.36,
         "pw_cutoff" : 26.4575,
 

--- a/verification/test12/sirius.json
+++ b/verification/test12/sirius.json
@@ -6,7 +6,7 @@
         "verbosity" : 1,
         "print_checksum" : false,
         "verification" : 0,
-        "cyclic block size" : 2
+        "cyclic_block_size" : 32
     },
     "iterative_solver" : {
         "!tolerance" : 1e-5,
@@ -18,7 +18,6 @@
     },
 
     "parameters" : {
-        "cyclic_block_size" : 32,
         "electronic_structure_method" : "pseudopotential",
 
         "xc_functionals" : ["XC_LDA_X", "XC_LDA_C_PZ"],
@@ -28,7 +27,7 @@
         "use_symmetry" : false,
 
         "num_mag_dims" : 3,
-        "spin_orbit" : true,
+        "so_correction" : true,
         "hubbard_correction" : true,
         "gk_cutoff" : 5.0,
         "pw_cutoff" : 20.0,
@@ -58,7 +57,7 @@
     },
 
     "hubbard" : {
-        "orthogonalize_hubbard_wave_functions": true,
+        "orthogonalize": true,
         "Au" : {
             "U": 4.4,
             "J": 0.0,

--- a/verification/test12/sirius.json
+++ b/verification/test12/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "processing_unit" : "cpu",
-        "!std_evp_solver_type" : "lapack",
-        "!gen_evp_solver_type" : "lapack",
+        "!std_evp_solver_name" : "lapack",
+        "!gen_evp_solver_name" : "lapack",
         "verbosity" : 1,
         "print_checksum" : false,
         "verification" : 0,

--- a/verification/test12/sirius.json
+++ b/verification/test12/sirius.json
@@ -57,7 +57,7 @@
     },
 
     "hubbard" : {
-        "orthogonalize": true,
+        "orthogonalize_hubbard_wave_functions": true,
         "Au" : {
             "U": 4.4,
             "J": 0.0,

--- a/verification/test13/sirius.json
+++ b/verification/test13/sirius.json
@@ -56,7 +56,7 @@
             }
     },
     "hubbard" : {
-        "orthogonalize": true,
+        "orthogonalize_hubbard_wave_functions": true,
         "Au" : {
             "U": 4.4,
             "J": 0.0,

--- a/verification/test13/sirius.json
+++ b/verification/test13/sirius.json
@@ -5,7 +5,8 @@
         "gen_evp_solver_name" : "lapack",
         "verbosity" : 1,
         "!print_checksum" : true,
-        "!verification" : 1
+        "!verification" : 1,
+        "cyclic_block_size" : 32
     },
     "iterative_solver" : {
         "!tolerance" : 1e-12,
@@ -17,7 +18,6 @@
     },
 
     "parameters" : {
-        "cyclic_block_size" : 32,
         "electronic_structure_method" : "pseudopotential",
 
         "xc_functionals" : ["XC_LDA_X", "XC_LDA_C_PZ"],
@@ -28,7 +28,7 @@
         "use_symmetry" : false,
         "hubbard_correction" : true,
         "num_mag_dims" : 3,
-        "spin_orbit" : true,
+        "so_correction" : true,
         "gk_cutoff" : 8.36,
         "pw_cutoff" : 26.4575,
 
@@ -56,7 +56,7 @@
             }
     },
     "hubbard" : {
-        "orthogonalize_hubbard_wave_functions": true,
+        "orthogonalize": true,
         "Au" : {
             "U": 4.4,
             "J": 0.0,

--- a/verification/test13/sirius.json
+++ b/verification/test13/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "verbosity" : 1,
         "!print_checksum" : true,
         "!verification" : 1

--- a/verification/test14/sirius.json
+++ b/verification/test14/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "verbosity" : 1,
         "print_forces" : true,
         "print_stress" : true

--- a/verification/test14/sirius.json
+++ b/verification/test14/sirius.json
@@ -32,10 +32,12 @@
         "ngridk" : [2,2,2]
     },
 
+    "settings" : {
+        "min_occupancy" : 1e-5
+    },
 
     "iterative_solver" : {
-        "type" : "davidson",
-        "min_occupancy" : 1e-5
+        "type" : "davidson"
     },
 
 

--- a/verification/test15/sirius.json
+++ b/verification/test15/sirius.json
@@ -2,8 +2,8 @@
   "control" : {
       "!cyclic_block_size" : 2,
       "processing_unit" : "cpu",
-      "std_evp_solver_type" : "lapack",
-      "gen_evp_solver_type" : "lapack",
+      "std_evp_solver_name" : "lapack",
+      "gen_evp_solver_name" : "lapack",
       "verbosity" : 1,
       "print_forces" : true,
       "print_stress" : true,

--- a/verification/test16/sirius.json
+++ b/verification/test16/sirius.json
@@ -3,8 +3,8 @@
         "cyclic_block_size" : 16,
         "processing_unit" : "cpu",
     
-        "!std_evp_solver_type" : "lapack",
-        "!gen_evp_solver_type" : "lapack",
+        "!std_evp_solver_name" : "lapack",
+        "!gen_evp_solver_name" : "lapack",
         "verbosity" : 2,
         "print_forces" : false
     },

--- a/verification/test17/sirius.json
+++ b/verification/test17/sirius.json
@@ -3,8 +3,8 @@
         "cyclic_block_size" : 16,
         "processing_unit" : "cpu",
     
-        "!std_evp_solver_type" : "lapack",
-        "!gen_evp_solver_type" : "lapack",
+        "!std_evp_solver_name" : "lapack",
+        "!gen_evp_solver_name" : "lapack",
         "verbosity" : 3,
         "print_forces" : false
 

--- a/verification/test18/sirius.json
+++ b/verification/test18/sirius.json
@@ -83,6 +83,5 @@
     "lmax_apw" : 6,
     "lmax_rho" : 6,
     "lmax_pot" : 6
-  },
-  "title": "input file created with AiiDA"
+  }
 }

--- a/verification/test18/sirius.json
+++ b/verification/test18/sirius.json
@@ -1,8 +1,8 @@
 {
   "control": {
     "processing_unit": "cpu",
-    "gen_evp_solver_type": "lapack",
-    "std_evp_solver_type": "lapack",
+    "gen_evp_solver_name": "lapack",
+    "std_evp_solver_name": "lapack",
     "cyclic_block_size": 16,
     "rmt_max": 2.2,
     "verbosity" : 1

--- a/verification/test19/sirius.json
+++ b/verification/test19/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "verbosity" : 1,
         "verification" : 0,
         "rmt_max": 2.0

--- a/verification/test20/sirius.json
+++ b/verification/test20/sirius.json
@@ -44,7 +44,7 @@
     },
 
     "hubbard" : {
-        "orthogonalize": true,
+        "orthogonalize_hubbard_wave_functions": true,
         "Fe" : {
             "U": 4.4,
             "J": 0.0,

--- a/verification/test20/sirius.json
+++ b/verification/test20/sirius.json
@@ -1,8 +1,8 @@
 {
     "control" : {
         "processing_unit" : "cpu",
-        "std_evp_solver_type" : "lapack",
-        "gen_evp_solver_type" : "lapack",
+        "std_evp_solver_name" : "lapack",
+        "gen_evp_solver_name" : "lapack",
         "verbosity" : 1,
         "print_forces" : true,
         "print_stress" : true

--- a/verification/test20/sirius.json
+++ b/verification/test20/sirius.json
@@ -44,7 +44,7 @@
     },
 
     "hubbard" : {
-        "orthogonalize_hubbard_wave_functions": true,
+        "orthogonalize": true,
         "Fe" : {
             "U": 4.4,
             "J": 0.0,


### PR DESCRIPTION
This one bit me:

`std_evp_solver_type` changed to `std_evp_solver_name` apparently, making benchmarks switch to scalapack instead of cusolver
