### PR TITLE
Change API to be able to pass array(:,:,:) kind of objects

### DIFF
--- a/src/api/generate_api.py
+++ b/src/api/generate_api.py
@@ -55,7 +55,7 @@ class ArgumentAttribute:
             idx1 = attr_str.find('(', idx)
             idx2 = attr_str.find(')', idx1)
             if idx1 != -1 and idx2 != -1 and idx2 > idx1:
-                self.dimension_ = attr_str[idx:idx2+1]
+                self.dimension_ = attr_str[idx1:idx2+1]
                 attr_str = attr_str[:idx] + attr_str[idx2+1:]
             else:
                 raise Exception(f'wrong attribute string: {attr_str}')
@@ -138,10 +138,13 @@ class Argument:
             out.write(', value')
         else:
             out.write(', target')
-        if self.attr().dimension() != 'scalar':
-            out.write(f', {self.attr().dimension()}')
+        #if self.attr().dimension() != 'scalar':
+        #    out.write(f', {self.attr().dimension()}')
 
-        out.write(f', intent({self.attr().intent()}) :: {self.name()}\n')
+        out.write(f', intent({self.attr().intent()}) :: {self.name()}')
+        if self.attr().dimension() != 'scalar':
+            out.write(f'{self.attr().dimension()}')
+        out.write('\n')
 
     def write_interface_api_arg(self, out):
         if self.type_id() == 'func':

--- a/src/api/sirius.f90
+++ b/src/api/sirius.f90
@@ -485,7 +485,7 @@ integer, optional, target, intent(in) :: num_bands
 integer, optional, target, intent(in) :: num_mag_dims
 real(8), optional, target, intent(in) :: pw_cutoff
 real(8), optional, target, intent(in) :: gk_cutoff
-integer, optional, target, dimension(3), intent(in) :: fft_grid_size
+integer, optional, target, intent(in) :: fft_grid_size(3)
 integer, optional, target, intent(in) :: auto_rmt
 logical, optional, target, intent(in) :: gamma_point
 logical, optional, target, intent(in) :: use_symmetry
@@ -805,7 +805,7 @@ integer, optional, target, intent(out) :: num_spins
 integer, optional, target, intent(out) :: num_mag_dims
 real(8), optional, target, intent(out) :: pw_cutoff
 real(8), optional, target, intent(out) :: gk_cutoff
-integer, optional, target, dimension(3), intent(out) :: fft_grid_size
+integer, optional, target, intent(out) :: fft_grid_size(3)
 integer, optional, target, intent(out) :: auto_rmt
 logical, optional, target, intent(out) :: gamma_point
 logical, optional, target, intent(out) :: use_symmetry
@@ -1055,7 +1055,7 @@ implicit none
 !
 type(sirius_context_handler), target, intent(in) :: handler
 integer, target, intent(in) :: ndims
-integer, target, dimension(ndims), intent(in) :: dims
+integer, target, intent(in) :: dims(ndims)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -1098,9 +1098,9 @@ subroutine sirius_set_lattice_vectors(handler,a1,a2,a3,error_code)
 implicit none
 !
 type(sirius_context_handler), target, intent(in) :: handler
-real(8), target, dimension(3), intent(in) :: a1
-real(8), target, dimension(3), intent(in) :: a2
-real(8), target, dimension(3), intent(in) :: a3
+real(8), target, intent(in) :: a1(3)
+real(8), target, intent(in) :: a2(3)
+real(8), target, intent(in) :: a3(3)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -1274,8 +1274,8 @@ implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
-real(8), optional, target, intent(in) :: f_mt
-real(8), optional, target, intent(in) :: f_rg
+real(8), optional, target, intent(in) :: f_mt(:,:,:)
+real(8), optional, target, intent(in) :: f_rg(:)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -1332,7 +1332,7 @@ implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
-real(8), optional, target, dimension(*), intent(in) :: f_rg
+real(8), optional, target, intent(in) :: f_rg(:)
 logical, optional, target, intent(in) :: f_rg_global
 integer, optional, target, intent(out) :: error_code
 !
@@ -1399,11 +1399,11 @@ implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
-real(8), optional, target, intent(out) :: f_mt
+real(8), optional, target, intent(out) :: f_mt(:,:,:)
 integer, optional, target, intent(in) :: lmmax
 integer, optional, target, intent(in) :: max_num_mt_points
 integer, optional, target, intent(in) :: num_atoms
-real(8), optional, target, dimension(*), intent(out) :: f_rg
+real(8), optional, target, intent(out) :: f_rg(:)
 integer, optional, target, intent(in) :: num_rg_points
 integer, optional, target, intent(out) :: error_code
 !
