### PR TITLE
a hacky way to switch from fp32 to fp64 on the fly

### DIFF
--- a/src/SDDK/wave_functions.hpp
+++ b/src/SDDK/wave_functions.hpp
@@ -322,7 +322,7 @@ class Wave_functions
         return preferred_memory_t_;
     }
 
-    inline std::complex<T> checksum(device_t pu__, int ispn__, int i0__, int n__) const
+    inline auto checksum(device_t pu__, int ispn__, int i0__, int n__) const
     {
         return checksum_pw(pu__, ispn__, i0__, n__) + checksum_mt(pu__, ispn__, i0__, n__);
     }

--- a/src/context/config.hpp
+++ b/src/context/config.hpp
@@ -201,9 +201,6 @@ class config_t
         }
         inline void itsol_tol_min(double itsol_tol_min__)
         {
-            if (dict_.contains("locked")) {
-                throw std::runtime_error(locked_msg);
-            }
             dict_["/settings/itsol_tol_min"_json_pointer] = itsol_tol_min__;
         }
         /// Minimum occupancy below which the band is treated as being 'empty'
@@ -1333,9 +1330,6 @@ class config_t
         }
         inline void precision(std::string precision__)
         {
-            if (dict_.contains("locked")) {
-                throw std::runtime_error(locked_msg);
-            }
             dict_["/parameters/precision"_json_pointer] = precision__;
         }
       private:

--- a/src/k_point/k_point_set.hpp
+++ b/src/k_point/k_point_set.hpp
@@ -46,12 +46,9 @@ class K_point_set
     /// List of k-points.
     std::vector<std::unique_ptr<K_point<double>>> kpoints_;
 
-#ifdef USE_FP32
+#if defined(USE_FP32)
     /// List of k-points in fp32 type, most calculation and assertion in this class only rely on fp64 type kpoints_
     std::vector<std::unique_ptr<K_point<float>>> kpoints_float_;
-
-    /// bool variable to store last access of kpoints using fp32 or fp64 type
-    //mutable bool access_fp64{true};
 #endif
 
     /// Split index of k-points.


### PR DESCRIPTION
@manhin321 That's an alternative approach to to mixed-precision DFT. First, we converge to 10^-6 with fp32 and then switch to fp64. The implementation is a bit hacky at the moment, but it works, provided that Davidson didn't fail in fp32