### PR TITLE
Bring back compilers

### DIFF
--- a/ci/spack/build.Dockerfile
+++ b/ci/spack/build.Dockerfile
@@ -58,6 +58,9 @@ ENV SPACK_SHA=$SPACK_SHA
 RUN mkdir -p /opt/spack && \
     curl -Ls "https://api.github.com/repos/spack/spack/tarball/$SPACK_SHA" | tar --strip-components=1 -xz -C /opt/spack
 
+# "Install" compilers
+COPY "$COMPILER_CONFIG" /opt/spack/etc/spack/compilers.yaml
+
 # Set up the binary cache and trust the public part of our signing key
 COPY ./ci/spack/public_key.asc ./public_key.asc
 RUN spack mirror add --scope site cscs https://spack.dev && \

--- a/ci/spack/compilers-18.04.yaml
+++ b/ci/spack/compilers-18.04.yaml
@@ -1,0 +1,27 @@
+compilers:
+- compiler:
+    spec: gcc@7.5.0
+    paths:
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: {}
+    operating_system: ubuntu18.04
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: clang@6.0.0
+    paths:
+      cc: /usr/bin/clang
+      cxx: /usr/bin/clang++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: {}
+    operating_system: ubuntu18.04
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []

--- a/ci/spack/compilers-20.04.yaml
+++ b/ci/spack/compilers-20.04.yaml
@@ -1,0 +1,27 @@
+compilers:
+- compiler:
+    spec: gcc@9.3.0
+    paths:
+      cc: /usr/bin/gcc
+      cxx: /usr/bin/g++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: {}
+    operating_system: ubuntu20.04
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []
+- compiler:
+    spec: clang@10.0.0
+    paths:
+      cc: /usr/bin/clang
+      cxx: /usr/bin/clang++
+      f77: /usr/bin/gfortran
+      fc: /usr/bin/gfortran
+    flags: {}
+    operating_system: ubuntu20.04
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths: []


### PR DESCRIPTION
Spack doesn't autodetect mixed compiler setups with clang for c/cpp and
gfortran for fortran, so we have to list them explicitly.