@@ -1489,8 +1489,8 @@ implicit none
 !
 type(sirius_context_handler), target, intent(in) :: handler
 integer, target, intent(in) :: num_kpoints
-real(8), target, dimension(3,num_kpoints), intent(in) :: kpoints
-real(8), target, dimension(num_kpoints), intent(in) :: kpoint_weights
+real(8), target, intent(in) :: kpoints(3,num_kpoints)
+real(8), target, intent(in) :: kpoint_weights(num_kpoints)
 logical, target, intent(in) :: init_kset
 type(sirius_kpoint_set_handler), target, intent(out) :: kset_handler
 integer, optional, target, intent(out) :: error_code
@@ -1553,8 +1553,8 @@ subroutine sirius_create_kset_from_grid(handler,k_grid,k_shift,use_symmetry,kset
 implicit none
 !
 type(sirius_context_handler), target, intent(in) :: handler
-integer, target, dimension(3), intent(in) :: k_grid
-integer, target, dimension(3), intent(in) :: k_shift
+integer, target, intent(in) :: k_grid(3)
+integer, target, intent(in) :: k_shift(3)
 logical, target, intent(in) :: use_symmetry
 type(sirius_kpoint_set_handler), target, intent(out) :: kset_handler
 integer, optional, target, intent(out) :: error_code
@@ -1646,7 +1646,7 @@ subroutine sirius_initialize_kset(ks_handler,count,error_code)
 implicit none
 !
 type(sirius_kpoint_set_handler), target, intent(in) :: ks_handler
-integer, optional, target, dimension(*), intent(in) :: count
+integer, optional, target, intent(in) :: count(*)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: ks_handler_ptr
@@ -2060,7 +2060,7 @@ implicit none
 type(sirius_context_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
 integer, target, intent(in) :: num_radial_points
-real(8), target, dimension(num_radial_points), intent(in) :: radial_points
+real(8), target, intent(in) :: radial_points(num_radial_points)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -2116,7 +2116,7 @@ implicit none
 type(sirius_context_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
 integer, target, intent(in) :: num_radial_points
-real(8), target, dimension(num_radial_points), intent(in) :: radial_points
+real(8), target, intent(in) :: radial_points(num_radial_points)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -2178,7 +2178,7 @@ implicit none
 type(sirius_context_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: atom_type
 character(*), target, intent(in) :: label
-real(8), target, dimension(num_points), intent(in) :: rf
+real(8), target, intent(in) :: rf(num_points)
 integer, target, intent(in) :: num_points
 integer, optional, target, intent(in) :: n
 integer, optional, target, intent(in) :: l
@@ -2369,7 +2369,7 @@ implicit none
 type(sirius_context_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
 integer, target, intent(in) :: num_beta
-real(8), target, dimension(num_beta, num_beta), intent(in) :: dion
+real(8), target, intent(in) :: dion(num_beta, num_beta)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -2424,7 +2424,7 @@ implicit none
 type(sirius_context_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
 real(8), target, intent(in) :: core_energy
-real(8), target, dimension(num_occ), intent(in) :: occupations
+real(8), target, intent(in) :: occupations(num_occ)
 integer, target, intent(in) :: num_occ
 integer, optional, target, intent(out) :: error_code
 !
@@ -2483,8 +2483,8 @@ implicit none
 !
 type(sirius_context_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
-real(8), target, dimension(3), intent(in) :: position
-real(8), optional, target, dimension(3), intent(in) :: vector_field
+real(8), target, intent(in) :: position(3)
+real(8), optional, target, intent(in) :: vector_field(3)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -2537,7 +2537,7 @@ implicit none
 !
 type(sirius_context_handler), target, intent(in) :: handler
 integer, target, intent(in) :: ia
-real(8), target, dimension(3), intent(in) :: position
+real(8), target, intent(in) :: position(3)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -2585,10 +2585,10 @@ implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
-complex(8), target, dimension(*), intent(in) :: pw_coeffs
+complex(8), target, intent(in) :: pw_coeffs(*)
 logical, optional, target, intent(in) :: transform_to_rg
 integer, optional, target, intent(in) :: ngv
-integer, optional, target, dimension(3, *), intent(in) :: gvl
+integer, optional, target, intent(in) :: gvl(3, *)
 integer, optional, target, intent(in) :: comm
 integer, optional, target, intent(out) :: error_code
 !
@@ -2669,9 +2669,9 @@ implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
-complex(8), target, dimension(*), intent(in) :: pw_coeffs
+complex(8), target, intent(in) :: pw_coeffs(*)
 integer, optional, target, intent(in) :: ngv
-integer, optional, target, dimension(3, *), intent(in) :: gvl
+integer, optional, target, intent(in) :: gvl(3, *)
 integer, optional, target, intent(in) :: comm
 integer, optional, target, intent(out) :: error_code
 !
@@ -2979,7 +2979,7 @@ implicit none
 type(sirius_kpoint_set_handler), target, intent(in) :: ks_handler
 integer, target, intent(in) :: ik
 integer, target, intent(in) :: ispn
-real(8), target, dimension(*), intent(in) :: band_occupancies
+real(8), target, intent(in) :: band_occupancies(*)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: ks_handler_ptr
@@ -3029,7 +3029,7 @@ implicit none
 type(sirius_kpoint_set_handler), target, intent(in) :: ks_handler
 integer, target, intent(in) :: ik
 integer, target, intent(in) :: ispn
-real(8), target, dimension(*), intent(out) :: band_occupancies
+real(8), target, intent(out) :: band_occupancies(:)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: ks_handler_ptr
@@ -3079,7 +3079,7 @@ implicit none
 type(sirius_kpoint_set_handler), target, intent(in) :: ks_handler
 integer, target, intent(in) :: ik
 integer, target, intent(in) :: ispn
-real(8), target, dimension(*), intent(out) :: band_energies
+real(8), target, intent(out) :: band_energies(:)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: ks_handler_ptr
@@ -3174,7 +3174,7 @@ implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
-real(8), target, dimension(3, *), intent(out) :: forces
+real(8), target, intent(out) :: forces(3, *)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -3221,7 +3221,7 @@ implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
-real(8), target, dimension(3, 3), intent(out) :: stress_tensor
+real(8), target, intent(out) :: stress_tensor(3, 3)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -3320,10 +3320,10 @@ subroutine sirius_get_wave_functions(ks_handler,vkl,spin,num_gvec_loc,gvec_loc,e
 implicit none
 !
 type(sirius_kpoint_set_handler), target, intent(in) :: ks_handler
-real(8), optional, target, dimension(3), intent(in) :: vkl
+real(8), optional, target, intent(in) :: vkl(3)
 integer, optional, target, intent(in) :: spin
 integer, optional, target, intent(in) :: num_gvec_loc
-integer, optional, target, dimension(3, *), intent(in) :: gvec_loc
+integer, optional, target, intent(in) :: gvec_loc(3, *)
 complex(8), optional, target, intent(out) :: evec
 integer, optional, target, intent(in) :: ld
 integer, optional, target, intent(in) :: num_spin_comp
@@ -3637,7 +3637,7 @@ subroutine sirius_generate_coulomb_potential(handler,vh_el,error_code)
 implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
-real(8), optional, target, dimension(*), intent(out) :: vh_el
+real(8), optional, target, intent(out) :: vh_el(*)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -3859,9 +3859,9 @@ subroutine sirius_get_gvec_arrays(handler,gvec,gvec_cart,gvec_len,index_by_gvec,
 implicit none
 !
 type(sirius_context_handler), target, intent(in) :: handler
-integer, optional, target, dimension(3, *), intent(in) :: gvec
-real(8), optional, target, dimension(3, *), intent(in) :: gvec_cart
-real(8), optional, target, dimension(*), intent(in) :: gvec_len
+integer, optional, target, intent(in) :: gvec(3, *)
+real(8), optional, target, intent(in) :: gvec_cart(3, *)
+real(8), optional, target, intent(in) :: gvec_len(*)
 integer, optional, target, intent(in) :: index_by_gvec
 integer, optional, target, intent(out) :: error_code
 !
@@ -4041,11 +4041,11 @@ implicit none
 type(sirius_kpoint_set_handler), target, intent(in) :: ks_handler
 integer, target, intent(in) :: ik
 integer, target, intent(out) :: num_gkvec
-integer, target, dimension(*), intent(out) :: gvec_index
-real(8), target, dimension(3, *), intent(out) :: gkvec
-real(8), target, dimension(3, *), intent(out) :: gkvec_cart
-real(8), target, dimension(*), intent(out) :: gkvec_len
-real(8), target, dimension(2, *), intent(out) :: gkvec_tp
+integer, target, intent(out) :: gvec_index(*)
+real(8), target, intent(out) :: gkvec(3, *)
+real(8), target, intent(out) :: gkvec_cart(3, *)
+real(8), target, intent(out) :: gkvec_len(*)
+real(8), target, intent(out) :: gkvec_tp(2, *)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: ks_handler_ptr
@@ -4110,8 +4110,8 @@ subroutine sirius_get_step_function(handler,cfunig,cfunrg,num_rg_points,error_co
 implicit none
 !
 type(sirius_context_handler), target, intent(in) :: handler
-complex(8), target, dimension(*), intent(out) :: cfunig
-real(8), target, dimension(*), intent(out) :: cfunrg
+complex(8), target, intent(out) :: cfunig(*)
+real(8), target, intent(out) :: cfunrg(*)
 integer, target, intent(in) :: num_rg_points
 integer, optional, target, intent(out) :: error_code
 !
@@ -4507,7 +4507,7 @@ subroutine sirius_set_equivalent_atoms(handler,equivalent_atoms,error_code)
 implicit none
 !
 type(sirius_context_handler), target, intent(in) :: handler
-integer, target, dimension(*), intent(in) :: equivalent_atoms
+integer, target, intent(in) :: equivalent_atoms(*)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -5044,7 +5044,7 @@ implicit none
 !
 type(sirius_kpoint_set_handler), target, intent(in) :: handler
 integer, target, intent(in) :: ik
-real(8), target, intent(out) :: fv_eval
+real(8), target, intent(out) :: fv_eval(:)
 integer, target, intent(in) :: num_fv_states
 integer, optional, target, intent(out) :: error_code
 !
@@ -5621,10 +5621,10 @@ subroutine sirius_add_hubbard_atom_pair(handler,atom_pair,translation,n,l,coupli
 implicit none
 !
 type(sirius_context_handler), target, intent(in) :: handler
-integer, target, dimension(2), intent(in) :: atom_pair
-integer, target, dimension(3), intent(in) :: translation
-integer, target, dimension(2), intent(in) :: n
-integer, target, dimension(2), intent(in) :: l
+integer, target, intent(in) :: atom_pair(2)
+integer, target, intent(in) :: translation(3)
+integer, target, intent(in) :: n(2)
+integer, target, intent(in) :: l(2)
 real(8), target, intent(in) :: coupling
 integer, optional, target, intent(out) :: error_code
 !
@@ -5690,13 +5690,13 @@ subroutine sirius_linear_solver(handler,vkq,num_gvec_kq_loc,gvec_kq_loc,dpsi,psi
 implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
-real(8), target, dimension(3), intent(in) :: vkq
+real(8), target, intent(in) :: vkq(3)
 integer, target, intent(in) :: num_gvec_kq_loc
-integer, target, dimension(3, num_gvec_kq_loc), intent(in) :: gvec_kq_loc
-complex(8), target, dimension(ld, num_spin_comp), intent(inout) :: dpsi
-complex(8), target, dimension(ld, num_spin_comp), intent(in) :: psi
-real(8), target, dimension(*), intent(in) :: eigvals
-complex(8), target, dimension(ld, num_spin_comp), intent(inout) :: dvpsi
+integer, target, intent(in) :: gvec_kq_loc(3, num_gvec_kq_loc)
+complex(8), target, intent(inout) :: dpsi(ld, num_spin_comp)
+complex(8), target, intent(in) :: psi(ld, num_spin_comp)
+real(8), target, intent(in) :: eigvals(*)
+complex(8), target, intent(inout) :: dvpsi(ld, num_spin_comp)
 integer, target, intent(in) :: ld
 integer, target, intent(in) :: num_spin_comp
 real(8), target, intent(in) :: alpha_pv

--- a/src/api/sirius.f90
+++ b/src/api/sirius.f90
@@ -1646,7 +1646,7 @@ subroutine sirius_initialize_kset(ks_handler,count,error_code)
 implicit none
 !
 type(sirius_kpoint_set_handler), target, intent(in) :: ks_handler
-integer, optional, target, intent(in) :: count(*)
+integer, optional, target, intent(in) :: count(:)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: ks_handler_ptr
@@ -2585,10 +2585,10 @@ implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
-complex(8), target, intent(in) :: pw_coeffs(*)
+complex(8), target, intent(in) :: pw_coeffs(:)
 logical, optional, target, intent(in) :: transform_to_rg
 integer, optional, target, intent(in) :: ngv
-integer, optional, target, intent(in) :: gvl(3, *)
+integer, optional, target, intent(in) :: gvl(:,:)
 integer, optional, target, intent(in) :: comm
 integer, optional, target, intent(out) :: error_code
 !
@@ -2669,9 +2669,9 @@ implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
-complex(8), target, intent(in) :: pw_coeffs(*)
+complex(8), target, intent(in) :: pw_coeffs(:)
 integer, optional, target, intent(in) :: ngv
-integer, optional, target, intent(in) :: gvl(3, *)
+integer, optional, target, intent(in) :: gvl(:,:)
 integer, optional, target, intent(in) :: comm
 integer, optional, target, intent(out) :: error_code
 !
@@ -2979,7 +2979,7 @@ implicit none
 type(sirius_kpoint_set_handler), target, intent(in) :: ks_handler
 integer, target, intent(in) :: ik
 integer, target, intent(in) :: ispn
-real(8), target, intent(in) :: band_occupancies(*)
+real(8), target, intent(in) :: band_occupancies(:)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: ks_handler_ptr
@@ -3174,7 +3174,7 @@ implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
-real(8), target, intent(out) :: forces(3, *)
+real(8), target, intent(out) :: forces(:,:)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -3323,7 +3323,7 @@ type(sirius_kpoint_set_handler), target, intent(in) :: ks_handler
 real(8), optional, target, intent(in) :: vkl(3)
 integer, optional, target, intent(in) :: spin
 integer, optional, target, intent(in) :: num_gvec_loc
-integer, optional, target, intent(in) :: gvec_loc(3, *)
+integer, optional, target, intent(in) :: gvec_loc(:,:)
 complex(8), optional, target, intent(out) :: evec
 integer, optional, target, intent(in) :: ld
 integer, optional, target, intent(in) :: num_spin_comp
@@ -3637,7 +3637,7 @@ subroutine sirius_generate_coulomb_potential(handler,vh_el,error_code)
 implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
-real(8), optional, target, intent(out) :: vh_el(*)
+real(8), optional, target, intent(out) :: vh_el(:)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -3859,9 +3859,9 @@ subroutine sirius_get_gvec_arrays(handler,gvec,gvec_cart,gvec_len,index_by_gvec,
 implicit none
 !
 type(sirius_context_handler), target, intent(in) :: handler
-integer, optional, target, intent(in) :: gvec(3, *)
-real(8), optional, target, intent(in) :: gvec_cart(3, *)
-real(8), optional, target, intent(in) :: gvec_len(*)
+integer, optional, target, intent(in) :: gvec(:,:)
+real(8), optional, target, intent(in) :: gvec_cart(:,:)
+real(8), optional, target, intent(in) :: gvec_len(:)
 integer, optional, target, intent(in) :: index_by_gvec
 integer, optional, target, intent(out) :: error_code
 !
@@ -4041,11 +4041,11 @@ implicit none
 type(sirius_kpoint_set_handler), target, intent(in) :: ks_handler
 integer, target, intent(in) :: ik
 integer, target, intent(out) :: num_gkvec
-integer, target, intent(out) :: gvec_index(*)
-real(8), target, intent(out) :: gkvec(3, *)
-real(8), target, intent(out) :: gkvec_cart(3, *)
-real(8), target, intent(out) :: gkvec_len(*)
-real(8), target, intent(out) :: gkvec_tp(2, *)
+integer, target, intent(out) :: gvec_index(:)
+real(8), target, intent(out) :: gkvec(:,:)
+real(8), target, intent(out) :: gkvec_cart(:,:)
+real(8), target, intent(out) :: gkvec_len(:)
+real(8), target, intent(out) :: gkvec_tp(:,:)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: ks_handler_ptr
@@ -4110,8 +4110,8 @@ subroutine sirius_get_step_function(handler,cfunig,cfunrg,num_rg_points,error_co
 implicit none
 !
 type(sirius_context_handler), target, intent(in) :: handler
-complex(8), target, intent(out) :: cfunig(*)
-real(8), target, intent(out) :: cfunrg(*)
+complex(8), target, intent(out) :: cfunig(:)
+real(8), target, intent(out) :: cfunrg(:)
 integer, target, intent(in) :: num_rg_points
 integer, optional, target, intent(out) :: error_code
 !
@@ -4440,7 +4440,7 @@ implicit none
 type(sirius_context_handler), target, intent(in) :: handler
 integer, target, intent(in) :: ia
 integer, target, intent(in) :: deriv_order
-real(8), target, intent(in) :: f
+real(8), target, intent(in) :: f(:)
 integer, optional, target, intent(in) :: l
 integer, optional, target, intent(in) :: o
 integer, optional, target, intent(in) :: ilo
@@ -4507,7 +4507,7 @@ subroutine sirius_set_equivalent_atoms(handler,equivalent_atoms,error_code)
 implicit none
 !
 type(sirius_context_handler), target, intent(in) :: handler
-integer, target, intent(in) :: equivalent_atoms(*)
+integer, target, intent(in) :: equivalent_atoms(:)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -4989,7 +4989,7 @@ implicit none
 !
 type(sirius_kpoint_set_handler), target, intent(in) :: handler
 integer, target, intent(in) :: ik
-complex(8), target, intent(out) :: fv_evec
+complex(8), target, intent(out) :: fv_evec(:,:)
 integer, target, intent(in) :: ld
 integer, target, intent(in) :: num_fv_states
 integer, optional, target, intent(out) :: error_code
@@ -5094,7 +5094,7 @@ implicit none
 !
 type(sirius_kpoint_set_handler), target, intent(in) :: handler
 integer, target, intent(in) :: ik
-complex(8), target, intent(out) :: sv_evec
+complex(8), target, intent(out) :: sv_evec(:,:)
 integer, target, intent(in) :: num_bands
 integer, optional, target, intent(out) :: error_code
 !
@@ -5149,9 +5149,9 @@ implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
-integer, target, intent(in) :: grid_dims
-integer, target, intent(in) :: local_box_origin
-integer, target, intent(in) :: local_box_size
+integer, target, intent(in) :: grid_dims(3)
+integer, target, intent(in) :: local_box_origin(:,:)
+integer, target, intent(in) :: local_box_size(:,:)
 integer, target, intent(in) :: fcomm
 real(8), target, intent(in) :: values
 logical, optional, target, intent(in) :: transform_to_pw
@@ -5235,9 +5235,9 @@ implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
 character(*), target, intent(in) :: label
-integer, target, intent(in) :: grid_dims
-integer, target, intent(in) :: local_box_origin
-integer, target, intent(in) :: local_box_size
+integer, target, intent(in) :: grid_dims(3)
+integer, target, intent(in) :: local_box_origin(:,:)
+integer, target, intent(in) :: local_box_size(:,:)
 integer, target, intent(in) :: fcomm
 real(8), target, intent(out) :: values
 logical, optional, target, intent(in) :: transform_to_rg

--- a/src/api/sirius.f90
+++ b/src/api/sirius.f90
@@ -3862,7 +3862,7 @@ type(sirius_context_handler), target, intent(in) :: handler
 integer, optional, target, intent(in) :: gvec(:,:)
 real(8), optional, target, intent(in) :: gvec_cart(:,:)
 real(8), optional, target, intent(in) :: gvec_len(:)
-integer, optional, target, intent(in) :: index_by_gvec
+integer, optional, target, intent(in) :: index_by_gvec(:,:,:)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
@@ -3958,7 +3958,7 @@ subroutine sirius_get_fft_index(handler,fft_index,error_code)
 implicit none
 !
 type(sirius_context_handler), target, intent(in) :: handler
-integer, target, intent(out) :: fft_index
+integer, target, intent(out) :: fft_index(:)
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr

--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -1280,11 +1280,11 @@ sirius_set_periodic_function_ptr:
       doc: Label of the function.
     f_mt:
       type: double
-      attr: in, optional
+      attr: in, optional, dimension(:,:,:)
       doc: Pointer to the muffin-tin part of the function.
     f_rg:
       type: double
-      attr: in, optional
+      attr: in, optional, dimension(:)
       doc: Pointer to the regualr-grid part of the function.
     error_code:
       type: int
@@ -1339,7 +1339,7 @@ sirius_set_periodic_function:
       doc: Label of the function.
     f_rg:
       type: double
-      attr: in, optional, dimension(*)
+      attr: in, optional, dimension(:)
       doc: Real space values on the regular grid.
     f_rg_global:
       type: bool
@@ -1394,7 +1394,7 @@ sirius_get_periodic_function:
       doc: Label of the function.
     f_mt:
       type: double
-      attr: out, optional
+      attr: out, optional, dimension(:,:,:)
       doc: Muffin-tin part of the function.
     lmmax:
       type: int
@@ -1410,7 +1410,7 @@ sirius_get_periodic_function:
       doc: Number of atoms
     f_rg:
       type: double
-      attr: out, optional, dimension(*)
+      attr: out, optional, dimension(:)
       doc: Real space values on the regular grid.
     num_rg_points:
       type: int
@@ -2924,7 +2924,7 @@ sirius_get_band_occupancies:
       doc: Spin component.
     band_occupancies:
       type: double
-      attr: out, required, dimension(*)
+      attr: out, required, dimension(:)
       doc: Array of band occupancies.
     error_code:
       type: int
@@ -2966,7 +2966,7 @@ sirius_get_band_energies:
       doc: Spin component.
     band_energies:
       type: double
-      attr: out, required, dimension(*)
+      attr: out, required, dimension(:)
       doc: Array of band energies.
     error_code:
       type: int
@@ -4968,7 +4968,7 @@ sirius_get_fv_eigen_values:
       doc: Global index of the k-point
     fv_eval:
       type: double
-      attr: out, required
+      attr: out, required, dimension(:)
       doc: Output first-variational eigenvector array
     num_fv_states:
       type: int

--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -1638,7 +1638,7 @@ sirius_initialize_kset:
       doc: K-point set handler.
     count:
       type: int
-      attr: in, optional, dimension(*)
+      attr: in, optional, dimension(:)
       doc: Local number of k-points for each MPI rank.
     error_code:
       type: int
@@ -2456,7 +2456,7 @@ sirius_set_pw_coeffs:
       doc: Label of the function.
     pw_coeffs:
       type: complex
-      attr: in, required, dimension(*)
+      attr: in, required, dimension(:)
       doc: Local array of plane-wave coefficients.
     transform_to_rg:
       type: bool
@@ -2468,7 +2468,7 @@ sirius_set_pw_coeffs:
       doc: Local number of G-vectors.
     gvl:
       type: int
-      attr: in, optional, dimension(3, *)
+      attr: in, optional, dimension(:,:)
       doc: List of G-vectors in lattice coordinates (Miller indices).
     comm:
       type: int
@@ -2583,7 +2583,7 @@ sirius_get_pw_coeffs:
       doc: Label of the function.
     pw_coeffs:
       type: complex
-      attr: in, required, dimension(*)
+      attr: in, required, dimension(:)
       doc: Local array of plane-wave coefficients.
     ngv:
       type: int
@@ -2591,7 +2591,7 @@ sirius_get_pw_coeffs:
       doc: Local number of G-vectors.
     gvl:
       type: int
-      attr: in, optional, dimension(3, *)
+      attr: in, optional, dimension(:,:)
       doc: List of G-vectors in lattice coordinates (Miller indices).
     comm:
       type: int
@@ -2882,7 +2882,7 @@ sirius_set_band_occupancies:
       doc: Spin component index.
     band_occupancies:
       type: double
-      attr: in, required, dimension(*)
+      attr: in, required, dimension(:)
       doc: Array of band occupancies.
     error_code:
       type: int
@@ -3070,7 +3070,7 @@ sirius_get_forces:
       doc: Label of the force component to get.
     forces:
       type: double
-      attr: out, required, dimension(3, *)
+      attr: out, required, dimension(:,:)
       doc: Total force component for each atom.
     error_code:
       type: int
@@ -3231,7 +3231,7 @@ sirius_get_wave_functions:
       doc: Local number of G-vectors for a k-point.
     gvec_loc:
       type: int
-      attr: in, optional, dimension(3, *)
+      attr: in, optional, dimension(:,:)
       doc: List of G-vectors.
     evec:
       type: complex
@@ -3598,7 +3598,7 @@ sirius_generate_coulomb_potential:
       doc: DFT ground state handler
     vh_el:
       type: double
-      attr: out, optional, dimension(*)
+      attr: out, optional, dimension(:)
       doc: Electronic part of Hartree potential at each atom's origin.
     error_code:
       type: int
@@ -3782,15 +3782,15 @@ sirius_get_gvec_arrays:
       doc: Simulation context handler
     gvec:
       type: int
-      attr: in, optional, dimension(3, *)
+      attr: in, optional, dimension(:,:)
       doc: G-vectors in lattice coordinates.
     gvec_cart:
       type: double
-      attr: in, optional, dimension(3, *)
+      attr: in, optional, dimension(:,:)
       doc: G-vectors in Cartesian coordinates.
     gvec_len:
       type: double
-      attr: in, optional, dimension(*)
+      attr: in, optional, dimension(:)
       doc: Length of G-vectors.
     index_by_gvec:
       type: int
@@ -3964,23 +3964,23 @@ sirius_get_gkvec_arrays:
       doc: Number of G+k vectors.
     gvec_index:
       type: int
-      attr: out, required, dimension(*)
+      attr: out, required, dimension(:)
       doc: Index of the G-vector part of G+k vector.
     gkvec:
       type: double
-      attr: out, required, dimension(3, *)
+      attr: out, required, dimension(:,:)
       doc: G+k vectors in fractional coordinates.
     gkvec_cart:
       type: double
-      attr: out, required, dimension(3, *)
+      attr: out, required, dimension(:,:)
       doc: G+k vectors in Cartesian coordinates.
     gkvec_len:
       type: double
-      attr: out, required, dimension(*)
+      attr: out, required, dimension(:)
       doc: Length of G+k vectors.
     gkvec_tp:
       type: double
-      attr: out, required, dimension(2, *)
+      attr: out, required, dimension(:,:)
       doc: Theta and Phi angles of G+k vectors.
     error_code:
       type: int
@@ -4046,11 +4046,11 @@ sirius_get_step_function:
       doc: Simulation context handler
     cfunig:
       type: complex
-      attr: out, required, dimension(*)
+      attr: out, required, dimension(:)
       doc: Plane-wave coefficients of step function.
     cfunrg:
       type: double
-      attr: out, required, dimension(*)
+      attr: out, required, dimension(:)
       doc: Values of the step function on the regular grid.
     num_rg_points:
       type: int
@@ -4363,7 +4363,7 @@ sirius_set_radial_function:
       doc: Radial derivative order.
     f:
       type: double
-      attr: in, required
+      attr: in, required, dimension(:)
       doc: Values of the radial function.
     l:
       type: int
@@ -4439,7 +4439,7 @@ sirius_set_equivalent_atoms:
       doc: Simulation context handler.
     equivalent_atoms:
       type: int
-      attr: in, required, dimension(*)
+      attr: in, required, dimension(:)
       doc: Array with equivalent atom IDs.
     error_code:
       type: int
@@ -4923,7 +4923,7 @@ sirius_get_fv_eigen_vectors:
       doc: Global index of the k-point
     fv_evec:
       type: complex
-      attr: out, required
+      attr: out, required, dimension(:,:)
       doc: Output first-variational eigenvector array
     ld:
       type: int
@@ -5013,7 +5013,7 @@ sirius_get_sv_eigen_vectors:
       doc: Global index of the k-point
     sv_evec:
       type: complex
-      attr: out, required
+      attr: out, required, dimension(:,:)
       doc: Output second-variational eigenvector array
     num_bands:
       type: int
@@ -5054,15 +5054,15 @@ sirius_set_rg_values:
       doc: Label of the function.
     grid_dims:
       type: int
-      attr: in, required
+      attr: in, required, dimension(3)
       doc: Dimensions of the FFT grid.
     local_box_origin:
       type: int
-      attr: in, required
+      attr: in, required, dimension(:,:)
       doc: Coordinates of the local box origin for each MPI rank
     local_box_size:
       type: int
-      attr: in, required
+      attr: in, required, dimension(:,:)
       doc: Dimensions of the local box for each MPI rank.
     fcomm:
       type: int
@@ -5187,15 +5187,15 @@ sirius_get_rg_values:
       doc: Label of the function.
     grid_dims:
       type: int
-      attr: in, required
+      attr: in, required, dimensions(3)
       doc: Dimensions of the FFT grid.
     local_box_origin:
       type: int
-      attr: in, required
+      attr: in, required, dimensions(:,:)
       doc: Coordinates of the local box origin for each MPI rank
     local_box_size:
       type: int
-      attr: in, required
+      attr: in, required, dimensions(:,:)
       doc: Dimensions of the local box for each MPI rank.
     fcomm:
       type: int

--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -3794,7 +3794,7 @@ sirius_get_gvec_arrays:
       doc: Length of G-vectors.
     index_by_gvec:
       type: int
-      attr: in, optional
+      attr: in, optional, dimension(:,:,:)
       doc: G-vector index by lattice coordinates.
     error_code:
       type: int
@@ -3893,7 +3893,7 @@ sirius_get_fft_index:
       doc: Simulation context handler
     fft_index:
       type: int
-      attr: out, required
+      attr: out, required, dimension(:)
       doc: Index inside FFT buffer
     error_code:
       type: int

--- a/src/geometry/force.cpp
+++ b/src/geometry/force.cpp
@@ -263,7 +263,7 @@ Force::calc_forces_ibs()
         }
     }
 
-    Hamiltonian0<double> H0(potential_, true);
+    Hamiltonian0<double> H0(potential_, false);
     for (int ikloc = 0; ikloc < kset_.spl_num_kpoints().local_size(); ikloc++) {
         int ik  = kset_.spl_num_kpoints(ikloc);
         auto hk = H0(*kset_.get<double>(ik));


### PR DESCRIPTION
There is also a fix for calculation of IBS forces in LAPW. The radial wave functions should not be recomputed.