### PR TITLE
[fix] Change spglib tolerance from 1e-4 to 1e-6

### DIFF
--- a/src/context/input_schema.json
+++ b/src/context/input_schema.json
@@ -362,7 +362,7 @@
                 },
                 "spglib_tolerance" : {
                     "type" : "number",
-                    "default" : 1e-4,
+                    "default" : 1e-6,
                     "title" : "Tolerance of the spglib in finding crystal symmetries"
                 },
                 "verbosity" : {


### PR DESCRIPTION
Use smaller value of tolerance parameter to detect symmetries of crystall and lattice.