### PR TITLE
[bug] Low symmetry lattices

### DIFF
--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -962,7 +962,8 @@ Simulation_context::update()
        the next time only reciprocal lattice of the G-vectors is updated */
     if (!gvec_coarse_) {
         /* create list of coarse G-vectors */
-        gvec_coarse_ = std::make_unique<fft::Gvec>(rlv, 2 * gk_cutoff(), comm(), cfg().control().reduce_gvec());
+        gvec_coarse_ = std::make_unique<fft::Gvec>(rlv, 2 * gk_cutoff(), comm(), cfg().control().reduce_gvec(),
+                cfg().control().spglib_tolerance());
         /* create FFT friendly partiton */
         gvec_coarse_fft_ = std::make_shared<fft::Gvec_fft>(*gvec_coarse_, comm_fft_coarse(),
                 comm_ortho_fft_coarse());

--- a/src/fft/gvec.cpp
+++ b/src/fft/gvec.cpp
@@ -29,7 +29,7 @@
 
 namespace fft {
 
-r3::vector<int> fft::Gvec::gvec_by_full_index(uint32_t idx__) const
+r3::vector<int> Gvec::gvec_by_full_index(uint32_t idx__) const
 {
     /* index of the z coordinate of G-vector: first 12 bits */
     uint32_t j = idx__ & 0xFFF;
@@ -43,7 +43,7 @@ r3::vector<int> fft::Gvec::gvec_by_full_index(uint32_t idx__) const
     return r3::vector<int>(x, y, z);
 }
 
-void fft::Gvec::find_z_columns(double Gmax__, fft::Grid const& fft_box__)
+void Gvec::find_z_columns(double Gmax__, fft::Grid const& fft_box__)
 {
     PROFILE("fft::Gvec::find_z_columns");
 
@@ -128,7 +128,7 @@ void fft::Gvec::find_z_columns(double Gmax__, fft::Grid const& fft_box__)
 
     /* now we have to remove edge G-vectors that don't form a complete shell */
     if (bare_gvec_) {
-        auto lat_sym = sirius::find_lat_sym(lattice_vectors_, 1e-6);
+        auto lat_sym = sirius::find_lat_sym(this->unit_cell_lattice_vectors(), this->sym_tol_);
 
         std::fill(non_zero_columns.at(sddk::memory_t::host), non_zero_columns.at(sddk::memory_t::host) + non_zero_columns.size(), -1);
         for (int i = 0; i < static_cast<int>(z_columns_.size()); i++) {
@@ -144,8 +144,8 @@ void fft::Gvec::find_z_columns(double Gmax__, fft::Grid const& fft_box__)
                 r3::vector<int> G(z_columns_[i].x, z_columns_[i].y, z_columns_[i].z[iz]);
                 bool found_for_all_sym{true};
                 for (auto& R: lat_sym) {
-                    /* apply lattice symmeetry operation to a G-vector */
-                    auto G1 = dot(R, G);
+                    /* apply lattice symmetry operation to a G-vector */
+                    auto G1 = r3::dot(G, R);
                     if (reduce_gvec_) {
                         if (G1[0] == 0 && G1[1] == 0) {
                             G1[2] = std::abs(G1[2]);
@@ -255,7 +255,7 @@ void Gvec::find_gvec_shells()
 
     PROFILE("fft::Gvec::find_gvec_shells");
 
-    auto lat_sym = sirius::find_lat_sym(lattice_vectors_, 1e-6);
+    auto lat_sym = sirius::find_lat_sym(this->unit_cell_lattice_vectors(), this->sym_tol_);
 
     num_gvec_shells_ = 0;
     gvec_shell_      = sddk::mdarray<int, 1>(num_gvec_, sddk::memory_t::host, "gvec_shell_");
@@ -264,10 +264,11 @@ void Gvec::find_gvec_shells()
 
     /* find G-vector shells using symmetry consideration */
     for (int ig = 0; ig < num_gvec_; ig++) {
+        /* if the shell for this vector is not yet found */
         if (gvec_shell_[ig] == -1) {
             auto G = gvec<sddk::index_domain_t::global>(ig);
             for (auto& R: lat_sym) {
-                auto G1 = dot(R, G);
+                auto G1 = r3::dot(G, R);
                 auto ig1 = index_by_gvec(G1);
                 if (ig1 == -1) {
                     G1 = G1 * (-1);
@@ -276,7 +277,24 @@ void Gvec::find_gvec_shells()
                         RTE_THROW("symmetry-related G-vector is not found");
                     }
                 }
-                gvec_shell_[ig1] = num_gvec_shells_;
+                if (gvec_shell_[ig1] == -1) {
+                    gvec_shell_[ig1] = num_gvec_shells_;
+                } else {
+                    if (gvec_shell_[ig1] != num_gvec_shells_) {
+                        auto gc  = r3::dot(lattice_vectors_, G);
+                        auto gc1  = r3::dot(lattice_vectors_, G1);
+                        std::stringstream s;
+                        s << "Error in G-vector shell index" << std::endl
+                          << "  G : " << G << std::endl
+                          << "  rotated G : " << G1 << std::endl
+                          << "  current shell index : " << num_gvec_shells_ << std::endl
+                          << "  rotated G shell index : " << gvec_shell_[ig1] << std::endl
+                          << "  length of G : " << gc.length() << std::endl
+                          << "  length of rotated G : " << gc1.length() << std::endl
+                          << "  length difference : " << std::abs(gc.length() - gc1.length());
+                        RTE_THROW(s);
+                    }
+                }
             }
             num_gvec_shells_++;
         }
@@ -288,62 +306,19 @@ void Gvec::find_gvec_shells()
     }
 
     gvec_shell_len_ = sddk::mdarray<double, 1>(num_gvec_shells_, sddk::memory_t::host, "gvec_shell_len_");
-    std::fill(&gvec_shell_len_[0], &gvec_shell_len_[0] + num_gvec_shells_, -1);
+    std::fill(&gvec_shell_len_[0], &gvec_shell_len_[0] + num_gvec_shells_, 0);
+
+    std::vector<int> ngv_sh(num_gvec_shells_, 0);
 
     for (int ig = 0; ig < num_gvec_; ig++) {
         auto g   = gvec_cart<sddk::index_domain_t::global>(ig).length();
         int igsh = gvec_shell_[ig];
-        if (gvec_shell_len_[igsh] < 0) {
-            gvec_shell_len_[igsh] = g;
-        } else {
-            /* lattice symmetries were found with 1e-6 tolererance for the metric tensor,
-               so tolerance on length should be square root of that */
-            if (std::abs(gvec_shell_len_[igsh] - g) > 1e-3) {
-                std::stringstream s;
-                s << "wrong G-vector length" << std::endl
-                  << "  length of G-vector : " << g << std::endl
-                  << "  length of G-shell : " << gvec_shell_len_[igsh] << std::endl
-                  << "  index of G-vector : " << ig << std::endl
-                  << "  index of G-shell : " << igsh << std::endl
-                  << "  length difference : " << std::abs(gvec_shell_len_[igsh] - g) << std::endl;
-                RTE_THROW(s);
-            }
-        }
+        gvec_shell_len_[igsh] += g;
+        ngv_sh[igsh]++;
     }
-
-    // TODO: maybe, make an average G-shell length.
-
-    /* list of pairs (length, index of G-vector) */
-    std::vector<std::pair<uint64_t, int>> tmp(num_gvec_);
-    #pragma omp parallel for schedule(static)
-    for (int ig = 0; ig < num_gvec(); ig++) {
-        /* make some reasonable roundoff */
-        uint64_t len = static_cast<uint64_t>(gvec_shell_len_[gvec_shell_[ig]] * 1e10);
-        tmp[ig]      = std::make_pair(len, ig);
+    for (int i = 0; i < num_gvec_shells_; i++) {
+        gvec_shell_len_[i] /= ngv_sh[i];
     }
-    /* sort by first element in pair (length) */
-    std::sort(tmp.begin(), tmp.end());
-
-    /* index of the first shell */
-    gvec_shell_(tmp[0].second) = 0;
-    num_gvec_shells_           = 1;
-    /* temporary vector to store G-shell radius */
-    std::vector<double> tmp_len;
-    /* radius of the first shell */
-    tmp_len.push_back(static_cast<double>(tmp[0].first) * 1e-10);
-    for (int ig = 1; ig < num_gvec_; ig++) {
-        /* if this G-vector has a different length */
-        if (tmp[ig].first != tmp[ig - 1].first) {
-            /* increment number of shells */
-            num_gvec_shells_++;
-            /* save the radius of the new shell */
-            tmp_len.push_back(static_cast<double>(tmp[ig].first) * 1e-10);
-        }
-        /* assign the index of the current shell */
-        gvec_shell_(tmp[ig].second) = num_gvec_shells_ - 1;
-    }
-    gvec_shell_len_ = sddk::mdarray<double, 1>(num_gvec_shells_, sddk::memory_t::host, "gvec_shell_len_");
-    std::copy(tmp_len.begin(), tmp_len.end(), gvec_shell_len_.at(sddk::memory_t::host));
 
     /* map from global index of G-shell to a list of local G-vectors */
     std::map<int, std::vector<int>> gshmap;

--- a/src/symmetry/crystal_symmetry.cpp
+++ b/src/symmetry/crystal_symmetry.cpp
@@ -325,7 +325,10 @@ void
 Crystal_symmetry::print_info(std::ostream& out__, int verbosity__) const
 {
     if (this->spg_dataset_ && (this->spg_dataset_->n_operations != this->num_spg_sym())) {
-        out__ << "space group found by spglib is defferent" << std::endl;
+        out__ << "space group found by spglib is different" << std::endl
+              << "  num. sym. spglib : " << this->spg_dataset_->n_operations << std::endl
+              << "  num. sym. actual : " << this->num_spg_sym() << std::endl
+              << "  tolerance : " << this->tolerance_ << std::endl;
     } else {
         out__ << "space group number   : " << this->spacegroup_number() << std::endl
               << "international symbol : " << this->international_symbol() << std::endl

--- a/src/symmetry/lattice.hpp
+++ b/src/symmetry/lattice.hpp
@@ -111,11 +111,12 @@ find_lat_sym(r3::matrix<double> const& lat_vec__, double tol__, double* mt_error
                 std::stringstream s;
                 s << "lattice symmetries do not form a group" << std::endl;
                 for (auto& R: lat_sym) {
-                    s << " sym.op : " << R << std::endl;
+                    s << " sym.op : " << R << ", metric tensor error : " << metric_tensor_error(lat_vec__, R) << std::endl;
                 }
                 s << "R1 : " << R1 << std::endl;
                 s << "R2 : " << R2 << std::endl;
-                s << "R1 * R2 : " << R3 << " not in group" << std::endl;
+                s << "R1 * R2 : " << R3 << " is not in group" << std::endl;
+                s << "metric tensor tolerance : " << tol__;
                 RTE_THROW(s);
             }
         }

--- a/src/symmetry/lattice.hpp
+++ b/src/symmetry/lattice.hpp
@@ -22,6 +22,7 @@
  *  \brief Crystal lattice functions.
  */
 
+#include <algorithm>
 #include "linalg/r3.hpp"
 #include "utils/rte.hpp"
 
@@ -54,11 +55,15 @@ metric_tensor_error(r3::matrix<double> const& lat_vec__, r3::matrix<int> const& 
 }
 
 inline auto
-find_lat_sym(r3::matrix<double> const& lat_vec__, double tol__)
+find_lat_sym(r3::matrix<double> const& lat_vec__, double tol__, double* mt_error__ = nullptr)
 {
     std::vector<r3::matrix<int>> lat_sym;
 
     auto r = {-1, 0, 1};
+
+    if (mt_error__) {
+        *mt_error__ = 0;
+    }
 
     for (int i00: r) {
     for (int i01: r) {
@@ -73,9 +78,13 @@ find_lat_sym(r3::matrix<double> const& lat_vec__, double tol__)
                 r3::matrix<int> R({{i00, i01, i02}, {i10, i11, i12}, {i20, i21, i22}});
                 /* valid symmetry operation has a determinant of +/- 1 */
                 if (std::abs(R.det()) == 1) {
+                    auto mt_error = metric_tensor_error(lat_vec__, R);
                     /* metric tensor should be invariant under symmetry operation */
-                    if (metric_tensor_error(lat_vec__, R) < tol__) {
+                    if (mt_error < tol__) {
                         lat_sym.push_back(R);
+                        if (mt_error__) {
+                            *mt_error__ = std::max(*mt_error__, mt_error);
+                        }
                     }
                 }
             }
@@ -92,6 +101,24 @@ find_lat_sym(r3::matrix<double> const& lat_vec__, double tol__)
         std::stringstream s;
         s << "wrong number of lattice symmetries: " << lat_sym.size();
         RTE_THROW(s);
+    }
+
+    /* check if the set of symmetry operations is a group */
+    for (auto& R1: lat_sym) {
+        for (auto& R2: lat_sym) {
+            auto R3 = r3::dot(R1, R2);
+            if (std::find(lat_sym.begin(), lat_sym.end(), R3) == lat_sym.end()) {
+                std::stringstream s;
+                s << "lattice symmetries do not form a group" << std::endl;
+                for (auto& R: lat_sym) {
+                    s << " sym.op : " << R << std::endl;
+                }
+                s << "R1 : " << R1 << std::endl;
+                s << "R2 : " << R2 << std::endl;
+                s << "R1 * R2 : " << R3 << " not in group" << std::endl;
+                RTE_THROW(s);
+            }
+        }
     }
 
     return lat_sym;

--- a/src/unit_cell/atom_symmetry_class.cpp
+++ b/src/unit_cell/atom_symmetry_class.cpp
@@ -55,7 +55,7 @@ Atom_symmetry_class::Atom_symmetry_class(int id__, Atom_type const& atom_type__)
         o1_radial_integrals_.zero();
     }
 
-    /* copy descriptors because enu is defferent between atom classes */
+    /* copy descriptors because enu is different between atom classes */
     aw_descriptors_.resize(atom_type_.num_aw_descriptors());
     for (int i = 0; i < num_aw_descriptors(); i++) {
         aw_descriptors_[i] = atom_type_.aw_descriptor(i);


### PR DESCRIPTION
This PR addresses the problem of finding symmetries of a lattice with very small distrotion of a high-symmetry phase. More error checks are intoroduces. In case of failure, the control:spglib_tolerance must be decreased. The following has been done:
* pass unit cell lattice tolerance to G-vectors to be used in find_lat_sym()
* introduce a check in find_lat_sym() to test if a set of lattice operations form a group
* find G-shells based on symmetry consideration; intoroduce more checks there
* find G-vector shell length using average value of G-vector lengths
* remove lurked obsolete code

### What has not been addressed yet
Ths most of the symmetry issues come from the ill defined lattices. Typical use case is a small distortion of the high-symmetry lattice to break the symmetry and perform lattice relaxation. In that case it can make sense to not use symmetry at all. When the distorion is small, spglib can overshoot the symmetry detection and find a higher-symmetry solution (even if spglib_tolerance is relatively small). That made us introduce the addition check in find_lat_sym(). But if you just remove the symmetries that transfrom metric tensor with some threshold error, you may end up with a set of symmetry operations that do not form a group. The search for a better solution to this problem continues. 