### PR TITLE
relax a bit threshold on the symmetry check

### DIFF
--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -376,6 +376,18 @@ inline std::string boolstr(bool b__)
     }
 }
 
+template <typename T>
+auto abs_diff(T a, T b)
+{
+    return std::abs(a - b);
+}
+
+template <typename T>
+auto rel_diff(T a, T b)
+{
+    return std::abs(a - b) / (std::abs(a) + std::abs(b) + 1e-13);
+}
+
 } // namespace
 
 template <typename T>


### PR DESCRIPTION
In the LAPW high-cutoff mode, the symmetry check was too tough as reported by @dev-zero 