### PR TITLE
fix API to sirius_find_ground_state()

### DIFF
--- a/apps/tests/test_srvo3_pwpp.f90
+++ b/apps/tests/test_srvo3_pwpp.f90
@@ -76,29 +76,26 @@ call sirius_find_ground_state(dft)
 if (rank.eq.0) then
   write(*,*)'running new DFT with updated lattice vectors'
 endif
-call sirius_set_parameters(handler, iter_solver_tol=1d-2)
 lat_vec = lat_vec * 0.9d0
 call sirius_set_lattice_vectors(handler, lat_vec(:, 1), lat_vec(:, 2), lat_vec(:, 3))
 call sirius_update_context(handler)
-call sirius_find_ground_state(dft)
+call sirius_find_ground_state(dft, iter_solver_tol=1d-3)
 
 if (rank.eq.0) then
   write(*,*)'running new DFT with updated lattice vectors'
 endif
-call sirius_set_parameters(handler, iter_solver_tol=1d-2)
 lat_vec = lat_vec * 0.9d0
 call sirius_set_lattice_vectors(handler, lat_vec(:, 1), lat_vec(:, 2), lat_vec(:, 3))
 call sirius_update_context(handler)
-call sirius_find_ground_state(dft)
+call sirius_find_ground_state(dft, iter_solver_tol=1d-2)
 
 if (rank.eq.0) then
   write(*,*)'running new DFT with updated lattice vectors'
 endif
-call sirius_set_parameters(handler, iter_solver_tol=1d-2)
 lat_vec = lat_vec * 0.8d0
 call sirius_set_lattice_vectors(handler, lat_vec(:, 1), lat_vec(:, 2), lat_vec(:, 3))
 call sirius_update_context(handler)
-call sirius_find_ground_state(dft)
+call sirius_find_ground_state(dft, iter_solver_tol=1d-2)
 
 
 

--- a/src/api/sirius.f90
+++ b/src/api/sirius.f90
@@ -454,7 +454,6 @@ end subroutine sirius_import_parameters
 !> @param [in] so_correction True if spin-orbit correnctio is enabled.
 !> @param [in] valence_rel Valence relativity treatment.
 !> @param [in] core_rel Core relativity treatment.
-!> @param [in] iter_solver_tol Tolerance of the iterative solver (deprecated).
 !> @param [in] iter_solver_tol_empty Tolerance for the empty states.
 !> @param [in] iter_solver_type Type of iterative solver.
 !> @param [in] verbosity Verbosity level.
@@ -471,9 +470,9 @@ end subroutine sirius_import_parameters
 !> @param [out] error_code Error code.
 subroutine sirius_set_parameters(handler,lmax_apw,lmax_rho,lmax_pot,num_fv_states,&
 &num_bands,num_mag_dims,pw_cutoff,gk_cutoff,fft_grid_size,auto_rmt,gamma_point,use_symmetry,&
-&so_correction,valence_rel,core_rel,iter_solver_tol,iter_solver_tol_empty,iter_solver_type,&
-&verbosity,hubbard_correction,hubbard_correction_kind,hubbard_full_orthogonalization,&
-&hubbard_orbitals,sht_coverage,min_occupancy,smearing,smearing_width,spglib_tol,electronic_structure_method,&
+&so_correction,valence_rel,core_rel,iter_solver_tol_empty,iter_solver_type,verbosity,&
+&hubbard_correction,hubbard_correction_kind,hubbard_full_orthogonalization,hubbard_orbitals,&
+&sht_coverage,min_occupancy,smearing,smearing_width,spglib_tol,electronic_structure_method,&
 &error_code)
 implicit none
 !
@@ -493,7 +492,6 @@ logical, optional, target, intent(in) :: use_symmetry
 logical, optional, target, intent(in) :: so_correction
 character(*), optional, target, intent(in) :: valence_rel
 character(*), optional, target, intent(in) :: core_rel
-real(8), optional, target, intent(in) :: iter_solver_tol
 real(8), optional, target, intent(in) :: iter_solver_tol_empty
 character(*), optional, target, intent(in) :: iter_solver_type
 integer, optional, target, intent(in) :: verbosity
@@ -530,7 +528,6 @@ type(C_PTR) :: valence_rel_ptr
 character(C_CHAR), target, allocatable :: valence_rel_c_type(:)
 type(C_PTR) :: core_rel_ptr
 character(C_CHAR), target, allocatable :: core_rel_c_type(:)
-type(C_PTR) :: iter_solver_tol_ptr
 type(C_PTR) :: iter_solver_tol_empty_ptr
 type(C_PTR) :: iter_solver_type_ptr
 character(C_CHAR), target, allocatable :: iter_solver_type_c_type(:)
