### PR TITLE
[enhancement] introduce Spheric_function_set class

### DIFF
--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -3054,7 +3054,7 @@ sirius_get_energy(void* const* handler__, char const* label__, double* energy__,
             {"descf", [&]() { return gs.scf_correction_energy(); }},
             {"demet", [&]() { return kset.entropy_sum(); }},
             {"paw-one-el", [&]() { return potential.PAW_one_elec_energy(density); }},
-            {"paw", [&]() { return potential.PAW_total_energy(); }},
+            {"paw", [&]() { return potential.PAW_total_energy(density); }},
             {"fermi", [&]() { return kset.energy_fermi(); }},
             {"hubbard", [&]() { return sirius::hubbard_energy(density); }}};
 

--- a/src/density/density.cpp
+++ b/src/density/density.cpp
@@ -105,7 +105,7 @@ Density::Density(Simulation_context& ctx__)
     }
 
     if (unit_cell_.num_paw_atoms()) {
-        paw_density_ = std::make_unique<paw_density<double>>(unit_cell_);
+        paw_density_ = std::make_unique<PAW_density<double>>(unit_cell_);
     }
 
     update();
@@ -1863,7 +1863,7 @@ Density::mixer_init(config_t::mixer_t const& mixer_cfg__)
     this->mixer_ =
         mixer::Mixer_factory<Periodic_function<double>, Periodic_function<double>, Periodic_function<double>,
                              Periodic_function<double>, sddk::mdarray<std::complex<double>, 4>,
-                             paw_density<double>, Hubbard_matrix>(mixer_cfg__);
+                             PAW_density<double>, Hubbard_matrix>(mixer_cfg__);
 
     const bool init_mt = ctx_.full_potential();
 

--- a/src/density/density.hpp
+++ b/src/density/density.hpp
@@ -27,11 +27,11 @@
 
 #include <iomanip>
 #include "function3d/field4d.hpp"
+#include "function3d/paw_field4d.hpp"
 #include "function3d/periodic_function.hpp"
 #include "function3d/spheric_function_set.hpp"
 #include "k_point/k_point_set.hpp"
 #include "mixer/mixer.hpp"
-#include "paw_density.hpp"
 #include "occupation_matrix.hpp"
 
 #if defined(SIRIUS_GPU)
