### PR TITLE
[fix] Use MPI grid for setting fft communicators

### DIFF
--- a/src/SDDK/wave_functions.hpp
+++ b/src/SDDK/wave_functions.hpp
@@ -912,7 +912,7 @@ class Wave_functions_fft : public Wave_functions_base<T>
 
         auto sp = wf_->actual_spin_index(ispn__);
         auto t0 = utils::time_now();
-        if (false) {
+        if (true) {
             auto layout_in  = wf_->grid_layout_pw(sp, b__);
             auto layout_out = this->grid_layout(b__.size());
 
@@ -979,7 +979,7 @@ class Wave_functions_fft : public Wave_functions_base<T>
         auto pp = env::print_performance();
 
         auto t0 = utils::time_now();
-        if (false) {
+        if (true) {
             auto layout_in  = this->grid_layout(b__.size());
             auto layout_out = wf_->grid_layout_pw(sp, b__);
 

--- a/src/SDDK/wave_functions.hpp
+++ b/src/SDDK/wave_functions.hpp
@@ -979,7 +979,7 @@ class Wave_functions_fft : public Wave_functions_base<T>
         auto pp = env::print_performance();
 
         auto t0 = utils::time_now();
-        if (true) {
+        if (false) {
             auto layout_in  = this->grid_layout(b__.size());
             auto layout_out = wf_->grid_layout_pw(sp, b__);
 
@@ -989,14 +989,14 @@ class Wave_functions_fft : public Wave_functions_base<T>
 
             auto& comm_col = gkvec_fft_->comm_ortho_fft();
 
-            auto ncol = sddk::splindex_base<int>::block_size(b__.size(), comm_col.size());
-            size_t sz = gkvec_fft_->count() * ncol;
-            sddk::mdarray<std::complex<T>, 1> send_recv_buf(sz, sddk::get_memory_pool(sddk::memory_t::host), "send_recv_buf");
-
-            auto& row_distr = gkvec_fft_->gvec_slab();
-
             /* local number of columns */
             int n_loc = spl_num_wf_.local_size();
+
+            /* send buffer */
+            sddk::mdarray<std::complex<T>, 1> send_buf(gkvec_fft_->count() * n_loc,
+                    sddk::get_memory_pool(sddk::memory_t::host), "send_buf");
+
+            auto& row_distr = gkvec_fft_->gvec_slab();
 
             /* reorder sending blocks */
             #pragma omp parallel for
@@ -1006,7 +1006,7 @@ class Wave_functions_fft : public Wave_functions_base<T>
                     int count  = row_distr.counts[j];
                     if (count) {
                         auto from = this->data_[0].at(sddk::memory_t::host, offset, i);
-                        std::copy(from, from + count, &send_recv_buf[offset * n_loc + count * i]);
+                        std::copy(from, from + count, &send_buf[offset * n_loc + count * i]);
                     }
                 }
             }
@@ -1018,10 +1018,43 @@ class Wave_functions_fft : public Wave_functions_base<T>
             }
             sd.calc_offsets();
             rd.calc_offsets();
-            auto* recv_buf = (this->num_pw_ == 0) ? nullptr : wf_->data_[sp.get()].at(sddk::memory_t::host, 0, b__.begin());
 
-            comm_col.alltoall(send_recv_buf.at(sddk::memory_t::host), sd.counts.data(), sd.offsets.data(), recv_buf,
+#if !defined(NDEBUG)
+            for (int i = 0; i < n_loc; i++) {
+                for (int j = 0; j < comm_col.size(); j++) {
+                    int offset = row_distr.offsets[j];
+                    int count  = row_distr.counts[j];
+                    for (int igg = 0; igg < count; igg++) {
+                        if (send_buf[offset * n_loc + count * i + igg] != this->data_[0](offset + igg, i)) {
+                            RTE_THROW("wrong packing of send buffer");
+                        }
+                    }
+                }
+            }
+#endif
+            /* full potential wave-functions have extra muffin-tin part;
+             * that makes the PW block of data not consecutive and thus we need to copy to a consecutive buffer
+             * for alltoall */
+            sddk::mdarray<std::complex<T>, 2> wf_tmp;
+            if (wf_->ld() == wf_->num_pw_) { /* pure plane-wave coeffs */
+                auto ptr = (wf_->num_pw_ == 0) ? nullptr : wf_->data_[sp.get()].at(sddk::memory_t::host, 0, b__.begin());
+                wf_tmp = sddk::mdarray<std::complex<T>, 2>(ptr, wf_->num_pw_, b__.size());
+            } else {
+                wf_tmp = sddk::mdarray<std::complex<T>, 2>(wf_->num_pw_, b__.size(), sddk::get_memory_pool(sddk::memory_t::host));
+            }
+
+            auto* recv_buf = (wf_tmp.ld() == 0) ? nullptr : wf_tmp.at(sddk::memory_t::host);
+
+            comm_col.alltoall(send_buf.at(sddk::memory_t::host), sd.counts.data(), sd.offsets.data(), recv_buf,
                           rd.counts.data(), rd.offsets.data());
+
+            if (wf_->ld() != wf_->num_pw_) {
+                for (int i = 0; i < b__.size(); i++) {
+                    auto out_ptr = wf_->data_[sp.get()].at(sddk::memory_t::host, 0, b__.begin() + i);
+                    std::copy(wf_tmp.at(sddk::memory_t::host, 0, i),
+                            wf_tmp.at(sddk::memory_t::host, 0, i) + wf_->num_pw_, out_ptr);
+                }
+            }
         }
         if (pp && wf_->gkvec().comm().rank() == 0) {
             auto t = utils::time_interval(t0);

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -1534,8 +1534,6 @@ Simulation_context::init_comm()
 
     /* create communicator, orthogonal to comm_fft_coarse */
     comm_ortho_fft_coarse_ = comm().split(comm_fft_coarse().rank());
-
-    /* create communicator, orthogonal to comm_fft_coarse within a band communicator */
-    comm_band_ortho_fft_coarse_ = comm_band().split(comm_fft_coarse().rank());
 }
+
 } // namespace sirius

--- a/src/context/simulation_context.hpp
+++ b/src/context/simulation_context.hpp
@@ -109,11 +109,6 @@ class Simulation_context : public Simulation_parameters
     /// Auxiliary communicator for the coarse-grid FFT transformation.
     mpi::Communicator comm_ortho_fft_coarse_;
 
-    /// Communicator, which is orthogonal to comm_fft_coarse within a band communicator.
-    /** This communicator is used in reshuffling the wave-functions for the FFT-friendly distribution. It will be
-        used to parallelize application of local Hamiltonian over bands. */
-    mpi::Communicator comm_band_ortho_fft_coarse_;
-
     /// Unit cell of the simulation.
     std::unique_ptr<Unit_cell> unit_cell_;
 
@@ -509,16 +504,13 @@ class Simulation_context : public Simulation_parameters
         if (cfg().control().fft_mode() == "serial") {
             return mpi::Communicator::self();
         } else {
-            //return comm_band();
             return mpi_grid_->communicator(1 << 0);
         }
     }
 
-    auto const& comm_ortho_fft_coarse() const
-    {
-        return comm_ortho_fft_coarse_;
-    }
-
+    /// Communicator, which is orthogonal to comm_fft_coarse within a band communicator.
+    /** This communicator is used in reshuffling the wave-functions for the FFT-friendly distribution. It will be
+        used to parallelize application of local Hamiltonian over bands. */
     auto const& comm_band_ortho_fft_coarse() const
     {
         if (cfg().control().fft_mode() == "serial") {
@@ -526,7 +518,11 @@ class Simulation_context : public Simulation_parameters
         } else {
             return mpi_grid_->communicator(1 << 1);
         }
-        //return comm_band_ortho_fft_coarse_;
+    }
+
+    auto const& comm_ortho_fft_coarse() const
+    {
+        return comm_ortho_fft_coarse_;
     }
 
     void create_storage_file() const;

--- a/src/context/simulation_context.hpp
+++ b/src/context/simulation_context.hpp
@@ -509,7 +509,8 @@ class Simulation_context : public Simulation_parameters
         if (cfg().control().fft_mode() == "serial") {
             return mpi::Communicator::self();
         } else {
-            return comm_band();
+            //return comm_band();
+            return mpi_grid_->communicator(1 << 0);
         }
     }
 
@@ -520,7 +521,12 @@ class Simulation_context : public Simulation_parameters
 
     auto const& comm_band_ortho_fft_coarse() const
     {
-        return comm_band_ortho_fft_coarse_;
+        if (cfg().control().fft_mode() == "serial") {
+            return comm_band();
+        } else {
+            return mpi_grid_->communicator(1 << 1);
+        }
+        //return comm_band_ortho_fft_coarse_;
     }
 
     void create_storage_file() const;


### PR DESCRIPTION
This PR isolates the work on setting the parallel FFT communiator using MPI grid from the PR (https://github.com/electronic-structure/SIRIUS/pull/803). Now the MPI grid for the band parallelisation is used to setup parallel FFT communcators. 