@@ -555,9 +552,9 @@ type(C_PTR) :: error_code_ptr
 interface
 subroutine sirius_set_parameters_aux(handler,lmax_apw,lmax_rho,lmax_pot,num_fv_states,&
 &num_bands,num_mag_dims,pw_cutoff,gk_cutoff,fft_grid_size,auto_rmt,gamma_point,use_symmetry,&
-&so_correction,valence_rel,core_rel,iter_solver_tol,iter_solver_tol_empty,iter_solver_type,&
-&verbosity,hubbard_correction,hubbard_correction_kind,hubbard_full_orthogonalization,&
-&hubbard_orbitals,sht_coverage,min_occupancy,smearing,smearing_width,spglib_tol,electronic_structure_method,&
+&so_correction,valence_rel,core_rel,iter_solver_tol_empty,iter_solver_type,verbosity,&
+&hubbard_correction,hubbard_correction_kind,hubbard_full_orthogonalization,hubbard_orbitals,&
+&sht_coverage,min_occupancy,smearing,smearing_width,spglib_tol,electronic_structure_method,&
 &error_code)&
 &bind(C, name="sirius_set_parameters")
 use, intrinsic :: ISO_C_BINDING
@@ -577,7 +574,6 @@ type(C_PTR), value :: use_symmetry
 type(C_PTR), value :: so_correction
 type(C_PTR), value :: valence_rel
 type(C_PTR), value :: core_rel
-type(C_PTR), value :: iter_solver_tol
 type(C_PTR), value :: iter_solver_tol_empty
 type(C_PTR), value :: iter_solver_type
 type(C_PTR), value :: verbosity
@@ -664,10 +660,6 @@ allocate(core_rel_c_type(len(core_rel)+1))
 core_rel_c_type = string_f2c(core_rel)
 core_rel_ptr = C_LOC(core_rel_c_type)
 endif
-iter_solver_tol_ptr = C_NULL_PTR
-if (present(iter_solver_tol)) then
-iter_solver_tol_ptr = C_LOC(iter_solver_tol)
-endif
 iter_solver_tol_empty_ptr = C_NULL_PTR
 if (present(iter_solver_tol_empty)) then
 iter_solver_tol_empty_ptr = C_LOC(iter_solver_tol_empty)
@@ -737,10 +729,10 @@ endif
 call sirius_set_parameters_aux(handler_ptr,lmax_apw_ptr,lmax_rho_ptr,lmax_pot_ptr,&
 &num_fv_states_ptr,num_bands_ptr,num_mag_dims_ptr,pw_cutoff_ptr,gk_cutoff_ptr,fft_grid_size_ptr,&
 &auto_rmt_ptr,gamma_point_ptr,use_symmetry_ptr,so_correction_ptr,valence_rel_ptr,&
-&core_rel_ptr,iter_solver_tol_ptr,iter_solver_tol_empty_ptr,iter_solver_type_ptr,&
-&verbosity_ptr,hubbard_correction_ptr,hubbard_correction_kind_ptr,hubbard_full_orthogonalization_ptr,&
-&hubbard_orbitals_ptr,sht_coverage_ptr,min_occupancy_ptr,smearing_ptr,smearing_width_ptr,&
-&spglib_tol_ptr,electronic_structure_method_ptr,error_code_ptr)
+&core_rel_ptr,iter_solver_tol_empty_ptr,iter_solver_type_ptr,verbosity_ptr,hubbard_correction_ptr,&
+&hubbard_correction_kind_ptr,hubbard_full_orthogonalization_ptr,hubbard_orbitals_ptr,&
+&sht_coverage_ptr,min_occupancy_ptr,smearing_ptr,smearing_width_ptr,spglib_tol_ptr,&
+&electronic_structure_method_ptr,error_code_ptr)
 if (present(gamma_point)) then
 endif
 if (present(use_symmetry)) then
@@ -1689,18 +1681,22 @@ end subroutine sirius_initialize_kset
 !> @param [in] gs_handler Handler of the ground state.
 !> @param [in] density_tol Tolerance on RMS in density.
 !> @param [in] energy_tol Tolerance in total energy difference.
+!> @param [in] iter_solver_tol Initial tolerance of the iterative solver.
+!> @param [in] initial_guess Boolean variable indicating if we want to start from the initial guess or from previous state.
 !> @param [in] max_niter Maximum number of SCF iterations.
 !> @param [in] save_state Boolean variable indicating if we want to save the ground state.
 !> @param [out] converged Boolean variable indicating if the calculation has converged
 !> @param [out] niter Actual number of SCF iterations.
 !> @param [out] error_code Error code.