@@ -73,7 +73,7 @@ sum_q_pw_dm_pw_gpu(int num_gvec_loc__, int nbf__, double const* q_pw__, int ldq_
 namespace sirius {
 
 /// Use Kuebler's trick to get rho_up and rho_dn from density and magnetisation.
-inline std::pair<double, double>
+inline auto
 get_rho_up_dn(int num_mag_dims__, double rho__, r3::vector<double> mag__)
 {
     if (rho__ < 0.0) {
@@ -94,6 +94,38 @@ get_rho_up_dn(int num_mag_dims__, double rho__, r3::vector<double> mag__)
 
     return std::make_pair<double, double>(0.5 * (rho__ + mag), 0.5 * (rho__ - mag));
 }
+
+/// PAW density storage.
+template <typename T>
+class PAW_density : public PAW_field4D<T>
+{
+  public:
+
+    PAW_density(Unit_cell const& uc__)
+        : PAW_field4D<T>(uc__, false)
+    {
+    }
+
+    auto& ae_density(int i__, int ja__)
+    {
+        return this->ae_component(i__)[ja__];
+    }
+
+    auto const& ae_density(int i__, int ja__) const
+    {
+        return this->ae_component(i__)[ja__];
+    }
+
+    auto& ps_density(int i__, int ja__)
+    {
+        return this->ps_component(i__)[ja__];
+    }
+
+    auto const& ps_density(int i__, int ja__) const
+    {
+        return this->ps_component(i__)[ja__];
+    }
+};
 
 /// Generate charge density and magnetization from occupied spinor wave-functions.
 /** Let's start from the definition of the complex density matrix:

--- a/src/density/paw_density.hpp
+++ b/src/density/paw_density.hpp
@@ -29,6 +29,8 @@
 
 namespace sirius {
 
+/// PAW density and potential storage.
+/** In PAW density and potential are represented with two counterpart: all-electron (AE) and pseudo (PS) */
 template <typename T>
 class PAW_field4D
 {

--- a/src/density/paw_density.hpp
+++ b/src/density/paw_density.hpp
@@ -112,11 +112,11 @@ class PAW_field4D
 };
 
 template <typename T>
-class paw_density : public PAW_field4D<T>
+class PAW_density : public PAW_field4D<T>
 {
   public:
 
-    paw_density(Unit_cell const& uc__)
+    PAW_density(Unit_cell const& uc__)
         : PAW_field4D<T>(uc__, false)
     {
     }

--- a/src/dft/dft_ground_state.cpp
+++ b/src/dft/dft_ground_state.cpp
@@ -462,7 +462,7 @@ DFT_ground_state::print_info(std::ostream& out__) const
         write_energy("hartree contribution", 0.5 * evha);
         write_energy("xc contribution", eexc);
         write_energy("ewald contribution", ewald_energy_);
-        write_energy("PAW contribution", potential_.PAW_total_energy());
+        write_energy("PAW contribution", potential_.PAW_total_energy(density_));
     }
     write_energy("smearing (-TS)", s_sum);
     write_energy("SCF correction", this->scf_correction_energy_);

--- a/src/dft/energy.cpp
+++ b/src/dft/energy.cpp
@@ -166,7 +166,7 @@ total_energy(Simulation_context const& ctx, K_point_set const& kset, Density con
         case electronic_structure_method_t::pseudopotential: {
             tot_en = (kset.valence_eval_sum() - energy_vxc(density, potential) - energy_bxc(density, potential) -
                       potential.PAW_one_elec_energy(density) - one_electron_energy_hubbard(density, potential)) -
-                     0.5 * energy_vha(potential) + energy_exc(density, potential) + potential.PAW_total_energy() +
+                     0.5 * energy_vha(potential) + energy_exc(density, potential) + potential.PAW_total_energy(density) +
                      ewald_energy + kset.entropy_sum() + ::sirius::hubbard_energy(density);
             break;
         }

--- a/src/function3d/field4d.cpp
+++ b/src/function3d/field4d.cpp
@@ -110,35 +110,39 @@ void Field4D::symmetrize(Periodic_function<double>* f__, Periodic_function<doubl
     }
 }
 
-sirius::Field4D::Field4D(Simulation_context& ctx__, int lmmax__)
+Field4D::Field4D(Simulation_context& ctx__, int lmmax__)
     : lmmax_(lmmax__)
     , ctx_(ctx__)
 {
     for (int i = 0; i < ctx_.num_mag_dims() + 1; i++) {
-        components_[i] = std::unique_ptr<Periodic_function<double>>(new Periodic_function<double>(ctx_, lmmax__));
-        /* allocate global MT array */
-        components_[i]->allocate_mt(true);
+        if (ctx_.full_potential()) {
+            components_[i] = std::make_unique<Periodic_function<double>>(ctx_, lmmax__);
+            /* allocate global MT array */
+            components_[i]->allocate_mt(true);
+        } else {
+            components_[i] = std::make_unique<Periodic_function<double>>(ctx_, lmmax__);
+        }
     }
 }
 
-Periodic_function<double> &sirius::Field4D::scalar() 
+Periodic_function<double>& Field4D::scalar()
 {
     return *(components_[0]);
 }
 
-const Periodic_function<double> &sirius::Field4D::scalar() const
+Periodic_function<double> const& Field4D::scalar() const
 {
     return *(components_[0]);
 }
 
-void sirius::Field4D::zero()
+void Field4D::zero()
 {
     for (int i = 0; i < ctx_.num_mag_dims() + 1; i++) {
         component(i).zero();
     }
 }
 
-void sirius::Field4D::fft_transform(int direction__)
+void Field4D::fft_transform(int direction__)
 {
     for (int i = 0; i < ctx_.num_mag_dims() + 1; i++) {
         component(i).fft_transform(direction__);

--- a/src/function3d/field4d.hpp
+++ b/src/function3d/field4d.hpp
@@ -54,6 +54,7 @@ class Field4D
                     Periodic_function<double>* gy__);
 
   public:
+    /// Constructor.
     Field4D(Simulation_context& ctx__, int lmmax__);
 
     /// Return scalar part of the field.

--- a/src/function3d/paw_field4d.hpp
+++ b/src/function3d/paw_field4d.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2019 Anton Kozhevnikov, Thomas Schulthess
+// Copyright (c) 2013-2023 Anton Kozhevnikov, Thomas Schulthess
 // All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without modification, are permitted provided that
@@ -17,13 +17,13 @@
 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 // OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-/** \file paw_density.hpp
+/** \file paw_field4d.hpp
  *
- *  \brief Contains definition and implementation of helper class sirius::paw_density.
+ *  \brief Contains definition and implementation of PAW_field4D class.
  */
 
-#ifndef __PAW_DENSITY_HPP__
-#define __PAW_DENSITY_HPP__
+#ifndef __PAW_FIELD4D_HPP__
+#define __PAW_FIELD4D_HPP__
 
 #include "function3d/spheric_function_set.hpp"
 
@@ -46,6 +46,7 @@ class PAW_field4D
     /* copy assignment operator is forbidden */
     PAW_field4D& operator=(PAW_field4D const& src__) = delete;
   public:
+    /// Constructor
     PAW_field4D(Unit_cell const& uc__, bool is_global__)
         : uc_{uc__}
     {
@@ -113,36 +114,6 @@ class PAW_field4D
     }
 };
 
-template <typename T>
-class PAW_density : public PAW_field4D<T>
-{
-  public:
-
-    PAW_density(Unit_cell const& uc__)
-        : PAW_field4D<T>(uc__, false)
-    {
-    }
-
-    auto& ae_density(int i__, int ja__)
-    {
-        return this->ae_component(i__)[ja__];
-    }
-
-    auto const& ae_density(int i__, int ja__) const
-    {
-        return this->ae_component(i__)[ja__];
-    }
-
-    auto& ps_density(int i__, int ja__)
-    {
-        return this->ps_component(i__)[ja__];
-    }
-
-    auto const& ps_density(int i__, int ja__) const
-    {
-        return this->ps_component(i__)[ja__];
-    }
-};
 
 } // namespace sirius
 

--- a/src/function3d/spheric_function.hpp
+++ b/src/function3d/spheric_function.hpp
@@ -365,7 +365,8 @@ auto operator*(Spheric_function<domain_t, T> const& b__, T a__)
 /// Inner product of two spherical functions.
 /** The result of the operation is a scalar value. */
 template <function_domain_t domain_t, typename T>
-T inner(Spheric_function<domain_t, T> const& f1, Spheric_function<domain_t, T> const& f2)
+inline auto
+inner(Spheric_function<domain_t, T> const& f1, Spheric_function<domain_t, T> const& f2)
 {
     Spline<T> s(f1.radial_grid());
 
@@ -391,7 +392,7 @@ T inner(Spheric_function<domain_t, T> const& f1, Spheric_function<domain_t, T> c
     \f]
  */
 template <typename T>
-auto
+inline auto
 laplacian(Spheric_function<function_domain_t::spectral, T> const& f__)
 {
     Spheric_function<function_domain_t::spectral, T> g;
@@ -424,8 +425,9 @@ laplacian(Spheric_function<function_domain_t::spectral, T> const& f__)
 }
 
 /// Convert from Ylm to Rlm representation.
-inline void convert(Spheric_function<function_domain_t::spectral, std::complex<double>> const& f__,
-                    Spheric_function<function_domain_t::spectral, double>& g__)
+inline void
+convert(Spheric_function<function_domain_t::spectral, std::complex<double>> const& f__,
+        Spheric_function<function_domain_t::spectral, double>& g__)
 {
     int lmax = utils::lmax(f__.angular_domain_size());
 
@@ -457,7 +459,8 @@ inline void convert(Spheric_function<function_domain_t::spectral, std::complex<d
 }
 
 /// Convert from Ylm to Rlm representation.
-inline auto convert(Spheric_function<function_domain_t::spectral, std::complex<double>> const& f__)
+inline auto
+convert(Spheric_function<function_domain_t::spectral, std::complex<double>> const& f__)
 {
     Spheric_function<function_domain_t::spectral, double> g(f__.angular_domain_size(), f__.radial_grid());
     convert(f__, g);
@@ -465,8 +468,9 @@ inline auto convert(Spheric_function<function_domain_t::spectral, std::complex<d
 }
 
 /// Convert from Rlm to Ylm representation.
-inline void convert(Spheric_function<function_domain_t::spectral, double> const& f__,
-                    Spheric_function<function_domain_t::spectral, std::complex<double>>& g__)
+inline void
+convert(Spheric_function<function_domain_t::spectral, double> const& f__,
+        Spheric_function<function_domain_t::spectral, std::complex<double>>& g__)
 {
     int lmax = utils::lmax(f__.angular_domain_size());
 
@@ -498,7 +502,8 @@ inline void convert(Spheric_function<function_domain_t::spectral, double> const&
 }
 
 /// Convert from Rlm to Ylm representation.
-inline auto convert(Spheric_function<function_domain_t::spectral, double> const& f__)
+inline auto
+convert(Spheric_function<function_domain_t::spectral, double> const& f__)
 {
     Spheric_function<function_domain_t::spectral, std::complex<double>> g(f__.angular_domain_size(), f__.radial_grid());
     convert(f__, g);
@@ -506,8 +511,9 @@ inline auto convert(Spheric_function<function_domain_t::spectral, double> const&
 }
 
 template <typename T>
-inline void transform(SHT const& sht__, Spheric_function<function_domain_t::spectral, T> const& f__,
-                      Spheric_function<function_domain_t::spatial, T>& g__)
+inline void
+transform(SHT const& sht__, Spheric_function<function_domain_t::spectral, T> const& f__,
+          Spheric_function<function_domain_t::spatial, T>& g__)
 {
     sht__.backward_transform(f__.angular_domain_size(), &f__(0, 0), f__.radial_grid().num_points(),
                              std::min(sht__.lmmax(), f__.angular_domain_size()), &g__(0, 0));
@@ -515,7 +521,8 @@ inline void transform(SHT const& sht__, Spheric_function<function_domain_t::spec
 
 /// Transform to spatial domain (to r, \theta, \phi coordinates).
 template <typename T>
-inline auto transform(SHT const& sht__, Spheric_function<function_domain_t::spectral, T> const& f__)
+inline auto
+transform(SHT const& sht__, Spheric_function<function_domain_t::spectral, T> const& f__)
 {
     Spheric_function<function_domain_t::spatial, T> g(sht__.num_points(), f__.radial_grid());
     transform(sht__, f__, g);
@@ -523,15 +530,17 @@ inline auto transform(SHT const& sht__, Spheric_function<function_domain_t::spec
 }
 
 template <typename T>
-inline void transform(SHT const& sht__, Spheric_function<function_domain_t::spatial, T> const& f__,
-                      Spheric_function<function_domain_t::spectral, T>& g__)
+inline void
+transform(SHT const& sht__, Spheric_function<function_domain_t::spatial, T> const& f__,
+          Spheric_function<function_domain_t::spectral, T>& g__)
 {
     sht__.forward_transform(&f__(0, 0), f__.radial_grid().num_points(), sht__.lmmax(), sht__.lmmax(), &g__(0, 0));
 }
 
 /// Transform to spectral domain.
 template <typename T>
-inline auto transform(SHT const& sht__, Spheric_function<function_domain_t::spatial, T> const& f__)
+inline auto
+transform(SHT const& sht__, Spheric_function<function_domain_t::spatial, T> const& f__)
 {
     Spheric_function<function_domain_t::spectral, T> g(sht__.lmmax(), f__.radial_grid());
     transform(sht__, f__, g);
@@ -539,7 +548,8 @@ inline auto transform(SHT const& sht__, Spheric_function<function_domain_t::spat
 }
 
 /// Gradient of the function in complex spherical harmonics.
-inline auto gradient(Spheric_function<function_domain_t::spectral, std::complex<double>> const& f)
+inline auto
+gradient(Spheric_function<function_domain_t::spectral, std::complex<double>> const& f)
 {
     Spheric_vector_function<function_domain_t::spectral, std::complex<double>> g(f.angular_domain_size(), f.radial_grid());
     for (int i = 0; i < 3; i++) {
@@ -593,7 +603,8 @@ inline auto gradient(Spheric_function<function_domain_t::spectral, std::complex<
 }
 
 /// Gradient of the function in real spherical harmonics.
-inline auto gradient(Spheric_function<function_domain_t::spectral, double> const& f__)
+inline auto
+gradient(Spheric_function<function_domain_t::spectral, double> const& f__)
 {
     int lmax = utils::lmax(f__.angular_domain_size());
     SHT sht(sddk::device_t::CPU, lmax);
@@ -607,7 +618,8 @@ inline auto gradient(Spheric_function<function_domain_t::spectral, double> const
 }
 
 /// Divergence of the vector function in complex spherical harmonics.
-inline auto divergence(Spheric_vector_function<function_domain_t::spectral, std::complex<double>> const& vf__)
+inline auto
+divergence(Spheric_vector_function<function_domain_t::spectral, std::complex<double>> const& vf__)
 {
     Spheric_function<function_domain_t::spectral, std::complex<double>> g(vf__.angular_domain_size(), vf__.radial_grid());
     g.zero();
@@ -619,7 +631,8 @@ inline auto divergence(Spheric_vector_function<function_domain_t::spectral, std:
     return g;
 }
 
-inline auto divergence(Spheric_vector_function<function_domain_t::spectral, double> const& vf)
+inline auto
+divergence(Spheric_vector_function<function_domain_t::spectral, double> const& vf)
 {
     Spheric_function<function_domain_t::spectral, double> g(vf.angular_domain_size(), vf.radial_grid());
     g.zero();

--- a/src/function3d/spheric_function.hpp
+++ b/src/function3d/spheric_function.hpp
@@ -165,14 +165,14 @@ class Spheric_function: public sddk::mdarray<T, 2>
 
     inline Radial_grid<double> const& radial_grid() const
     {
-        assert(radial_grid_ != nullptr);
+        RTE_ASSERT(radial_grid_ != nullptr);
         return *radial_grid_;
     }
 
     Spline<T> component(int lm__) const
     {
         if (domain_t != function_domain_t::spectral) {
-            TERMINATE("function is not is spectral domain");
+            RTE_THROW("function is not is spectral domain");
         }
 
         Spline<T> s(radial_grid());
@@ -185,7 +185,7 @@ class Spheric_function: public sddk::mdarray<T, 2>
 
     T value(double theta__, double phi__, int jr__, double dr__) const
     {
-        assert(domain_t == function_domain_t::spectral);
+        RTE_ASSERT(domain_t == function_domain_t::spectral);
 
         int lmax = utils::lmax(angular_domain_size_);
         std::vector<T> ylm(angular_domain_size_);
@@ -228,7 +228,7 @@ class Spheric_vector_function : public std::array<Spheric_function<domain_t, T>,
 
     inline Radial_grid<double> const& radial_grid() const
     {
-        assert(radial_grid_ != nullptr);
+        RTE_ASSERT(radial_grid_ != nullptr);
         return *radial_grid_;
     }
 
@@ -241,14 +241,14 @@ class Spheric_vector_function : public std::array<Spheric_function<domain_t, T>,
 /// Multiplication of two functions in spatial domain.
 /** The result of the operation is a scalar function in spatial domain */
 template <typename T>
-inline Spheric_function<function_domain_t::spatial, T> operator*(Spheric_function<function_domain_t::spatial, T> const& a__,
-                                                                 Spheric_function<function_domain_t::spatial, T> const& b__)
+inline auto operator*(Spheric_function<function_domain_t::spatial, T> const& a__,
+                      Spheric_function<function_domain_t::spatial, T> const& b__)
 {
     if (a__.radial_grid().hash() != b__.radial_grid().hash()) {
-        TERMINATE("wrong radial grids");
+        RTE_THROW("wrong radial grids");
     }
     if (a__.angular_domain_size() != b__.angular_domain_size()) {
-        TERMINATE("wrong angular domain sizes");
+        RTE_THROW("wrong angular domain sizes");
     }
 
     Spheric_function<function_domain_t::spatial, T> res(a__.angular_domain_size(), a__.radial_grid());
@@ -265,16 +265,16 @@ inline Spheric_function<function_domain_t::spatial, T> operator*(Spheric_functio
 
 /// Dot product of two gradiensts of real functions in spatial domain.
 /** The result of the operation is the real scalar function in spatial domain */
-inline Spheric_function<function_domain_t::spatial, double> operator*(Spheric_vector_function<function_domain_t::spatial, double> const& f,
-                                                                      Spheric_vector_function<function_domain_t::spatial, double> const& g)
+inline auto operator*(Spheric_vector_function<function_domain_t::spatial, double> const& f,
+                      Spheric_vector_function<function_domain_t::spatial, double> const& g)
 {
     if (f.radial_grid().hash() != g.radial_grid().hash()) {
-        TERMINATE("wrong radial grids");
+        RTE_THROW("wrong radial grids");
     }
 
     for (int x: {0, 1, 2}) {
         if (f[x].angular_domain_size() != g[x].angular_domain_size()) {
-            TERMINATE("wrong number of angular points");
+            RTE_THROW("wrong number of angular points");
         }
     }
 
@@ -295,13 +295,13 @@ inline Spheric_function<function_domain_t::spatial, double> operator*(Spheric_ve
 
 /// Summation of two functions.
 template <function_domain_t domain_t, typename T>
-Spheric_function<domain_t, T> operator+(Spheric_function<domain_t, T> const& a__, Spheric_function<domain_t, T> const& b__)
+auto operator+(Spheric_function<domain_t, T> const& a__, Spheric_function<domain_t, T> const& b__)
 {
     if (a__.radial_grid().hash() != b__.radial_grid().hash()) {
-        TERMINATE("wrong radial grids");
+        RTE_THROW("wrong radial grids");
     }
     if (a__.angular_domain_size() != b__.angular_domain_size()) {
-        TERMINATE("wrong angular domain sizes");
+        RTE_THROW("wrong angular domain sizes");
     }
 
     Spheric_function<domain_t, T> result(a__.angular_domain_size(), a__.radial_grid());
@@ -318,13 +318,13 @@ Spheric_function<domain_t, T> operator+(Spheric_function<domain_t, T> const& a__
 
 /// Subtraction of functions.
 template <function_domain_t domain_t, typename T>
-Spheric_function<domain_t, T> operator-(Spheric_function<domain_t, T> const& a__, Spheric_function<domain_t, T> const& b__)
+auto operator-(Spheric_function<domain_t, T> const& a__, Spheric_function<domain_t, T> const& b__)
 {
     if (a__.radial_grid().hash() != b__.radial_grid().hash()) {
-        TERMINATE("wrong radial grids");
+        RTE_THROW("wrong radial grids");
     }
     if (a__.angular_domain_size() != b__.angular_domain_size()) {
-        TERMINATE("wrong angular domain sizes");
+        RTE_THROW("wrong angular domain sizes");
     }
 
     Spheric_function<domain_t, T> res(a__.angular_domain_size(), a__.radial_grid());
@@ -341,7 +341,7 @@ Spheric_function<domain_t, T> operator-(Spheric_function<domain_t, T> const& a__
 
 /// Multiply function by a scalar.
 template <function_domain_t domain_t, typename T>
-Spheric_function<domain_t, T> operator*(T a__, Spheric_function<domain_t, T> const& b__)
+auto operator*(T a__, Spheric_function<domain_t, T> const& b__)
 {
     Spheric_function<domain_t, T> res(b__.angular_domain_size(), b__.radial_grid());
 
@@ -357,7 +357,7 @@ Spheric_function<domain_t, T> operator*(T a__, Spheric_function<domain_t, T> con
 }
 /// Multiply function by a scalar (inverse order).
 template <function_domain_t domain_t, typename T>
-Spheric_function<domain_t, T> operator*(Spheric_function<domain_t, T> const& b__, T a__)
+auto operator*(Spheric_function<domain_t, T> const& b__, T a__)
 {
     return (a__ * b__);
 }
@@ -391,7 +391,7 @@ T inner(Spheric_function<domain_t, T> const& f1, Spheric_function<domain_t, T> c
     \f]
  */
 template <typename T>
-Spheric_function<function_domain_t::spectral, T>
+auto
 laplacian(Spheric_function<function_domain_t::spectral, T> const& f__)
 {
     Spheric_function<function_domain_t::spectral, T> g;
@@ -457,7 +457,7 @@ inline void convert(Spheric_function<function_domain_t::spectral, std::complex<d
 }
 
 /// Convert from Ylm to Rlm representation.
-inline Spheric_function<function_domain_t::spectral, double> convert(Spheric_function<function_domain_t::spectral, std::complex<double>> const& f__)
+inline auto convert(Spheric_function<function_domain_t::spectral, std::complex<double>> const& f__)
 {
     Spheric_function<function_domain_t::spectral, double> g(f__.angular_domain_size(), f__.radial_grid());
     convert(f__, g);
@@ -498,7 +498,7 @@ inline void convert(Spheric_function<function_domain_t::spectral, double> const&
 }
 
 /// Convert from Rlm to Ylm representation.
-inline Spheric_function<function_domain_t::spectral, std::complex<double>> convert(Spheric_function<function_domain_t::spectral, double> const& f__)
+inline auto convert(Spheric_function<function_domain_t::spectral, double> const& f__)
 {
     Spheric_function<function_domain_t::spectral, std::complex<double>> g(f__.angular_domain_size(), f__.radial_grid());
     convert(f__, g);
@@ -515,7 +515,7 @@ inline void transform(SHT const& sht__, Spheric_function<function_domain_t::spec
 
 /// Transform to spatial domain (to r, \theta, \phi coordinates).
 template <typename T>
-inline Spheric_function<function_domain_t::spatial, T> transform(SHT const& sht__, Spheric_function<function_domain_t::spectral, T> const& f__)
+inline auto transform(SHT const& sht__, Spheric_function<function_domain_t::spectral, T> const& f__)
 {
     Spheric_function<function_domain_t::spatial, T> g(sht__.num_points(), f__.radial_grid());
     transform(sht__, f__, g);
@@ -531,7 +531,7 @@ inline void transform(SHT const& sht__, Spheric_function<function_domain_t::spat
 
 /// Transform to spectral domain.
 template <typename T>
-inline Spheric_function<function_domain_t::spectral, T> transform(SHT const& sht__, Spheric_function<function_domain_t::spatial, T> const& f__)
+inline auto transform(SHT const& sht__, Spheric_function<function_domain_t::spatial, T> const& f__)
 {
     Spheric_function<function_domain_t::spectral, T> g(sht__.lmmax(), f__.radial_grid());
     transform(sht__, f__, g);
@@ -539,7 +539,7 @@ inline Spheric_function<function_domain_t::spectral, T> transform(SHT const& sht
 }
 
 /// Gradient of the function in complex spherical harmonics.
-inline Spheric_vector_function<function_domain_t::spectral, std::complex<double>> gradient(Spheric_function<function_domain_t::spectral, std::complex<double>> const& f)
+inline auto gradient(Spheric_function<function_domain_t::spectral, std::complex<double>> const& f)
 {
     Spheric_vector_function<function_domain_t::spectral, std::complex<double>> g(f.angular_domain_size(), f.radial_grid());
     for (int i = 0; i < 3; i++) {
@@ -593,7 +593,7 @@ inline Spheric_vector_function<function_domain_t::spectral, std::complex<double>
 }
 
 /// Gradient of the function in real spherical harmonics.
-inline Spheric_vector_function<function_domain_t::spectral, double> gradient(Spheric_function<function_domain_t::spectral, double> const& f__)
+inline auto gradient(Spheric_function<function_domain_t::spectral, double> const& f__)
 {
     int lmax = utils::lmax(f__.angular_domain_size());
     SHT sht(sddk::device_t::CPU, lmax);
@@ -607,7 +607,7 @@ inline Spheric_vector_function<function_domain_t::spectral, double> gradient(Sph
 }
 
 /// Divergence of the vector function in complex spherical harmonics.
-inline Spheric_function<function_domain_t::spectral, std::complex<double>> divergence(Spheric_vector_function<function_domain_t::spectral, std::complex<double>> const& vf__)
+inline auto divergence(Spheric_vector_function<function_domain_t::spectral, std::complex<double>> const& vf__)
 {
     Spheric_function<function_domain_t::spectral, std::complex<double>> g(vf__.angular_domain_size(), vf__.radial_grid());
     g.zero();
@@ -619,7 +619,7 @@ inline Spheric_function<function_domain_t::spectral, std::complex<double>> diver
     return g;
 }
 
-inline Spheric_function<function_domain_t::spectral, double> divergence(Spheric_vector_function<function_domain_t::spectral, double> const& vf)
+inline auto divergence(Spheric_vector_function<function_domain_t::spectral, double> const& vf)
 {
     Spheric_function<function_domain_t::spectral, double> g(vf.angular_domain_size(), vf.radial_grid());
     g.zero();
@@ -635,4 +635,4 @@ inline Spheric_function<function_domain_t::spectral, double> divergence(Spheric_
 
 } // namespace
 
-#endif // __SPHERIC_FUNCTION_H__
+#endif // __SPHERIC_FUNCTION_HPP__

--- a/src/function3d/spheric_function_set.hpp
+++ b/src/function3d/spheric_function_set.hpp
@@ -1,0 +1,123 @@
+#ifndef __SPHERIC_FUNCTION_SET_HPP__
+#define __SPHERIC_FUNCTION_SET_HPP__
+
+#include "unit_cell/unit_cell.hpp"
+
+namespace sirius {
+
+template <typename T>
+class Spheric_function_set
+{
+  private:
+    /// Pointer to the unit cell
+    Unit_cell const* unit_cell_{nullptr};
+    /// List of atoms for which the spherical expansion is defined.
+    std::vector<int> atoms_;
+    /// Split the number of atoms between MPI ranks.
+    /** If the pointer is not set, set of spheric functions is treated as global, without MPI distribution */
+    sddk::splindex<sddk::splindex_t::block> const* spl_atoms_{nullptr};
+    /// List of spheric functions.
+    std::vector<Spheric_function<function_domain_t::spectral, T>> func_;
+
+    bool all_atoms_{false};
+
+    void init(std::function<int(int)> lmax__)
+    {
+        func_.resize(unit_cell_->num_atoms());
+        if (spl_atoms_) {
+            for (int i = 0; i < spl_atoms_->local_size(); i++) {
+                int ia = atoms_[(*spl_atoms_)[i]];
+                func_[ia] = Spheric_function<function_domain_t::spectral, T>(utils::lmmax(lmax__(ia)),
+                        unit_cell_->atom(ia).radial_grid());
+            }
+        } else {
+            for (int ia : atoms_) {
+                func_[ia] = Spheric_function<function_domain_t::spectral, T>(utils::lmmax(lmax__(ia)),
+                        unit_cell_->atom(ia).radial_grid());
+            }
+        }
+    }
+
+  public:
+    Spheric_function_set()
+    {
+    }
+
+    /// Constructor for all atoms.
+    Spheric_function_set(Unit_cell const& unit_cell__, std::function<int(int)> lmax__,
+            sddk::splindex<sddk::splindex_t::block> const* spl_atoms__ = nullptr)
+        : unit_cell_{&unit_cell__}
+        , spl_atoms_{spl_atoms__}
+        , all_atoms_{true}
+    {
+        atoms_.resize(unit_cell__.num_atoms());
+        std::iota(atoms_.begin(), atoms_.end(), 0);
+        if (spl_atoms_) {
+            if (spl_atoms_->global_index_size() != unit_cell__.num_atoms()) {
+                RTE_THROW("wrong split atom index");
+            }
+        }
+        init(lmax__);
+    }
+
+    /// Constructor for a subset of atoms.
+    Spheric_function_set(Unit_cell const& unit_cell__, std::vector<int> atoms__, std::function<int(int)> lmax__,
+            sddk::splindex<sddk::splindex_t::block> const* spl_atoms__ = nullptr)
+        : unit_cell_{&unit_cell__}
+        , atoms_{atoms__}
+        , spl_atoms_{spl_atoms__}
+        , all_atoms_{false}
+    {
+        if (spl_atoms_) {
+            if (spl_atoms_->global_index_size() != static_cast<int>(atoms__.size())) {
+                RTE_THROW("wrong split atom index");
+            }
+        }
+        init(lmax__);
+    }
+
+    auto const& atoms() const
+    {
+        return atoms_;
+    }
+
+    auto& operator[](int ia__)
+    {
+        return func_[ia__];
+    }
+
+    auto const& operator[](int ia__) const
+    {
+        return func_[ia__];
+    }
+
+    auto const& unit_cell() const
+    {
+        return *unit_cell_;
+    }
+
+    void zero()
+    {
+        for (int ia = 0; ia < unit_cell_->num_atoms(); ia++) {
+            if (func_[ia].size()) {
+                func_[ia].zero();
+            }
+        }
+    }
+
+    /// Synchronize global function.
+    /** Assuming that each MPI rank was handling part of the global spherical function, broadcast data
+     *  from each rank. As a result, each rank stores a full and identical copy of global spherical function. */
+    void sync(sddk::splindex<sddk::splindex_t::block> const& spl_atoms__)
+    {
+        for (int i = 0; i < spl_atoms__.global_index_size(); i++) {
+            auto loc = spl_atoms__.location(i);
+            int ia = atoms_[i];
+            unit_cell_->comm().bcast(func_[ia].at(sddk::memory_t::host), static_cast<int>(func_[ia].size()), loc.rank);
+        }
+    }
+};
+
+}
+
+#endif

--- a/src/mixer/mixer_functions.cpp
+++ b/src/mixer/mixer_functions.cpp
@@ -313,20 +313,20 @@ FunctionProperties<sddk::mdarray<std::complex<double>, 4>> density_function_prop
                                                                 copy_function, axpy_function, rotate_function);
 }
 
-FunctionProperties<paw_density<double>> paw_density_function_property()
+FunctionProperties<PAW_density<double>> paw_density_function_property()
 {
-    auto global_size_func = [](paw_density<double> const& x) -> double
+    auto global_size_func = [](PAW_density<double> const& x) -> double
     {
         return x.unit_cell().num_paw_atoms();
     };
 
-    auto inner_prod_func = [](paw_density<double> const& x, paw_density<double> const& y) -> double
+    auto inner_prod_func = [](PAW_density<double> const& x, PAW_density<double> const& y) -> double
     {
         /* do not contribute to mixing */
         return 0.0;
     };
 
-    auto scale_func = [](double alpha, paw_density<double>& x) -> void
+    auto scale_func = [](double alpha, PAW_density<double>& x) -> void
     {
         for (int i = 0; i < x.unit_cell().spl_num_paw_atoms().local_size(); i++) {
             int ipaw = x.unit_cell().spl_num_paw_atoms(i);
@@ -338,7 +338,7 @@ FunctionProperties<paw_density<double>> paw_density_function_property()
         }
     };
 
-    auto copy_function = [](paw_density<double> const& x, paw_density<double>& y) -> void
+    auto copy_function = [](PAW_density<double> const& x, PAW_density<double>& y) -> void
     {
         for (int i = 0; i < x.unit_cell().spl_num_paw_atoms().local_size(); i++) {
             int ipaw = x.unit_cell().spl_num_paw_atoms(i);
@@ -350,7 +350,7 @@ FunctionProperties<paw_density<double>> paw_density_function_property()
         }
     };
 
-    auto axpy_function = [](double alpha, paw_density<double> const& x, paw_density<double>& y) -> void
+    auto axpy_function = [](double alpha, PAW_density<double> const& x, PAW_density<double>& y) -> void
     {
         for (int i = 0; i < x.unit_cell().spl_num_paw_atoms().local_size(); i++) {
             int ipaw = x.unit_cell().spl_num_paw_atoms(i);
@@ -362,7 +362,7 @@ FunctionProperties<paw_density<double>> paw_density_function_property()
         }
     };
 
-    auto rotate_function = [](double c, double s, paw_density<double>& x, paw_density<double>& y) -> void
+    auto rotate_function = [](double c, double s, PAW_density<double>& x, PAW_density<double>& y) -> void
     {
         for (int i = 0; i < x.unit_cell().spl_num_paw_atoms().local_size(); i++) {
             int ipaw = x.unit_cell().spl_num_paw_atoms(i);
@@ -377,7 +377,7 @@ FunctionProperties<paw_density<double>> paw_density_function_property()
         }
     };
 
-    return FunctionProperties<paw_density<double>>(global_size_func, inner_prod_func, scale_func, copy_function,
+    return FunctionProperties<PAW_density<double>>(global_size_func, inner_prod_func, scale_func, copy_function,
                                            axpy_function, rotate_function);
 }
 

--- a/src/mixer/mixer_functions.hpp
+++ b/src/mixer/mixer_functions.hpp
@@ -41,7 +41,7 @@ FunctionProperties<Periodic_function<double>> periodic_function_property_modifie
 
 FunctionProperties<sddk::mdarray<std::complex<double>, 4>> density_function_property();
 
-FunctionProperties<paw_density> paw_density_function_property();
+FunctionProperties<paw_density<double>> paw_density_function_property();
 
 FunctionProperties<Hubbard_matrix> hubbard_matrix_function_property();
 

--- a/src/mixer/mixer_functions.hpp
+++ b/src/mixer/mixer_functions.hpp
@@ -41,7 +41,7 @@ FunctionProperties<Periodic_function<double>> periodic_function_property_modifie
 
 FunctionProperties<sddk::mdarray<std::complex<double>, 4>> density_function_property();
 
-FunctionProperties<paw_density<double>> paw_density_function_property();
+FunctionProperties<PAW_density<double>> paw_density_function_property();
 
 FunctionProperties<Hubbard_matrix> hubbard_matrix_function_property();
 

--- a/src/mixer/mixer_functions.hpp
+++ b/src/mixer/mixer_functions.hpp
@@ -26,9 +26,9 @@
 #define __MIXER_FUNCTIONS_HPP__
 
 #include "function3d/periodic_function.hpp"
+#include "density/density.hpp"
 #include "SDDK/memory.hpp"
 #include "mixer/mixer.hpp"
-#include "density/paw_density.hpp"
 #include "hubbard/hubbard_matrix.hpp"
 
 namespace sirius {

--- a/src/potential/paw_potential.cpp
+++ b/src/potential/paw_potential.cpp
@@ -96,8 +96,9 @@ void Potential::generate_PAW_effective_potential(Density const& density)
     /* calculate PAW Dij matrix */
     #pragma omp parallel for
     for (int i = 0; i < unit_cell_.spl_num_paw_atoms().local_size(); i++) {
-        int ia = unit_cell_.paw_atom_index(unit_cell_.spl_num_paw_atoms(i));
-        calc_PAW_local_Dij(ia, paw_dij_[i]);
+        int ia_paw = unit_cell_.spl_num_paw_atoms(i);
+        int ia = unit_cell_.paw_atom_index(ia_paw);
+        calc_PAW_local_Dij(ia, paw_dij_[ia_paw]);
     }
     for (int i = 0; i < unit_cell_.num_paw_atoms(); i++) {
         auto location = unit_cell_.spl_num_paw_atoms().location(i);

--- a/src/potential/paw_potential.cpp
+++ b/src/potential/paw_potential.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "potential.hpp"
+#include "symmetry/symmetrize.hpp"
 
 namespace sirius {
 
@@ -41,22 +42,11 @@ void Potential::init_PAW()
 
         auto& atom_type = atom.type();
 
-        int l_max      = 2 * atom_type.indexr().lmax_lo();
-        int lm_max_rho = utils::lmmax(l_max);
-
         paw_potential_data_t ppd;
-
-        ppd.atom_ = &atom;
 
         ppd.ia = ia;
 
         ppd.ia_paw = ia_paw;
-
-        /* allocate potential arrays */
-        for (int i = 0; i < ctx_.num_mag_dims() + 1; i++) {
-            ppd.ae_potential_.push_back(sf(lm_max_rho, ppd.atom_->radial_grid()));
-            ppd.ps_potential_.push_back(sf(lm_max_rho, ppd.atom_->radial_grid()));
-        }
 
         ppd.core_energy_ = atom_type.paw_core_energy();
 
@@ -69,15 +59,15 @@ void Potential::init_PAW()
         max_paw_basis_size_ = std::max(max_paw_basis_size_, bs);
     }
 
+    bool const is_global{true};
+    paw_potential_ = std::make_unique<PAW_field4D<double>>(unit_cell_, is_global);
+
+    paw_exc_ = std::make_unique<Spheric_function_set<double>>(unit_cell_, unit_cell_.paw_atoms(),
+                    [this](int ia){return 2 * this->unit_cell_.atom(ia).type().indexr().lmax();});
+
     /* initialize dij matrix */
     paw_dij_ = sddk::mdarray<double, 4>(max_paw_basis_size_, max_paw_basis_size_, ctx_.num_mag_dims() + 1,
                                   unit_cell_.num_paw_atoms(), sddk::memory_t::host, "paw_dij_");
-
-    /* allocate PAW energy array */
-    paw_hartree_energies_.resize(unit_cell_.num_paw_atoms());
-    paw_xc_energies_.resize(unit_cell_.num_paw_atoms());
-    paw_core_energies_.resize(unit_cell_.num_paw_atoms());
-    paw_one_elec_energies_.resize(unit_cell_.num_paw_atoms());
 }
 
 void Potential::generate_PAW_effective_potential(Density const& density)
@@ -88,25 +78,31 @@ void Potential::generate_PAW_effective_potential(Density const& density)
         return;
     }
 
-    /* zero PAW arrays */
-    std::fill(paw_one_elec_energies_.begin(), paw_one_elec_energies_.end(), 0.0);
-    std::fill(paw_hartree_energies_.begin(), paw_hartree_energies_.end(), 0.0);
-    std::fill(paw_xc_energies_.begin(), paw_xc_energies_.end(), 0.0);
-
     /* zero Dij */
     paw_dij_.zero();
 
+    paw_potential_->zero();
+
     /* calculate xc and hartree for atoms */
     for (int i = 0; i < unit_cell_.spl_num_paw_atoms().local_size(); i++) {
-        calc_PAW_local_potential(paw_potential_data_[i], density.paw_ae_density(i), density.paw_ps_density(i));
+        int ia = unit_cell_.paw_atom_index(unit_cell_.spl_num_paw_atoms(i));
+        calc_PAW_local_potential(ia, paw_potential_data_[i], density.paw_ae_density(ia), density.paw_ps_density(ia));
     }
+
+    paw_potential_->sync();
+    std::vector<Spheric_function_set<double>*> ae_comp;
+    std::vector<Spheric_function_set<double>*> ps_comp;
+    for (int j = 0; j < ctx_.num_mag_dims() + 1; j++) {
+        ae_comp.push_back(&paw_potential_->ae_component(j));
+        ps_comp.push_back(&paw_potential_->ps_component(j));
+    }
+    sirius::symmetrize(unit_cell_.symmetry(), unit_cell_.comm(), ctx_.num_mag_dims(), ae_comp);
+    sirius::symmetrize(unit_cell_.symmetry(), unit_cell_.comm(), ctx_.num_mag_dims(), ps_comp);
 
     /* calculate PAW Dij matrix */
     #pragma omp parallel for
     for (int i = 0; i < unit_cell_.spl_num_paw_atoms().local_size(); i++) {
         calc_PAW_local_Dij(paw_potential_data_[i], paw_dij_);
-
-        //calc_PAW_one_elec_energy(paw_potential_data_[i], density.density_matrix(), paw_dij_);
     }
 
     // collect Dij and add to atom d_mtrx
@@ -126,7 +122,6 @@ void Potential::generate_PAW_effective_potential(Density const& density)
     for (int ia = 0; ia < unit_cell_.spl_num_paw_atoms().local_size(); ia++) {
         energies[0] += paw_potential_data_[ia].hartree_energy_;
         energies[1] += paw_potential_data_[ia].xc_energy_;
-        //energies[2] += paw_potential_data_[ia].one_elec_energy_;
         energies[3] += paw_potential_data_[ia].core_energy_; // it is light operation
     }
 
@@ -134,7 +129,6 @@ void Potential::generate_PAW_effective_potential(Density const& density)
 
     paw_hartree_total_energy_ = energies[0];
     paw_xc_total_energy_      = energies[1];
-    //paw_one_elec_energy_      = energies[2];
     paw_total_core_energy_    = energies[3];
 }
 
@@ -147,7 +141,7 @@ double xc_mt_paw(std::vector<XC_functional> const& xc_func__, int lmax__, int nu
     /* new array to store core and valence densities */
     Flm rho0(lmmax, rgrid__);
 
-    assert(rho0.size(0) == rho__[0]->size(0));
+    RTE_ASSERT(rho0.size(0) == rho__[0]->size(0));
 
     rho0.zero();
     rho0 += (*rho__[0]);
@@ -176,66 +170,44 @@ double xc_mt_paw(std::vector<XC_functional> const& xc_func__, int lmax__, int nu
     return inner(exclm, rho0);
 }
 
-double Potential::calc_PAW_hartree_potential(Atom& atom, sf const& full_density, sf& full_potential)
+double Potential::calc_PAW_hartree_potential(Atom& atom__, Flm const& rho__, Flm& v_tot__)
 {
-    int lmsize_rho = static_cast<int>(full_density.size(0));
+    auto lmmax = rho__.angular_domain_size();
 
-    auto& grid = full_density.radial_grid();
+    auto& grid = rho__.radial_grid();
 
     /* array passed to poisson solver */
-    Spheric_function<function_domain_t::spectral, double> atom_pot_sf(lmsize_rho, grid);
-    atom_pot_sf.zero();
+    Flm v_ha(lmmax, grid);
+    v_ha.zero();
 
-    poisson_vmt<true>(atom, full_density, atom_pot_sf);
+    poisson_vmt<true>(atom__, rho__, v_ha);
 
     /* add hartree contribution */
-    full_potential += atom_pot_sf;
+    v_tot__ += v_ha;
 
-    /* calculate energy */
-
-    auto l_by_lm = utils::l_by_lm(utils::lmax(lmsize_rho));
-
-    /* create array for integration */
-    std::vector<double> intdata(grid.num_points(), 0);
-
-    double hartree_energy{0};
-
-    for (int lm = 0; lm < lmsize_rho; lm++) {
-        /* fill data to integrate */
-        for (int irad = 0; irad < grid.num_points(); irad++) {
-            intdata[irad] = full_density(lm, irad) * full_potential(lm, irad) * grid[irad] * grid[irad];
-        }
-
-        /* create spline from the data */
-        Spline<double> h_spl(grid, intdata);
-        hartree_energy += 0.5 * h_spl.integrate(0);
-    }
-
-    return hartree_energy;
+    return 0.5 * inner(rho__, v_ha);
 }
 
-void Potential::calc_PAW_local_potential(paw_potential_data_t& ppd,
+void Potential::calc_PAW_local_potential(int ia, paw_potential_data_t& ppd,
     std::vector<Spheric_function<function_domain_t::spectral, double> const*> ae_density,
     std::vector<Spheric_function<function_domain_t::spectral, double> const*> ps_density)
 {
-    /* calculation of Hartree potential */
-    for (int i = 0; i < ctx_.num_mag_dims() + 1; i++) {
-        ppd.ae_potential_[i].zero();
-        ppd.ps_potential_[i].zero();
-    }
+    auto& atom = unit_cell_.atom(ia);
 
-    double ae_hartree_energy = calc_PAW_hartree_potential(*ppd.atom_, *ae_density[0], ppd.ae_potential_[0]);
+    double ae_hartree_energy = calc_PAW_hartree_potential(atom, *ae_density[0],
+            paw_potential_->ae_component(0)[ia]);
 
-    double ps_hartree_energy = calc_PAW_hartree_potential(*ppd.atom_, *ps_density[0], ppd.ps_potential_[0]);
+    double ps_hartree_energy = calc_PAW_hartree_potential(atom, *ps_density[0],
+            paw_potential_->ps_component(0)[ia]);
 
     ppd.hartree_energy_ = ae_hartree_energy - ps_hartree_energy;
 
     /* calculation of XC potential */
-    auto& ps_core = ppd.atom_->type().ps_core_charge_density();
-    auto& ae_core = ppd.atom_->type().paw_ae_core_charge_density();
+    auto& ps_core = atom.type().ps_core_charge_density();
+    auto& ae_core = atom.type().paw_ae_core_charge_density();
 
-    auto& rgrid = ppd.atom_->type().radial_grid();
-    int l_max = 2 * ppd.atom_->type().indexr().lmax_lo();
+    auto& rgrid = atom.type().radial_grid();
+    int l_max = 2 * atom.type().indexr().lmax_lo();
 
     std::vector<Flm> vxc;
     for (int j = 0; j < ctx_.num_mag_dims() + 1; j++) {
@@ -245,14 +217,14 @@ void Potential::calc_PAW_local_potential(paw_potential_data_t& ppd,
     auto ae_xc_energy = sirius::xc_mt_paw(xc_func_, l_max, ctx_.num_mag_dims(), *sht_, rgrid, ae_density,
                                           ae_core, vxc);
     for (int i = 0; i < ctx_.num_mag_dims() + 1; i++) {
-        ppd.ae_potential_[i] += vxc[i];
+        paw_potential_->ae_component(i)[ia] += vxc[i];
     }
 
     auto ps_xc_energy = sirius::xc_mt_paw(xc_func_, l_max, ctx_.num_mag_dims(), *sht_, rgrid, ps_density,
                                           ps_core, vxc);
 
     for (int i = 0; i < ctx_.num_mag_dims() + 1; i++) {
-        ppd.ps_potential_[i] += vxc[i];
+        paw_potential_->ps_component(i)[ia] += vxc[i];
     }
 
     /* save xc energy in pdd structure */
@@ -262,39 +234,41 @@ void Potential::calc_PAW_local_potential(paw_potential_data_t& ppd,
 void Potential::calc_PAW_local_Dij(paw_potential_data_t& pdd, sddk::mdarray<double, 4>& paw_dij)
 {
     int paw_ind = pdd.ia_paw;
+    int ia = unit_cell_.paw_atom_index(paw_ind);
 
-    auto& atom_type = pdd.atom_->type();
+    auto& atom = unit_cell_.atom(ia);
+
+    auto& atom_type = atom.type();
 
     auto& paw_ae_wfs = atom_type.ae_paw_wfs_array();
     auto& paw_ps_wfs = atom_type.ps_paw_wfs_array();
 
     /* get lm size for density */
-    int lmax       = atom_type.indexr().lmax_lo();
-    int lmsize_rho = utils::lmmax(2 * lmax);
+    int lmax  = atom_type.indexr().lmax();
+    int lmmax = utils::lmmax(2 * lmax);
 
     auto l_by_lm = utils::l_by_lm(2 * lmax);
 
     Gaunt_coefficients<double> GC(lmax, 2 * lmax, lmax, SHT::gaunt_rrr);
 
+    auto nbrf = atom_type.num_beta_radial_functions();
+
     /* store integrals here */
-    sddk::mdarray<double, 3> integrals(
-        lmsize_rho, atom_type.num_beta_radial_functions() * (atom_type.num_beta_radial_functions() + 1) / 2,
-        ctx_.num_mag_dims() + 1);
+    sddk::mdarray<double, 3> integrals(lmmax, nbrf * (nbrf + 1) / 2, ctx_.num_mag_dims() + 1);
 
     auto& rgrid = atom_type.radial_grid();
 
     for (int imagn = 0; imagn < ctx_.num_mag_dims() + 1; imagn++) {
-        auto& ae_atom_pot = pdd.ae_potential_[imagn];
-        auto& ps_atom_pot = pdd.ps_potential_[imagn];
+        auto& ae_atom_pot = paw_potential_->ae_component(imagn)[ia];
+        auto& ps_atom_pot = paw_potential_->ps_component(imagn)[ia];
 
-        for (int irb2 = 0; irb2 < atom_type.num_beta_radial_functions(); irb2++) {
+        for (int irb2 = 0; irb2 < nbrf; irb2++) {
             for (int irb1 = 0; irb1 <= irb2; irb1++) {
-                int iqij = (irb2 * (irb2 + 1)) / 2 + irb1;
 
                 /* create array for integration */
                 std::vector<double> intdata(rgrid.num_points());
 
-                for (int lm3 = 0; lm3 < lmsize_rho; lm3++) {
+                for (int lm3 = 0; lm3 < lmmax; lm3++) {
                     /* fill array */
                     for (int irad = 0; irad < rgrid.num_points(); irad++) {
                         double ae_part = paw_ae_wfs(irad, irb1) * paw_ae_wfs(irad, irb2);
@@ -304,11 +278,8 @@ void Potential::calc_PAW_local_Dij(paw_potential_data_t& pdd, sddk::mdarray<doub
                         intdata[irad] = ae_atom_pot(lm3, irad) * ae_part - ps_atom_pot(lm3, irad) * ps_part;
                     }
 
-                    /* create spline from data arrays */
-                    Spline<double> dij_spl(rgrid, intdata);
-
                     /* integrate */
-                    integrals(lm3, iqij, imagn) = dij_spl.integrate(0);
+                    integrals(lm3, utils::packed_index(irb1, irb2), imagn) = Spline<double>(rgrid, intdata).integrate(0);
                 }
             }
         }
@@ -327,7 +298,7 @@ void Potential::calc_PAW_local_Dij(paw_potential_data_t& pdd, sddk::mdarray<doub
             int irb2 = atom_type.indexb(ib2).idxrf;
 
             /* common index */
-            int iqij = (irb2 * (irb2 + 1)) / 2 + irb1;
+            int iqij = utils::packed_index(irb1, irb2);
 
             /* get num of non-zero GC */
             int num_non_zero_gk = GC.num_gaunt(lm1, lm2);
@@ -358,8 +329,10 @@ double Potential::calc_PAW_one_elec_energy(paw_potential_data_t const& pdd,
 
     std::complex<double> energy = 0.0;
 
-    for (int ib2 = 0; ib2 < pdd.atom_->mt_lo_basis_size(); ib2++) {
-        for (int ib1 = 0; ib1 < pdd.atom_->mt_lo_basis_size(); ib1++) {
+    auto& atom = unit_cell_.atom(ia);
+
+    for (int ib2 = 0; ib2 < atom.mt_lo_basis_size(); ib2++) {
+        for (int ib1 = 0; ib1 < atom.mt_lo_basis_size(); ib1++) {
             double dm[4] = {0, 0, 0, 0};
             switch (ctx_.num_mag_dims()) {
                 case 3: {
@@ -376,7 +349,7 @@ double Potential::calc_PAW_one_elec_energy(paw_potential_data_t const& pdd,
                     break;
                 }
                 default: {
-                    TERMINATE("calc_PAW_one_elec_energy FATAL ERROR!");
+                    RTE_THROW("calc_PAW_one_elec_energy FATAL ERROR!");
                     break;
                 }
             }
@@ -389,7 +362,7 @@ double Potential::calc_PAW_one_elec_energy(paw_potential_data_t const& pdd,
     if (std::abs(energy.imag()) > 1e-10) {
         std::stringstream s;
         s << "PAW energy is not real: " << energy;
-        TERMINATE(s.str());
+        RTE_THROW(s.str());
     }
 
     return energy.real();

--- a/src/potential/potential.hpp
+++ b/src/potential/potential.hpp
@@ -124,7 +124,7 @@ class Potential : public Field4D
         int ia_paw{-1};
 
         double hartree_energy_{0.0};
-        double xc_energy_{0.0};
+        //double xc_energy_{0.0};
         double core_energy_{0.0};
     };
 
@@ -670,15 +670,6 @@ class Potential : public Field4D
 
     void generate_PAW_effective_potential(Density const& density);
 
-    //double PAW_hartree_total_energy() const
-    //{
-    //    return paw_hartree_total_energy_;
-    //}
-
-    //double PAW_xc_total_energy() const
-    //{
-    //    return paw_xc_total_energy_;
-    //}
     double PAW_xc_total_energy(Density const& density__) const
     {
         if (!unit_cell_.num_paw_atoms()) {
@@ -711,11 +702,6 @@ class Potential : public Field4D
         return inner(*paw_ae_exc_, density__.paw_density().ae_component(0)) -
             inner(*paw_ps_exc_, density__.paw_density().ps_component(0)) + ecore;
     }
-
-    //double PAW_total_core_energy() const
-    //{
-    //    return paw_total_core_energy_;
-    //}
 
     double PAW_total_energy(Density const& density__) const
     {

--- a/src/potential/potential.hpp
+++ b/src/potential/potential.hpp
@@ -670,24 +670,29 @@ class Potential : public Field4D
 
     void generate_PAW_effective_potential(Density const& density);
 
-    double PAW_hartree_total_energy() const
+    //double PAW_hartree_total_energy() const
+    //{
+    //    return paw_hartree_total_energy_;
+    //}
+
+    //double PAW_xc_total_energy() const
+    //{
+    //    return paw_xc_total_energy_;
+    //}
+    double PAW_xc_total_energy(Density const& density__) const
     {
-        return paw_hartree_total_energy_;
+        return inner(*paw_ae_exc_, density__.paw_density().ae_component(0)) -
+            inner(*paw_ps_exc_, density__.paw_density().ps_component(0));
     }
 
-    double PAW_xc_total_energy() const
-    {
-        return paw_xc_total_energy_;
-    }
+    //double PAW_total_core_energy() const
+    //{
+    //    return paw_total_core_energy_;
+    //}
 
-    double PAW_total_core_energy() const
+    double PAW_total_energy(Density const& density__) const
     {
-        return paw_total_core_energy_;
-    }
-
-    double PAW_total_energy() const
-    {
-        return paw_hartree_total_energy_ + paw_xc_total_energy_;
+        return paw_hartree_total_energy_ + PAW_xc_total_energy(density__);
     }
 
     double PAW_one_elec_energy(Density const& density__) const

--- a/src/potential/potential.hpp
+++ b/src/potential/potential.hpp
@@ -48,7 +48,6 @@ double density_residual_hartree_energy(Density const& rho1__, Density const& rho
 class Potential : public Field4D
 {
   private:
-
     /// Alias to unit cell.
     Unit_cell& unit_cell_;
 
@@ -125,12 +124,12 @@ class Potential : public Field4D
 
         double hartree_energy_{0.0};
         //double xc_energy_{0.0};
-        double core_energy_{0.0};
+        //double core_energy_{0.0};
     };
 
     double paw_hartree_total_energy_{0.0};
-    double paw_xc_total_energy_{0.0};
-    double paw_total_core_energy_{0.0};
+    //double paw_xc_total_energy_{0.0};
+    //double paw_total_core_energy_{0.0};
 
     std::vector<paw_potential_data_t> paw_potential_data_;
 
@@ -147,9 +146,10 @@ class Potential : public Field4D
 
     sddk::mdarray<double, 2> aux_bf_;
 
-    /// Hubbard potential correction.
+    /// Hubbard potential correction operator.
     std::unique_ptr<Hubbard> U_;
 
+    /// Hubbard potential correction matrix.
     Hubbard_matrix hubbard_potential_;
 
     /// Add extra charge to the density.
@@ -162,8 +162,9 @@ class Potential : public Field4D
 
     void init_PAW();
 
-    void calc_PAW_local_potential(int ia, paw_potential_data_t& pdd, std::vector<Flm const*> ae_density,
-                                  std::vector<Flm const*> ps_density);
+    /// Calculate PAW potential for a given atom.
+    /** \return Hartree energy contribution. */
+    double calc_PAW_local_potential(int ia, std::vector<Flm const*> ae_density, std::vector<Flm const*> ps_density);
 
     void calc_PAW_local_Dij(paw_potential_data_t& pdd, sddk::mdarray<double, 4>& paw_dij);
 

--- a/src/potential/potential.hpp
+++ b/src/potential/potential.hpp
@@ -138,7 +138,8 @@ class Potential : public Field4D
     std::unique_ptr<PAW_field4D<double>> paw_potential_;
 
     /// Exchange-correlation energy density of PAW atoms.
-    std::unique_ptr<Spheric_function_set<double>> paw_exc_;
+    std::unique_ptr<Spheric_function_set<double>> paw_ps_exc_;
+    std::unique_ptr<Spheric_function_set<double>> paw_ae_exc_;
 
     sddk::mdarray<double, 4> paw_dij_;
 

--- a/src/symmetry/symmetrize.hpp
+++ b/src/symmetry/symmetrize.hpp
@@ -495,7 +495,8 @@ symmetrize(Crystal_symmetry const& sym__, mpi::Communicator const& comm__, int n
         sht::rotation_matrix(lmax, sym__[i].spg_op.euler_angles, sym__[i].spg_op.proper, rotm);
 
         for (int ialoc = 0; ialoc < spl_atoms.local_size(); ialoc++) {
-            int ia = spl_atoms[ialoc];
+            /* get global index of the atom */
+            int ia = frlm.atoms()[spl_atoms[ialoc]];
             int lmmax_ia = frlm[ia].angular_domain_size();
             int nrmax_ia = frlm.unit_cell().atom(ia).num_mt_points();
             int ja = sym__[i].spg_op.inv_sym_atom[ia];
@@ -506,11 +507,10 @@ symmetrize(Crystal_symmetry const& sym__, mpi::Communicator const& comm__, int n
                     (*frlm__[j])[ja].ld(), &la::constant<double>::zero(),
                     ftmp.at(sddk::memory_t::host, 0, 0, j), ftmp.ld());
             }
-            if (num_mag_dims__ == 0) {
-                for (int ir = 0; ir < nrmax_ia; ir++) {
-                    for (int lm = 0; lm < lmmax_ia; lm++) {
-                        fsym_loc(lm, ir, 0, ialoc) += ftmp(lm, ir, 0);
-                    }
+            /* always symmetrize the scalar component */
+            for (int ir = 0; ir < nrmax_ia; ir++) {
+                for (int lm = 0; lm < lmmax_ia; lm++) {
+                    fsym_loc(lm, ir, 0, ialoc) += ftmp(lm, ir, 0);
                 }
             }
             /* apply S part to [0, 0, z] collinear vector */

--- a/src/symmetry/symmetrize.hpp
+++ b/src/symmetry/symmetrize.hpp
@@ -32,6 +32,7 @@
 #include "sht/sht.hpp"
 #include "utils/profiler.hpp"
 #include "utils/rte.hpp"
+#include "function3d/spheric_function_set.hpp"
 
 namespace sirius {
 
@@ -396,6 +397,168 @@ symmetrize_function(Crystal_symmetry const& sym__, mpi::Communicator const& comm
     comm__.allgather(sbuf, frlm__.at(sddk::memory_t::host), lmmax * nrmax * spl_atoms.local_size(),
                      lmmax * nrmax * spl_atoms.global_offset());
 }
+
+
+///// Symmetrize the set of spheric functions.
+///** frlm must be a global function
+// */
+//inline void
+//symmetrize_function(Crystal_symmetry const& sym__, mpi::Communicator const& comm__, Spheric_function_set<double>& frlm__)
+//{
+//    PROFILE("sirius::symmetrize_function|flm");
+//
+//    int lmmax{0};
+//    for (auto ia : frlm__.atoms()) {
+//        lmmax = std::max(lmmax, frlm__[ia].angular_domain_size());
+//    }
+//    int lmax = utils::lmax(lmmax);
+//
+//    sddk::splindex<sddk::splindex_t::block> spl_atoms(frlm__.atoms().size(), comm__.size(), comm__.rank());
+//
+//    sddk::mdarray<double, 2> rotm(lmmax, lmmax);
+//
+//    sddk::mdarray<double, 3> fsym(lmmax, frlm__.unit_cell().max_num_mt_points(), spl_atoms.local_size());
+//    fsym.zero();
+//
+//    double alpha = 1.0 / double(sym__.size());
+//
+//    for (int i = 0; i < sym__.size(); i++) {
+//        /* full space-group symmetry operation is {R|t} */
+//        int pr    = sym__[i].spg_op.proper;
+//        auto eang = sym__[i].spg_op.euler_angles;
+//        sht::rotation_matrix(lmax, eang, pr, rotm);
+//
+//        for (int ialoc = 0; ialoc < spl_atoms.local_size(); ialoc++) {
+//            int ia = spl_atoms[ialoc];
+//            int lmmax_ia = frlm__[ia].angular_domain_size();
+//            int ja = sym__[i].spg_op.inv_sym_atom[ia];
+//            la::wrap(la::lib_t::blas)
+//                .gemm('N', 'N', lmmax_ia, frlm__.unit_cell().atom(ia).num_mt_points(), lmmax_ia, &alpha,
+//                    rotm.at(sddk::memory_t::host), rotm.ld(),
+//                      frlm__[ja].at(sddk::memory_t::host), frlm__[ja].ld(), &la::constant<double>::one(),
+//                      fsym.at(sddk::memory_t::host, 0, 0, ialoc), fsym.ld());
+//        }
+//    }
+//    double* sbuf = spl_atoms.local_size() ? fsym.at(sddk::memory_t::host) : nullptr;
+//    auto ld = static_cast<int>(fsym.size(0) * fsym.size(1));
+//
+//    sddk::mdarray<double, 3> fsym_glob(lmmax, frlm__.unit_cell().max_num_mt_points(), frlm__.atoms().size(),
+//            sddk::get_memory_pool(sddk::memory_t::host));
+//    comm__.allgather(sbuf, fsym_glob.at(sddk::memory_t::host), ld * spl_atoms.local_size(),
+//            ld * spl_atoms.global_offset());
+//    for (int i = 0; i < static_cast<int>(frlm__.atoms().size()); i++) {
+//        int ia = frlm__.atoms()[i];
+//        for (int ir = 0; ir < frlm__.unit_cell().atom(ia).num_mt_points(); ir++) {
+//            for (int lm = 0; lm < frlm__[ia].angular_domain_size(); lm++) {
+//                frlm__[ia](lm, ir) = fsym_glob(lm, ir, i);
+//            }
+//        }
+//    }
+//}
+
+inline void
+symmetrize(Crystal_symmetry const& sym__, mpi::Communicator const& comm__, int num_mag_dims__,
+        std::vector<Spheric_function_set<double>*> frlm__)
+{
+    PROFILE("sirius::symmetrize_function|flm");
+
+    /* first (scalar) component is always available */
+    auto& frlm = *frlm__[0];
+
+    /* compute maximum lm size */
+    int lmmax{0};
+    for (auto ia : frlm.atoms()) {
+        lmmax = std::max(lmmax, frlm[ia].angular_domain_size());
+    }
+    int lmax = utils::lmax(lmmax);
+
+    /* split atoms between MPI ranks */
+    sddk::splindex<sddk::splindex_t::block> spl_atoms(frlm.atoms().size(), comm__.size(), comm__.rank());
+
+    /* space for real Rlm rotation matrix */
+    sddk::mdarray<double, 2> rotm(lmmax, lmmax);
+
+    /* symmetry-transformed functions */
+    sddk::mdarray<double, 4> fsym_loc(lmmax, frlm.unit_cell().max_num_mt_points(), num_mag_dims__ + 1,
+            spl_atoms.local_size());
+    fsym_loc.zero();
+
+    sddk::mdarray<double, 3> ftmp(lmmax, frlm.unit_cell().max_num_mt_points(), num_mag_dims__ + 1);
+
+    double alpha = 1.0 / sym__.size();
+
+    /* loop over crystal symmetries */
+    for (int i = 0; i < sym__.size(); i++) {
+        /* full space-group symmetry operation is S{R|t} */
+        auto S = sym__[i].spin_rotation;
+        /* compute Rlm rotation matrix */
+        sht::rotation_matrix(lmax, sym__[i].spg_op.euler_angles, sym__[i].spg_op.proper, rotm);
+
+        for (int ialoc = 0; ialoc < spl_atoms.local_size(); ialoc++) {
+            int ia = spl_atoms[ialoc];
+            int lmmax_ia = frlm[ia].angular_domain_size();
+            int nrmax_ia = frlm.unit_cell().atom(ia).num_mt_points();
+            int ja = sym__[i].spg_op.inv_sym_atom[ia];
+            /* apply {R|t} part of symmetry operation to all components */
+            for (int j = 0; j < num_mag_dims__ + 1; j++) {
+                la::wrap(la::lib_t::blas).gemm('N', 'N', lmmax_ia, nrmax_ia, lmmax_ia, &alpha,
+                    rotm.at(sddk::memory_t::host), rotm.ld(), (*frlm__[j])[ja].at(sddk::memory_t::host),
+                    (*frlm__[j])[ja].ld(), &la::constant<double>::zero(),
+                    ftmp.at(sddk::memory_t::host, 0, 0, j), ftmp.ld());
+            }
+            if (num_mag_dims__ == 0) {
+                for (int ir = 0; ir < nrmax_ia; ir++) {
+                    for (int lm = 0; lm < lmmax_ia; lm++) {
+                        fsym_loc(lm, ir, 0, ialoc) += ftmp(lm, ir, 0);
+                    }
+                }
+            }
+            /* apply S part to [0, 0, z] collinear vector */
+            if (num_mag_dims__ == 1) {
+                for (int ir = 0; ir < nrmax_ia; ir++) {
+                    for (int lm = 0; lm < lmmax_ia; lm++) {
+                        fsym_loc(lm, ir, 1, ialoc) += ftmp(lm, ir, 1) * S(2, 2);
+                    }
+                }
+            }
+            /* apply 3x3 S-matrix to [x, y, z] vector */
+            if (num_mag_dims__ == 3) {
+                for (int k : {0, 1, 2}) {
+                    for (int j : {0, 1, 2}) {
+                        for (int ir = 0; ir < nrmax_ia; ir++) {
+                            for (int lm = 0; lm < lmmax_ia; lm++) {
+                                fsym_loc(lm, ir, 1 + k, ialoc) += ftmp(lm, ir, 1 + j) * S(k, j);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /* gather full function */
+    double* sbuf = spl_atoms.local_size() ? fsym_loc.at(sddk::memory_t::host) : nullptr;
+    auto ld = static_cast<int>(fsym_loc.size(0) * fsym_loc.size(1) * fsym_loc.size(2));
+
+    sddk::mdarray<double, 4> fsym_glob(lmmax, frlm.unit_cell().max_num_mt_points(), num_mag_dims__ + 1,
+            frlm.atoms().size());
+
+    comm__.allgather(sbuf, fsym_glob.at(sddk::memory_t::host), ld * spl_atoms.local_size(),
+            ld * spl_atoms.global_offset());
+
+    /* copy back the result */
+    for (int i = 0; i < static_cast<int>(frlm.atoms().size()); i++) {
+        int ia = frlm.atoms()[i];
+        for (int j = 0; j < num_mag_dims__ + 1; j++) {
+            for (int ir = 0; ir < frlm.unit_cell().atom(ia).num_mt_points(); ir++) {
+                for (int lm = 0; lm < frlm[ia].angular_domain_size(); lm++) {
+                    (*frlm__[j])[ia](lm, ir) = fsym_glob(lm, ir, j, i);
+                }
+            }
+        }
+    }
+}
+
 
 inline void
 symmetrize_vector_function(Crystal_symmetry const& sym__, mpi::Communicator const& comm__, sddk::mdarray<double, 3>& vz_rlm__)

--- a/src/unit_cell/unit_cell.hpp
+++ b/src/unit_cell/unit_cell.hpp
@@ -204,6 +204,11 @@ class Unit_cell
         return static_cast<int>(paw_atom_index_.size());
     }
 
+    inline auto const& paw_atoms() const
+    {
+        return paw_atom_index_;
+    }
+
     /// Get split index of PAW atoms.
     inline auto const& spl_num_paw_atoms() const
     {


### PR DESCRIPTION
Introduce a set of spherical functions and symmetrization of the set. The first use case  is the PAW Vxc and Exc functions. Now the potential is computed first, then symmetrized and only then the contribution to total energy is computed. As by-product, the PAW code itself is cleaned up and simplified a little bit.