### PR TITLE
use smart pointers

### DIFF
--- a/src/unit_cell/atom.hpp
+++ b/src/unit_cell/atom.hpp
@@ -40,7 +40,7 @@ class Atom
     Atom_type const& type_;
 
     /// Symmetry class of the given atom.
-    Atom_symmetry_class* symmetry_class_{nullptr};
+    std::shared_ptr<Atom_symmetry_class> symmetry_class_;
 
     /// Position in fractional coordinates.
     vector3d<double> position_;
@@ -374,7 +374,7 @@ class Atom
     }
 
     /// Set symmetry class of the atom.
-    inline void set_symmetry_class(Atom_symmetry_class* symmetry_class__)
+    inline void set_symmetry_class(std::shared_ptr<Atom_symmetry_class> symmetry_class__)
     {
         symmetry_class_ = symmetry_class__;
     }

--- a/src/unit_cell/atom.hpp
+++ b/src/unit_cell/atom.hpp
@@ -376,7 +376,7 @@ class Atom
     /// Set symmetry class of the atom.
     inline void set_symmetry_class(std::shared_ptr<Atom_symmetry_class> symmetry_class__)
     {
-        symmetry_class_ = symmetry_class__;
+        symmetry_class_ = std::move(symmetry_class__);
     }
 
     /// Set muffin-tin potential and magnetic field.

--- a/src/unit_cell/unit_cell.cpp
+++ b/src/unit_cell/unit_cell.cpp
@@ -90,7 +90,7 @@ std::vector<double> Unit_cell::find_mt_radii()
     for (int i = 0; i < num_atom_types(); i++) {
         if (Rmt[i] < 0.3) {
             std::stringstream s;
-            s << "muffin-tin radius for atom type " << i << " (" << atom_types_[i].label()
+            s << "muffin-tin radius for atom type " << i << " (" << atom_type(i).label()
               << ") is too small: " << Rmt[i];
             TERMINATE(s);
         }
@@ -501,12 +501,12 @@ std::string Unit_cell::chemical_formula()
 Atom_type& Unit_cell::add_atom_type(const std::string label__, const std::string file_name__)
 {
     if (atoms_.size()) {
-        TERMINATE("Can't add new atom type if atoms are already added");
+        WARNING("New feature in use: add new atom type if atoms are already added. Please check your results!");
     }
 
     int id = next_atom_type_id(label__);
-    atom_types_.push_back(Atom_type(parameters_, id, label__, file_name__));
-    return atom_types_.back();
+    atom_types_.push_back(std::shared_ptr<Atom_type>(new Atom_type(parameters_, id, label__, file_name__)));
+    return *atom_types_.back();
 }
 
 void Unit_cell::add_atom(const std::string label, vector3d<double> position, vector3d<double> vector_field)
@@ -523,7 +523,7 @@ void Unit_cell::add_atom(const std::string label, vector3d<double> position, vec
         TERMINATE(s);
     }
 
-    atoms_.push_back(Atom(atom_type(label), position, vector_field));
+    atoms_.push_back(std::shared_ptr<Atom>(new Atom(atom_type(label), position, vector_field)));
     atom_type(label).add_atom_id(static_cast<int>(atoms_.size()) - 1);
 }
 
@@ -636,7 +636,8 @@ void Unit_cell::get_symmetry()
         if (asc[i] == -1) {
             /* take next id */
             atom_class_id++;
-            atom_symmetry_classes_.push_back(Atom_symmetry_class(atom_class_id, atoms_[i].type()));
+            atom_symmetry_classes_.push_back(std::shared_ptr<Atom_symmetry_class>(
+                        new Atom_symmetry_class(atom_class_id, atom(i).type())));
 
             /* scan all atoms */
             for (int j = 0; j < num_atoms(); j++) {
@@ -646,16 +647,16 @@ void Unit_cell::get_symmetry()
                 /* assign new class id for all equivalent atoms */
                 if (is_equal) {
                     asc[j] = atom_class_id;
-                    atom_symmetry_classes_.back().add_atom_id(j);
+                    atom_symmetry_classes_.back()->add_atom_id(j);
                 }
             }
         }
     }
 
-    for (auto& e : atom_symmetry_classes_) {
-        for (int i = 0; i < e.num_atoms(); i++) {
-            int ia = e.atom_id(i);
-            atoms_[ia].set_symmetry_class(&e);
+    for (auto e : atom_symmetry_classes_) {
+        for (int i = 0; i < e->num_atoms(); i++) {
+            int ia = e->atom_id(i);
+            atom(ia).set_symmetry_class(e);
         }
     }
 

--- a/src/unit_cell/unit_cell.hpp
+++ b/src/unit_cell/unit_cell.hpp
@@ -47,13 +47,13 @@ class Unit_cell
     std::map<std::string, int> atom_type_id_map_;
 
     /// List of atom types.
-    std::vector<Atom_type> atom_types_;
+    std::vector<std::shared_ptr<Atom_type>> atom_types_;
 
     /// List of atom classes.
-    std::vector<Atom_symmetry_class> atom_symmetry_classes_;
+    std::vector<std::shared_ptr<Atom_symmetry_class>> atom_symmetry_classes_;
 
     /// List of atoms.
-    std::vector<Atom> atoms_;
+    std::vector<std::shared_ptr<Atom>> atoms_;
 
     /// Split index of atoms.
     splindex<splindex_t::block> spl_num_atoms_;
@@ -326,14 +326,14 @@ class Unit_cell
     inline Atom_type& atom_type(int id__)
     {
         assert(id__ >= 0 && id__ < (int)atom_types_.size());
-        return atom_types_[id__];
+        return *atom_types_[id__];
     }
 
     /// Return const atom type instance by id.
     inline Atom_type const& atom_type(int id__) const
     {
         assert(id__ >= 0 && id__ < (int)atom_types_.size());
-        return atom_types_[id__];
+        return *atom_types_[id__];
     }
 
     /// Return atom type instance by label.
@@ -369,13 +369,13 @@ class Unit_cell
     /// Return const symmetry class instance by class id.
     inline Atom_symmetry_class const& atom_symmetry_class(int id__) const
     {
-        return atom_symmetry_classes_[id__];
+        return *atom_symmetry_classes_[id__];
     }
 
     /// Return symmetry class instance by class id.
     inline Atom_symmetry_class& atom_symmetry_class(int id__)
     {
-        return atom_symmetry_classes_[id__];
+        return *atom_symmetry_classes_[id__];
     }
 
     /// Number of atoms in the unit cell.
@@ -388,14 +388,14 @@ class Unit_cell
     inline Atom const& atom(int id__) const
     {
         assert(id__ >= 0 && id__ < (int)atoms_.size());
-        return atoms_[id__];
+        return *atoms_[id__];
     }
 
     /// Return atom instance by id.
     inline Atom& atom(int id__)
     {
         assert(id__ >= 0 && id__ < (int)atoms_.size());
-        return atoms_[id__];
+        return *atoms_[id__];
     }
 
     inline int total_nuclear_charge() const


### PR DESCRIPTION
Use std::shared_ptr in the lists of atoms, atom types and atom symmetry classes. This allows to add atom type and atoms of that type at the same time. Before, all atom types had to be added first.