### PR TITLE
Add missing initialization to zero when computing the hubbard forces

### DIFF
--- a/src/geometry/force.cpp
+++ b/src/geometry/force.cpp
@@ -344,7 +344,9 @@ mdarray<double, 2> const& Force::calc_forces_hubbard()
     forces_hubbard_.zero();
 
     if (ctx_.hubbard_correction()) {
-        /* we can probably task run this in a task fashion */
+        // recompute the hubbard potential.
+        potential_.U().generate_potential(density_.occupation_matrix().data());
+
         Q_operator q_op(ctx_);
 
         for (int ikloc = 0; ikloc < kset_.spl_num_kpoints().local_size(); ikloc++) {
@@ -663,7 +665,7 @@ void Force::hubbard_force_add_k_contribution_colinear(K_point& kp__, Q_operator&
     for (int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
         /* compute the derivative of the occupancies numbers */
         for (int dir = 0; dir < 3; dir++) {
-            double d{0};
+            double_complex d{0.0};
             for (int ia1 = 0; ia1 < ctx_.unit_cell().num_atoms(); ia1++) {
                 auto const& atom = ctx_.unit_cell().atom(ia1);
                 if (atom.type().hubbard_correction()) {
@@ -671,13 +673,13 @@ void Force::hubbard_force_add_k_contribution_colinear(K_point& kp__, Q_operator&
                     for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
                         for (int m1 = 0; m1 < lmax_at; m1++) {
                             for (int m2 = 0; m2 < lmax_at; m2++) {
-                                d += std::real(potential_.U().U(m2, m1, ispn, ia1) * dn(m1, m2, ispn, ia1, dir, ia));
+                                d += potential_.U().U(m2, m1, ispn, ia1) * dn(m1, m2, ispn, ia1, dir, ia);
                             }
                         }
                     }
                 }
             }
-            forceh_(dir, ia) -= d;
+            forceh_(dir, ia) -= std::real(d);
         }
     }
 }

--- a/src/hubbard/hubbard_potential_energy.cpp
+++ b/src/hubbard/hubbard_potential_energy.cpp
@@ -26,6 +26,9 @@
 
 namespace sirius {
 
+  /* we can use Ref PRB {\bf 102}, 235159 (2020) as reference for the colinear
+   * case.
+   */
 void
 Hubbard::generate_potential_collinear(sddk::mdarray<double_complex, 4> const& om__)
 {
@@ -55,12 +58,15 @@ Hubbard::generate_potential_collinear(sddk::mdarray<double_complex, 4> const& om
                     // is = 0 up-up
                     // is = 1 down-down
 
+                  /* Expression Eq.7 without the P_IJ which is applied when we
+                   * actually apply the potential to the wave functions. Also
+                   * note the presence of alpha  */
                     for (int m1 = 0; m1 < lmax_at; m1++) {
-                        this->hubbard_potential_(m1, m1, is, ia) +=
+                        this->hubbard_potential_(m1, m1, is, ia) =
                             (atom.type().lo_descriptor_hub(0).Hubbard_alpha() + 0.5 * U_effective);
 
                         for (int m2 = 0; m2 < lmax_at; m2++) {
-                            this->hubbard_potential_(m1, m2, is, ia) -= U_effective * om__(m2, m1, is, ia);
+                            this->hubbard_potential_(m2, m1, is, ia) -= U_effective * om__(m2, m1, is, ia);
                         }
                     }
                 }
@@ -313,7 +319,7 @@ Hubbard::calculate_energy_collinear(sddk::mdarray<double_complex, 4> const& om__
     }
 
     if ((ctx_.verbosity() >= 1) && (ctx_.comm().rank() == 0)) {
-        std::printf("\n hub Energy (total) %.5lf  (dc) %.5lf\n", hubbard_energy, hubbard_energy_dc_contribution);
+        std::printf("hub Energy (total) %.5lf  (dc) %.5lf\n", hubbard_energy, hubbard_energy_dc_contribution);
     }
     return hubbard_energy;
 }

--- a/src/k_point/k_point.hpp
+++ b/src/k_point/k_point.hpp
@@ -90,6 +90,9 @@ class K_point
     /// Two-component (spinor) wave functions used to compute the hubbard corrections. They can be different from the atomic wave functions.
     std::unique_ptr<Wave_functions> hubbard_wave_functions_{nullptr};
 
+    /// Two-component (spinor) wave functions used to compute the hubbard corrections. They can be different from the atomic wave functions.
+    std::unique_ptr<Wave_functions> hubbard_wave_functions_without_S_{nullptr};
+
     /// Two-component (spinor) atomic orbitals used to compute the hubbard wave functions
     std::unique_ptr<Wave_functions> atomic_wave_functions_hub_{nullptr};
 
@@ -351,7 +354,7 @@ class K_point
         }
     }
 
-    void orthogonalize_hubbard_orbitals(Wave_functions& phi__, Wave_functions& sphi__, Wave_functions& sphi_hub__);
+    void orthogonalize_hubbard_orbitals(Wave_functions& phi__, Wave_functions& sphi__, Wave_functions& phi_hub__, Wave_functions& sphi_hub__);
 
     /// Save data to HDF5 file.
     void save(std::string const& name__, int id__) const;
@@ -476,6 +479,7 @@ class K_point
         return spinor_wave_functions_;
     }
 
+   // the S operator is applied on these functions
     inline Wave_functions& hubbard_wave_functions()
     {
         assert(hubbard_wave_functions_ != nullptr);
@@ -486,6 +490,18 @@ class K_point
     {
         assert(hubbard_wave_functions_ != nullptr);
         return *hubbard_wave_functions_;
+    }
+
+    inline Wave_functions& hubbard_wave_functions_without_S()
+    {
+        assert(hubbard_wave_functions_ != nullptr);
+        return *hubbard_wave_functions_without_S_;
+    }
+
+    inline Wave_functions const& hubbard_wave_functions_without_S() const
+    {
+        assert(hubbard_wave_functions_ != nullptr);
+        return *hubbard_wave_functions_without_S_;
     }
 
     /// return the atomic wave functions used to compute the hubbard wave functions. The S operator is applied when uspp are used.

--- a/src/unit_cell/hubbard_orbitals_descriptor.hpp
+++ b/src/unit_cell/hubbard_orbitals_descriptor.hpp
@@ -51,7 +51,7 @@ class hubbard_orbital_descriptor
         hubbard_coefficients_[3]
         hubbard_coefficients[4] = U_alpha
         hubbard_coefficients[5] = U_beta */
-    double hubbard_coefficients_[4];
+  double hubbard_coefficients_[4] = {0.0, 0.0, 0.0, 0.0};
 
     sddk::mdarray<double, 4> hubbard_matrix_;
 
@@ -105,7 +105,7 @@ class hubbard_orbital_descriptor
 
         // Note that for consistency, the ak are calculated with complex
         // harmonics in the gaunt coefficients <R_lm|Y_l'm'|R_l''m''>.
-        // we need to keep it that way because of the hubbard potential
+        // we need to keep it that way because of the hubbard potential.
         // With a spherical one it does not really matter-
         ak.zero();
 


### PR DESCRIPTION
- add missing initialization to zero of temporary hubbard wave functions
- remove unneeded sign when computing hubbard potential.
- recompute the hubbard potential before computing the hubbard forces
- updated the references used for the implementation