### PR TITLE
[fix] Allocate wave-function from memory pool

### DIFF
--- a/src/SDDK/wave_functions.hpp
+++ b/src/SDDK/wave_functions.hpp
@@ -397,8 +397,8 @@ class Wave_functions_base
             num_sc_ = num_spins(2);
         }
         for (int is = 0; is < num_sc_.get(); is++) {
-            data_[is] = sddk::mdarray<std::complex<T>, 2>(num_pw_ + num_mt_, num_wf_.get(), default_mem__,
-                "Wave_functions_base::data_");
+            data_[is] = sddk::mdarray<std::complex<T>, 2>(num_pw_ + num_mt_, num_wf_.get(),
+                    sddk::get_memory_pool(default_mem__), "Wave_functions_base::data_");
         }
     }
 
@@ -493,7 +493,7 @@ class Wave_functions_base
     allocate(sddk::memory_t mem__)
     {
         for (int s = 0; s < num_sc_.get(); s++) {
-            data_[s].allocate(get_memory_pool(mem__));
+            data_[s].allocate(sddk::get_memory_pool(mem__));
         }
     }
 

--- a/src/band/davidson.hpp
+++ b/src/band/davidson.hpp
@@ -138,6 +138,7 @@ davidson(Hamiltonian_k<T>& Hk__, wf::num_bands num_bands__, wf::num_mag_dims num
 {
     PROFILE("sirius::davidson");
 
+    PROFILE_START("sirius::davidson|init");
     auto& ctx = Hk__.H0().ctx();
     ctx.print_memory_usage(__FILE__, __LINE__);
 
@@ -317,6 +318,7 @@ davidson(Hamiltonian_k<T>& Hk__, wf::num_bands num_bands__, wf::num_mag_dims num
                << "  non-collinear       : " << nc_mag << std::endl
                << "  number of extra phi : " << num_extra_phi << std::endl;
     }
+    PROFILE_STOP("sirius::davidson|init");
 
     PROFILE_START("sirius::davidson|iter");
     for (int ispin_step = 0; ispin_step < num_spinors; ispin_step++) {


### PR DESCRIPTION
Small fix that improves a lot allocation of the host-pinned memory for the wave-functions. I tested it on Au-surf example and the performance is good now.

As a by-product: use std::make_unique in a couple of places and allow to set parallel FFT transformation for the wave functions if mpi grid is of the [n, 1] shape.