### PR TITLE
Fixes for clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,10 @@ endif()
 
 set(CMAKE_CXX_STANDARD 14)
 
+# This ensures that -std=c++14 is passed to nvcc. See
+# https://github.com/electronic-structure/SIRIUS/issues/716 for details.
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)

--- a/src/gpu/spherical_harmonics.cu
+++ b/src/gpu/spherical_harmonics.cu
@@ -38,7 +38,7 @@ __global__ void spherical_harmonics_ylm_gpu_kernel(int lmax__, int ntp__, double
 
     if (itp < ntp__) {
         double theta = tp__[2 * itp];
-        double phi   = tp__[2 * itp + 1];
+        // double phi   = tp__[2 * itp + 1];
         double sint = sin(theta);
         double cost = cos(theta);
 

--- a/src/linalg/eigenproblem.hpp
+++ b/src/linalg/eigenproblem.hpp
@@ -298,7 +298,7 @@ class Eigensolver_lapack : public Eigensolver
         auto ifail = mp_h_.get_unique_ptr<ftn_int>(matrix_size__);
 
         int nb, lwork, liwork;
-        int lrwork; // only required in complex
+        int lrwork = 0; // only required in complex
         if (std::is_same<T, double>::value) {
             nb     = linalg_base::ilaenv(1, "DSYTRD", "U", matrix_size__, 0, 0, 0);
             lwork  = (nb + 3) * matrix_size__ + 1024;


### PR DESCRIPTION
- Squash some clang warnings
- Force a -std=c++14 flag to nvcc
