### PR TITLE
Tweaks to API generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # We could be fine with 3.12, but 3.14 has ctest --show-only=json-v1 used in CI.
 cmake_minimum_required(VERSION 3.14)
 
-project(SIRIUS VERSION 7.2.1)
+project(SIRIUS VERSION 7.2.2)
 
 # user variables
 set(CREATE_PYTHON_MODULE    OFF CACHE BOOL "create sirius Python module")

--- a/apps/tests/CMakeLists.txt
+++ b/apps/tests/CMakeLists.txt
@@ -13,10 +13,10 @@ endforeach()
 
 if(CREATE_FORTRAN_BINDINGS)
   add_executable(test_fortran_api test_fortran_api.f90)
-  target_link_libraries(test_fortran_api PRIVATE sirius)
+  target_link_libraries(test_fortran_api PRIVATE sirius MPI::MPI_FORTRAN)
   install(TARGETS test_fortran_api RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 
   add_executable(test_srvo3_pwpp test_srvo3_pwpp.f90)
-  target_link_libraries(test_srvo3_pwpp PRIVATE sirius)
+  target_link_libraries(test_srvo3_pwpp PRIVATE sirius MPI::MPI_FORTRAN)
   install(TARGETS test_srvo3_pwpp RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 endif(CREATE_FORTRAN_BINDINGS)

--- a/apps/tests/CMakeLists.txt
+++ b/apps/tests/CMakeLists.txt
@@ -13,10 +13,10 @@ endforeach()
 
 if(CREATE_FORTRAN_BINDINGS)
   add_executable(test_fortran_api test_fortran_api.f90)
-  target_link_libraries(test_fortran_api PRIVATE sirius MPI::MPI_FORTRAN)
+  target_link_libraries(test_fortran_api PRIVATE sirius MPI::MPI_Fortran)
   install(TARGETS test_fortran_api RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 
   add_executable(test_srvo3_pwpp test_srvo3_pwpp.f90)
-  target_link_libraries(test_srvo3_pwpp PRIVATE sirius MPI::MPI_FORTRAN)
+  target_link_libraries(test_srvo3_pwpp PRIVATE sirius MPI::MPI_Fortran)
   install(TARGETS test_srvo3_pwpp RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 endif(CREATE_FORTRAN_BINDINGS)

--- a/apps/tests/test_fortran_api.f90
+++ b/apps/tests/test_fortran_api.f90
@@ -1,5 +1,7 @@
 program test_fortran_api
+use mpi
 use sirius
+implicit none
 type(C_PTR) :: handler
 type(C_PTR) :: kset
 type(C_PTR) :: dft

--- a/apps/tests/test_srvo3_pwpp.f90
+++ b/apps/tests/test_srvo3_pwpp.f90
@@ -16,7 +16,7 @@ call sirius_create_context(MPI_COMM_WORLD, handler)
 
 call sirius_import_parameters(handler, &
     '{"parameters" : {"electronic_structure_method" : "pseudopotential"},&
-      "control" : {"verbosity" : 2, "verification" : 0}}')
+      "control" : {"verbosity" : 1, "verification" : 0}}')
 
 ! atomic units are used everywhere
 ! plane-wave cutoffs are provided in a.u.^-1
@@ -70,6 +70,8 @@ do i = 1, 3
   write(*,*)stress(i,:)
 enddo
 write(*,*)"Total energy: ",energy + scf_correction, " Ha"
+
+call MPI_BARRIER(MPI_COMM_WORLD, i)
 
 
 call sirius_free_handler(dft)

--- a/apps/tests/test_srvo3_pwpp.f90
+++ b/apps/tests/test_srvo3_pwpp.f90
@@ -5,7 +5,7 @@ implicit none
 type(C_PTR) :: handler
 type(C_PTR) :: kset
 type(C_PTR) :: dft
-integer i
+integer i, rank
 real(8) :: lat_vec(3,3), pos(3), forces(3, 5), stress(3,3), energy, scf_correction
 
 ! initialize the library
@@ -61,15 +61,19 @@ call sirius_get_stress_tensor(dft, "total", stress)
 call sirius_get_energy(dft, "total", energy)
 call sirius_get_energy(dft, "descf", scf_correction)
 
-write(*,*)'Forces:'
-do i = 1, 5
-  write(*,*)'atom=',i, ' force=',forces(:,i)
-enddo
-write(*,*)'Stress:'
-do i = 1, 3
-  write(*,*)stress(i,:)
-enddo
-write(*,*)"Total energy: ",energy + scf_correction, " Ha"
+call MPI_COMM_RANK(MPI_COMM_WORLD, rank, i)
+
+if (rank.eq.0) then
+  write(*,*)'Forces:'
+  do i = 1, 5
+    write(*,*)'atom=',i, ' force=',forces(:,i)
+  enddo
+  write(*,*)'Stress:'
+  do i = 1, 3
+    write(*,*)stress(i,:)
+  enddo
+  write(*,*)"Total energy: ",energy + scf_correction, " Ha"
+endif
 
 call MPI_BARRIER(MPI_COMM_WORLD, i)
 

--- a/apps/tests/test_srvo3_pwpp.f90
+++ b/apps/tests/test_srvo3_pwpp.f90
@@ -1,23 +1,22 @@
 program test_fortran_api
+use mpi
 use sirius
+implicit none
 type(C_PTR) :: handler
 type(C_PTR) :: kset
 type(C_PTR) :: dft
 integer i
 real(8) :: lat_vec(3,3), pos(3), forces(3, 5), stress(3,3), energy, scf_correction
-integer comm
 
 ! initialize the library
 call sirius_initialize(call_mpi_init=.true.)
 
 ! create simulation context using a specified communicator
-comm = MPI_COMM_WORLD
-write(*,*)'comm=',comm
-call sirius_create_context(comm, handler)
+call sirius_create_context(MPI_COMM_WORLD, handler)
 
 call sirius_import_parameters(handler, &
     '{"parameters" : {"electronic_structure_method" : "pseudopotential"},&
-      "control" : {"verbosity" : 0, "verification" : 0}}')
+      "control" : {"verbosity" : 2, "verification" : 0}}')
 
 ! atomic units are used everywhere
 ! plane-wave cutoffs are provided in a.u.^-1

--- a/src/api/generated.f90
+++ b/src/api/generated.f90
@@ -283,11 +283,10 @@ end subroutine sirius_context_initialized
 subroutine sirius_create_context(fcomm,handler,error_code)
 implicit none
 !
-integer, target, intent(in) :: fcomm
+integer, value, intent(in) :: fcomm
 type(C_PTR), target, intent(out) :: handler
 integer, optional, target, intent(out) :: error_code
 !
-type(C_PTR) :: fcomm_ptr
 type(C_PTR) :: handler_ptr
 type(C_PTR) :: error_code_ptr
 !
@@ -295,21 +294,19 @@ interface
 subroutine sirius_create_context_aux(fcomm,handler,error_code)&
 &bind(C, name="sirius_create_context")
 use, intrinsic :: ISO_C_BINDING
-type(C_PTR), value :: fcomm
+integer(C_INT), value :: fcomm
 type(C_PTR), value :: handler
 type(C_PTR), value :: error_code
 end subroutine
 end interface
 !
-fcomm_ptr = C_NULL_PTR
-fcomm_ptr = C_LOC(fcomm)
 handler_ptr = C_NULL_PTR
 handler_ptr = C_LOC(handler)
 error_code_ptr = C_NULL_PTR
 if (present(error_code)) then
 error_code_ptr = C_LOC(error_code)
 endif
-call sirius_create_context_aux(fcomm_ptr,handler_ptr,error_code_ptr)
+call sirius_create_context_aux(fcomm,handler_ptr,error_code_ptr)
 end subroutine sirius_create_context
 
 !
@@ -2127,7 +2124,7 @@ implicit none
 type(C_PTR), target, intent(in) :: handler
 character(*), target, intent(in) :: label
 integer, target, intent(in) :: num_beta
-real(8), target, dimension(num_beta,num_beta), intent(in) :: dion
+real(8), target, dimension(num_beta, num_beta), intent(in) :: dion
 !
 type(C_PTR) :: handler_ptr
 type(C_PTR) :: label_ptr
@@ -2312,7 +2309,7 @@ character(*), target, intent(in) :: label
 complex(8), target, dimension(*), intent(in) :: pw_coeffs
 logical, optional, target, intent(in) :: transform_to_rg
 integer, optional, target, intent(in) :: ngv
-integer, optional, target, dimension(3,*), intent(in) :: gvl
+integer, optional, target, dimension(3, *), intent(in) :: gvl
 integer, optional, target, intent(in) :: comm
 !
 type(C_PTR) :: handler_ptr
@@ -2387,7 +2384,7 @@ type(C_PTR), target, intent(in) :: handler
 character(*), target, intent(in) :: label
 complex(8), target, dimension(*), intent(in) :: pw_coeffs
 integer, optional, target, intent(in) :: ngv
-integer, optional, target, dimension(3,*), intent(in) :: gvl
+integer, optional, target, dimension(3, *), intent(in) :: gvl
 integer, optional, target, intent(in) :: comm
 !
 type(C_PTR) :: handler_ptr
@@ -2453,7 +2450,7 @@ character(*), target, intent(in) :: atom_type
 character(*), target, intent(in) :: label
 real(8), target, dimension(*), intent(out) :: pw_coeffs
 integer, optional, target, intent(in) :: ngv
-integer, optional, target, dimension(3,*), intent(in) :: gvl
+integer, optional, target, dimension(3, *), intent(in) :: gvl
 integer, optional, target, intent(in) :: comm
 !
 type(C_PTR) :: handler_ptr
@@ -2876,7 +2873,7 @@ implicit none
 type(C_PTR), target, intent(in) :: handler
 integer, target, intent(in) :: ia
 integer, target, intent(in) :: ispn
-real(8), target, dimension(ld,ld), intent(out) :: d_mtrx
+real(8), target, dimension(ld, ld), intent(out) :: d_mtrx
 integer, target, intent(in) :: ld
 !
 type(C_PTR) :: handler_ptr
@@ -3013,7 +3010,7 @@ implicit none
 !
 type(C_PTR), target, intent(in) :: handler
 character(*), target, intent(in) :: label
-real(8), target, dimension(ld,ld), intent(out) :: q_mtrx
+real(8), target, dimension(ld, ld), intent(out) :: q_mtrx
 integer, target, intent(in) :: ld
 !
 type(C_PTR) :: handler_ptr
@@ -3179,7 +3176,7 @@ implicit none
 !
 type(C_PTR), target, intent(in) :: handler
 character(*), target, intent(in) :: label
-real(8), target, dimension(3,*), intent(out) :: forces
+real(8), target, dimension(3, *), intent(out) :: forces
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -3226,7 +3223,7 @@ implicit none
 !
 type(C_PTR), target, intent(in) :: handler
 character(*), target, intent(in) :: label
-real(8), target, dimension(3,3), intent(out) :: stress_tensor
+real(8), target, dimension(3, 3), intent(out) :: stress_tensor
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -3326,7 +3323,7 @@ character(*), target, intent(in) :: label
 integer, target, intent(in) :: xi1
 integer, target, intent(in) :: xi2
 integer, target, intent(in) :: ngv
-integer, target, dimension(3,ngv), intent(in) :: gvl
+integer, target, dimension(3, ngv), intent(in) :: gvl
 complex(8), target, dimension(ngv), intent(out) :: q_pw
 !
 type(C_PTR) :: handler_ptr
@@ -4096,8 +4093,8 @@ subroutine sirius_get_gvec_arrays(handler,gvec,gvec_cart,gvec_len,index_by_gvec)
 implicit none
 !
 type(C_PTR), target, intent(in) :: handler
-integer, optional, target, dimension(3,*), intent(in) :: gvec
-real(8), optional, target, dimension(3,*), intent(in) :: gvec_cart
+integer, optional, target, dimension(3, *), intent(in) :: gvec
+real(8), optional, target, dimension(3, *), intent(in) :: gvec_cart
 real(8), optional, target, dimension(*), intent(in) :: gvec_len
 integer, optional, target, intent(in) :: index_by_gvec
 !

--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -354,7 +354,7 @@ sirius_create_context:
   arguments:
     fcomm:
       type: int
-      attr: in, required
+      attr: in, required, value
       doc: Entire communicator of the simulation.
     handler:
       type: void*
@@ -366,11 +366,11 @@ sirius_create_context:
       doc: Error code.
 @api end
 */
-void sirius_create_context(int const* fcomm__, void** handler__, int* error_code__)
+void sirius_create_context(int fcomm__, void** handler__, int* error_code__)
 {
     call_sirius([&]()
     {
-        auto& comm = Communicator::map_fcomm(*fcomm__);
+        auto& comm = Communicator::map_fcomm(fcomm__);
         *handler__ = new utils::any_ptr(new sirius::Simulation_context(comm));
     }, error_code__);
 }
@@ -6034,7 +6034,7 @@ sirius_set_callback_function:
       doc: Lable of the callback function.
     fptr:
       type: func
-      attr: in, required
+      attr: in, required, value
       doc: Pointer to callback function.
     error_code:
       type: int


### PR DESCRIPTION
Allow `pass by value` for the Fortran API.
This is now possible `call sirius_create_context(MPI_COMM_WORLD, handler)`