-subroutine sirius_find_ground_state(gs_handler,density_tol,energy_tol,max_niter,&
-&save_state,converged,niter,error_code)
+subroutine sirius_find_ground_state(gs_handler,density_tol,energy_tol,iter_solver_tol,&
+&initial_guess,max_niter,save_state,converged,niter,error_code)
 implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: gs_handler
 real(8), optional, target, intent(in) :: density_tol
 real(8), optional, target, intent(in) :: energy_tol
+real(8), optional, target, intent(in) :: iter_solver_tol
+logical, optional, target, intent(in) :: initial_guess
 integer, optional, target, intent(in) :: max_niter
 logical, optional, target, intent(in) :: save_state
 logical, optional, target, intent(out) :: converged
@@ -1710,6 +1706,9 @@ integer, optional, target, intent(out) :: error_code
 type(C_PTR) :: gs_handler_ptr
 type(C_PTR) :: density_tol_ptr
 type(C_PTR) :: energy_tol_ptr
+type(C_PTR) :: iter_solver_tol_ptr
+type(C_PTR) :: initial_guess_ptr
+logical(C_BOOL), target :: initial_guess_c_type
 type(C_PTR) :: max_niter_ptr
 type(C_PTR) :: save_state_ptr
 logical(C_BOOL), target :: save_state_c_type
@@ -1719,13 +1718,15 @@ type(C_PTR) :: niter_ptr
 type(C_PTR) :: error_code_ptr
 !
 interface
-subroutine sirius_find_ground_state_aux(gs_handler,density_tol,energy_tol,max_niter,&
-&save_state,converged,niter,error_code)&
+subroutine sirius_find_ground_state_aux(gs_handler,density_tol,energy_tol,iter_solver_tol,&
+&initial_guess,max_niter,save_state,converged,niter,error_code)&
 &bind(C, name="sirius_find_ground_state")
 use, intrinsic :: ISO_C_BINDING
 type(C_PTR), value :: gs_handler
 type(C_PTR), value :: density_tol
 type(C_PTR), value :: energy_tol
+type(C_PTR), value :: iter_solver_tol
+type(C_PTR), value :: initial_guess
 type(C_PTR), value :: max_niter
 type(C_PTR), value :: save_state
 type(C_PTR), value :: converged
@@ -1743,6 +1744,15 @@ endif
 energy_tol_ptr = C_NULL_PTR
 if (present(energy_tol)) then
 energy_tol_ptr = C_LOC(energy_tol)
+endif
+iter_solver_tol_ptr = C_NULL_PTR
+if (present(iter_solver_tol)) then
+iter_solver_tol_ptr = C_LOC(iter_solver_tol)
+endif
+initial_guess_ptr = C_NULL_PTR
+if (present(initial_guess)) then
+initial_guess_c_type = initial_guess
+initial_guess_ptr = C_LOC(initial_guess_c_type)
 endif
 max_niter_ptr = C_NULL_PTR
 if (present(max_niter)) then
@@ -1766,7 +1776,10 @@ if (present(error_code)) then
 error_code_ptr = C_LOC(error_code)
 endif
 call sirius_find_ground_state_aux(gs_handler_ptr,density_tol_ptr,energy_tol_ptr,&
-&max_niter_ptr,save_state_ptr,converged_ptr,niter_ptr,error_code_ptr)
+&iter_solver_tol_ptr,initial_guess_ptr,max_niter_ptr,save_state_ptr,converged_ptr,&
+&niter_ptr,error_code_ptr)
+if (present(initial_guess)) then
+endif
 if (present(save_state)) then
 endif
 if (present(converged)) then
@@ -5660,7 +5673,7 @@ end subroutine sirius_add_hubbard_atom_pair
 
 !
 !> @brief Interface to linear solver.
-!> @param [in] handler DFT ground staate handler.
+!> @param [in] handler DFT ground state handler.
 !> @param [in] vk K-point in lattice coordinates
 !> @param [in] vkq K+q-point in lattice coordinates
 !> @param [in] num_gvec_k_loc Local number of G-vectors for k-point

--- a/src/dft/dft_ground_state.cpp
+++ b/src/dft/dft_ground_state.cpp
@@ -178,7 +178,9 @@ DFT_ground_state::check_scf_density()
     return dict;
 }
 
