### PR TITLE
Cleanup unused variables / Warnings

### DIFF
--- a/src/SDDK/gvec.hpp
+++ b/src/SDDK/gvec.hpp
@@ -128,7 +128,7 @@ class Gvec
     matrix3d<double> lattice_vectors_;
 
     /// Total communicator which is used to distribute G or G+k vectors.
-    Communicator const& comm_;
+    Communicator comm_;
 
     /// Indicates that G-vectors are reduced by inversion symmetry.
     bool reduce_gvec_{false};

--- a/src/SDDK/wf_ortho.cpp
+++ b/src/SDDK/wf_ortho.cpp
@@ -309,6 +309,10 @@ orthogonalize(::spla::Context& spla_ctx__, memory_t mem__, linalg_t la__, spin_r
             RTE_OUT(std::cout) << "orthogonalization error : " << err << std::endl;
         }
     }
+
+    // TODO: remove this?
+    (void) gflops;
+
     return 0;
 }
 

--- a/src/linalg/blacs_grid.hpp
+++ b/src/linalg/blacs_grid.hpp
@@ -39,7 +39,10 @@ class BLACS_grid
 
     std::unique_ptr<MPI_grid> mpi_grid_;
 
+
+#ifdef SIRIUS_SCALAPACK
     int blacs_handler_{-1};
+#endif
 
     int blacs_context_{-1};
 

--- a/src/mixer/mixer.hpp
+++ b/src/mixer/mixer.hpp
@@ -31,7 +31,7 @@
 #include <vector>
 #include <limits>
 #include <memory>
-#include <exception>
+#include <stdexcept>
 #include <cmath>
 #include <numeric>
 

--- a/src/mixer/mixer_functions.cpp
+++ b/src/mixer/mixer_functions.cpp
@@ -360,18 +360,11 @@ FunctionProperties<paw_density> paw_density_function_property()
     {
         for (int i = 0; i < x.ctx().unit_cell().spl_num_paw_atoms().local_size(); i++) {
             for (int j = 0; j < x.ctx().num_mag_dims() + 1; j++) {
-                {
-                    auto tmp1 = x.ae_density(j, i) * c + y.ae_density(j, i) * s;
-                    auto tmp2 = x.ae_density(j, i) * -s + y.ae_density(j, i) * c;
-                    x.ae_density(j, i) = std::move(tmp1);
-                    y.ae_density(j, i) = std::move(tmp2);
-                }
-                {
-                    auto tmp1 = x.ps_density(j, i) * c + y.ps_density(j, i) * s;
-                    auto tmp2 = x.ps_density(j, i) * -s + y.ps_density(j, i) * c;
-                    x.ps_density(j, i) = std::move(tmp1);
-                    y.ps_density(j, i) = std::move(tmp2);
-                }
+                x.ae_density(j, i) = x.ae_density(j, i) * c + y.ae_density(j, i) * s;
+                y.ae_density(j, i) = x.ae_density(j, i) * -s + y.ae_density(j, i) * c;
+
+                x.ps_density(j, i) = x.ps_density(j, i) * c + y.ps_density(j, i) * s;
+                y.ps_density(j, i) = x.ps_density(j, i) * -s + y.ps_density(j, i) * c;
             }
         }
     };

--- a/src/specfunc/sbessel.cpp
+++ b/src/specfunc/sbessel.cpp
@@ -45,8 +45,7 @@ static void custom_bessel(int lmax, double x, double* result) {
 Spherical_Bessel_functions::Spherical_Bessel_functions(int lmax__,
                                                        Radial_grid<double> const& rgrid__,
                                                        double q__)
-    : lmax_(lmax__)
-    , q_(q__)
+    : q_(q__)
     , rgrid_(&rgrid__)
 {
     assert(q_ >= 0);

--- a/src/specfunc/sbessel.cpp
+++ b/src/specfunc/sbessel.cpp
@@ -98,14 +98,12 @@ Spherical_Bessel_functions::sbessel_deriv_q(int lmax__, double q__, double x__, 
 Spline<double> const&
 Spherical_Bessel_functions::operator[](int l__) const
 {
-    assert(l__ <= lmax_);
     return sbessel_[l__];
 }
 
 Spline<double>
 Spherical_Bessel_functions::deriv_q(int l__)
 {
-    assert(l__ <= lmax_);
     assert(q_ >= 0);
     Spline<double> s(*rgrid_);
     if (q_ != 0) {

--- a/src/specfunc/sbessel.hpp
+++ b/src/specfunc/sbessel.hpp
@@ -35,8 +35,6 @@ namespace sirius {
 class Spherical_Bessel_functions
 {
   private:
-    int lmax_{-1};
-
     double q_{0};
 
     Radial_grid<double> const* rgrid_{nullptr};


### PR DESCRIPTION
Fix warnings, unused variables. Remove unnecessary temporary variables followed by std::move.
Replace `const Communicator&` -> `Communicator` in `Gvec` class.