### PR TITLE
use cfg.control.spglib_tolerance in find_lat_sym

### DIFF
--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -474,7 +474,7 @@ Simulation_context::initialize()
     if (use_symmetry()) {
         auto lv = matrix3d<double>(unit_cell().lattice_vectors());
 
-        auto lat_sym = find_lat_sym(lv, 1e-6);
+        auto lat_sym = find_lat_sym(lv, cfg().control().spglib_tolerance());
 
         #pragma omp parallel for
         for (int i = 0; i < unit_cell().symmetry().size(); i++) {


### PR DESCRIPTION
There are structures where `find_lat_sym` discards some of the symmetry operations spglib finds. There is a hardcoded value of 1e-6 in the code. In other places where `find_lat_sym` is called, the control default value of 1e-4 is used. Could we remove `find_lat_sym` entirely and instead rely on the results of spglib?

A unit cell which throws this error:
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  
[initialize] /run/user/25361/simonpi/spack-stage-sirius-develop-3snm6vxsjqyz6nurdxkg3chuqnr2znqt/spack-src/src/context/simulation_context.cpp:496
[initialize] spglib lattice symmetry was not found in the list of SIRIUS generated symmetries
```

is for example the following one (the metric tensor error is 1e-5)
```
{
    "lattice_vectors": [
        [5.302491361848048, 0, 0],
        [2.651245817267764, 4.610990229031738, 0],
        [2.6512547647430185, 1.5306946293431323, 8.846284266119104]
    ],
    "atom_coordinate_units": "au",
    "atom_types": ["Co", "Li", "O"],
    "atom_files": {"Co": "Co.json", "Li": "Li.json", "O": "O.json"},
    "atoms": {
        "Co": [
            [5.302495971834929, 3.0613937985643065, 4.423142133059552, 0, 0, 1]
        ],
        "Li": [
            [0, 0, 0, 0, 0, 1]
        ],
        "O": [
            [2.6512482761793974, 1.53069617570602, 2.4884463734803184, 0, 0, 1],
            [7.9537436674904605, 4.592091421422593, 6.357837892638786, 0, 0, 1]
        ]
    }
}
```