-json DFT_ground_state::find(double density_tol, double energy_tol, double itsol_tol, int num_dft_iter, bool write_state)
+json
+DFT_ground_state::find(double density_tol__, double energy_tol__, double iter_solver_tol__, int num_dft_iter__,
+                       bool write_state__)
 {
     PROFILE("sirius::DFT_ground_state::scf_loop");
 
@@ -195,19 +197,19 @@ json DFT_ground_state::find(double density_tol, double energy_tol, double itsol_
     Density rho1(ctx_);
 
     std::stringstream s;
-    s << "density_tol            : " << density_tol << std::endl
-      << "energy_tol             : " << energy_tol << std::endl
-      << "itsol_tol (initial)    : " << itsol_tol << std::endl
-      << "itsol_tol_min          : " << ctx_.cfg().settings().itsol_tol_min() << std::endl
-      << "num_dft_iter           : " << num_dft_iter;
+    s << "density_tol               : " << density_tol__ << std::endl
+      << "energy_tol                : " << energy_tol__ << std::endl
+      << "iter_solver_tol (initial) : " << iter_solver_tol__ << std::endl
+      << "iter_solver_tol (target)  : " << ctx_.cfg().settings().itsol_tol_min() << std::endl
+      << "num_dft_iter              : " << num_dft_iter__;
     ctx_.message(1, __func__, s);
 
-    for (int iter = 0; iter < num_dft_iter; iter++) {
+    for (int iter = 0; iter < num_dft_iter__; iter++) {
         PROFILE("sirius::DFT_ground_state::scf_loop|iteration");
         std::stringstream s;
         s << std::endl;
         s << "+------------------------------+" << std::endl
-          << "| SCF iteration " << std::setw(3) << iter << " out of " << std::setw(3) << num_dft_iter << '|' << std::endl
+          << "| SCF iteration " << std::setw(3) << iter << " out of " << std::setw(3) << num_dft_iter__ << '|' << std::endl
           << "+------------------------------+" << std::endl;
         ctx_.message(2, __func__, s);
 
@@ -216,9 +218,9 @@ json DFT_ground_state::find(double density_tol, double energy_tol, double itsol_
             Hamiltonian0<float> H0(potential_, true);
             /* find new wave-functions */
             if (ctx_.cfg().parameters().precision_hs() == "fp32") {
-                Band(ctx_).solve<float, float>(kset_, H0, itsol_tol);
+                Band(ctx_).solve<float, float>(kset_, H0, iter_solver_tol__);
             } else {
-                Band(ctx_).solve<float, double>(kset_, H0, itsol_tol);
+                Band(ctx_).solve<float, double>(kset_, H0, iter_solver_tol__);
             }
             /* find band occupancies */
             kset_.find_band_occupancies<float>();
@@ -230,7 +232,7 @@ json DFT_ground_state::find(double density_tol, double energy_tol, double itsol_
         } else {
             Hamiltonian0<double> H0(potential_, true);
             /* find new wave-functions */
-            Band(ctx_).solve<double, double>(kset_, H0, itsol_tol);
+            Band(ctx_).solve<double, double>(kset_, H0, iter_solver_tol__);
             /* find band occupancies */
             kset_.find_band_occupancies<double>();
             /* generate new density from the occupied wave-functions */
@@ -252,9 +254,9 @@ json DFT_ground_state::find(double density_tol, double energy_tol, double itsol_
             tol = eha_res / std::max(1.0, unit_cell_.num_electrons());
         }
         tol = std::min(ctx_.cfg().settings().itsol_tol_scale()[0] * tol,
-                       ctx_.cfg().settings().itsol_tol_scale()[1] * itsol_tol);
+                       ctx_.cfg().settings().itsol_tol_scale()[1] * iter_solver_tol__);
         /* tolerance can't be too small */
-        itsol_tol = std::max(ctx_.cfg().settings().itsol_tol_min(), tol);
+        iter_solver_tol__ = std::max(ctx_.cfg().settings().itsol_tol_min(), tol);
 
 #if defined(USE_FP32)
         if (ctx_.cfg().parameters().precision_gs() != "auto") {
@@ -325,11 +327,11 @@ json DFT_ground_state::find(double density_tol, double energy_tol, double itsol_
         ctx_.message(2, __func__, out);
         /* check if the calculation has converged */
         bool converged{true};
-        converged = converged && (std::abs(eold - etot) < energy_tol);
+        converged = converged && (std::abs(eold - etot) < energy_tol__);
         if (ctx_.cfg().mixer().use_hartree()) {
-            converged = converged && (eha_res < density_tol);
+            converged = converged && (eha_res < density_tol__);
         } else {
-            converged = converged && (rms < density_tol);
+            converged = converged && (rms < density_tol__);
         }
         if (converged) {
             std::stringstream out;
@@ -348,7 +350,7 @@ json DFT_ground_state::find(double density_tol, double energy_tol, double itsol_
     print_info(out);
     ctx_.message(1, __func__, out);
 
-    if (write_state) {
+    if (write_state__) {
         ctx_.create_storage_file();
         if (ctx_.full_potential()) { // TODO: why this is necessary?
             density_.rho().fft_transform(-1);


### PR DESCRIPTION
Allow to start ground state SCF calculation from the previous solution, without making initial guess for wave functions, density and potential. 