### PR TITLE
Add example of Dockerfile

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -1,0 +1,84 @@
+#FROM nvidia/cuda:11.3.0-runtime-ubuntu20.04
+FROM ubuntu:20.04
+
+#==ENV NCCL_VERSION 2.9.6
+#==
+ENV DEBIAN_FRONTEND noninteractive
+#==
+ENV FORCE_UNSAFE_CONFIGURE 1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  apt-utils python3-distutils python3-apt python3-dev \
+  gcc g++ gfortran python3 git make apt-transport-https ca-certificates \
+  gnupg software-properties-common curl patch pkg-config vim wget xz-utils unzip
+#==
+#==RUN apt-get update && apt-get install -y --no-install-recommends \
+#==    libtinfo5 libncursesw5 \
+#==    gcc g++ gfortran git make \
+#==    cuda-cudart-dev-11-3=11.3.58-1 \
+#==    cuda-command-line-tools-11-3=11.3.0-1 \
+#==    cuda-minimal-build-11-3=11.3.0-1 \
+#==    cuda-libraries-dev-11-3=11.3.0-1 \
+#==    cuda-nvml-dev-11-3=11.3.58-1 \
+#==    libnpp-dev-11-3=11.3.3.44-1 \
+#==    libnccl-dev=2.9.6-1+cuda11.3 \
+#==    libcublas-dev-11-3=11.4.2.10064-1 \
+#==    libcusparse-dev-11-3=11.5.0.58-1 \
+#==    python \
+#==    && rm -rf /var/lib/apt/lists/*
+#==
+#==# apt from auto upgrading the cublas package. See https://gitlab.com/nvidia/container-images/cuda/-/issues/88
+#==RUN apt-mark hold libcublas-dev-11-3 libnccl-dev
+#==ENV LIBRARY_PATH /usr/local/cuda/lib64/stubs
+#==
+# get latest version of spack
+#RUN git clone https://github.com/spack/spack.git /usr/spack
+#
+#ENV SPACK_ROOT /usr/spack
+#
+#ENV PATH="${SPACK_ROOT}/bin:${PATH}"
+#
+#COPY compilers.yaml /root/.spack/linux/
+
+# install spack to /spack/ folder
+RUN wget -qO spack.x https://github.com/haampie/spack-batteries-included/releases/download/develop/spack-x86_64.x
+RUN chmod +x spack.x
+RUN ./spack.x --squashfs-extract
+# add environment variables
+RUN echo "source /spack/spack_src/share/spack/setup-env.sh" >> /etc/profile.d/spack.sh
+
+RUN /spack/spack install sirius@develop +fortran +scalapack
+
+#COPY test.f90 /root/test.f90
+
+#==#
+#==#RUN /bin/bash -c eval `spack load --sh pkgconf`
+#==#
+#==
+#==
+#==
+#==
+#==# RUN apt-get install -y apt-utils
+#==# 
+#==# # install basic tools
+#==# RUN apt-get install -y gcc g++ gfortran git make cmake unzip \
+#==#   vim wget pkg-config python3-pip curl environment-modules tcl
+#==# 
+#==# # add environment variables
+#==# RUN echo "source /root/spack/share/spack/setup-env.sh" >> /etc/profile.d/spack.sh
+#==# 
+#==# ## build GCC
+#==# #RUN /bin/bash -l -c "spack install gcc@8.2.0"
+#==# #
+#==# ## add GCC to environment
+#==# #RUN echo "spack load --dependencies gcc@8.2.0" >> /etc/profile.d/spack.sh
+#==# #
+#==# ## update list of spack compilers
+#==# #RUN /bin/bash -l -c "spack compiler find"
+#==# #
+#==# ## build CMake
+#==# #RUN /bin/bash -l -c "spack install --no-checksum cmake@3.16.2 %gcc@8.2.0"
+#==# #
+WORKDIR /root
+
+ENTRYPOINT ["bash", "-l"]


### PR DESCRIPTION
Hi Harmen @haampie !
Can you please have a look and refactor if needed the Dockerfile. I want to have an example of the base container with  sirius installed. It works so far, but if jump inside the container and execute `spack spec sirius@develop` or `spack spec sirius@develop +fortran +scalapack' it starts building some other packages which is weird. Here:
```
root@43002c3f99b0:~# spack spec sirius@develop +fortran +scalapack
Input spec
--------------------------------
sirius@develop+fortran+scalapack

Concretized
--------------------------------
==> Warning: Missing a source id for python@3.8
==> Installing libiconv-1.16-w6zptbclncs3jsnl3i4qtg72fgheiwdf
==> No binary for libiconv-1.16-w6zptbclncs3jsnl3i4qtg72fgheiwdf found: installing from source
==> Using cached archive: /tmp/root/source_cache/_source-cache/archive/e6/e6a1b1b589654277ee790cce3734f07876ac4ccfaecbee8afa0b649cf529cc04.tar.gz
==> No patches needed for libiconv
==> libiconv: Executing phase: 'autoreconf'
==> libiconv: Executing phase: 'configure'
==> Error: Exception occurred in writer daemon!
==> Error: Failed to install libiconv due to KeyboardInterrupt:
Traceback (most recent call last):
  File "/spack/spack_src/lib/spack/llnl/util/tty/log.py", line 754, in _writer_daemon
    rlist, _, _ = _retry(select.select)(istreams, [], [], 1e-1)
  File "/spack/spack_src/lib/spack/llnl/util/tty/log.py", line 837, in wrapped
    return function(*args, **kwargs)
KeyboardInterrupt

==> Error: Keyboard interrupt.
```