### PR TITLE
[enhancement] more CI on k8s

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: ['master', 'develop', '!trying', '!staging']
+    branches: ['master', 'develop']
   pull_request:
     branches: ['master', 'develop']
 
@@ -12,208 +12,45 @@ jobs:
     runs-on: ubuntu-latest
     container: electronicstructure/sirius
     env:
-      SPEC_GCC: sirius@develop %gcc +python +tests +apps +vdwxc +scalapack +fortran build_type=RelWithDebInfo ^openblas ^mpich
+      DEVSPEC: sirius@develop %gcc +python +memory_pool +tests +apps +vdwxc +scalapack +fortran build_type=RelWithDebInfo ^openblas ^mpich
     steps:
       - uses: actions/checkout@v2
-      - name: Show the spec
-        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
       - name: Configure SIRIUS
         run: |
+          spack spec -I $DEVSPEC
           cd ${GITHUB_WORKSPACE}
           mkdir build
           cd build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_SCALAPACK=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCREATE_PYTHON_MODULE=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          spack --color always build-env $DEVSPEC -- cmake .. -DUSE_SCALAPACK=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCREATE_PYTHON_MODULE=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - name: Build SIRIUS
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
+          spack --color always build-env $DEVSPEC -- make
       - name: Run unit tests
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- ctest --output-on-failure --label-exclude integration_test
+          spack --color always build-env $DEVSPEC -- ctest --output-on-failure --label-exclude integration_test
       - name: Run verification tests
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- ctest --output-on-failure -L cpu_serial
+          spack --color always build-env $DEVSPEC -- ctest --output-on-failure -L cpu_serial
 
-  build_openmpi:
-    runs-on: ubuntu-latest
-    container: electronicstructure/sirius_openmpi
-    env:
-      SPEC_GCC: "sirius@develop %gcc@12: +python +tests +apps +vdwxc +scalapack +fortran build_type=RelWithDebInfo ^openblas ^openmpi"
-    steps:
-      - uses: actions/checkout@v2
-      - name: Show the spec
-        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
-      - name: Configure SIRIUS
-        run: |
-          cd ${GITHUB_WORKSPACE}
-          mkdir build
-          cd build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_SCALAPACK=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCREATE_PYTHON_MODULE=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - name: Build SIRIUS
-        run: |
-          cd ${GITHUB_WORKSPACE}/build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
-
-          #  build_elpa:
-          #    runs-on: ubuntu-latest
-          #    container: electronicstructure/sirius
-          #    env:
-          #      SPEC_GCC: sirius@develop %gcc +tests +apps +vdwxc +scalapack +elpa +fortran build_type=RelWithDebInfo ^openblas ^mpich
-          #    steps:
-          #      - uses: actions/checkout@v2
-          #      - name: Show the spec
-          #        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
-          #      - name: Configure SIRIUS
-          #        run: |
-          #          cd ${GITHUB_WORKSPACE}
-          #          mkdir build
-          #          cd build
-          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_ELPA=1 -DUSE_SCALAPACK=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-          #      - name: Build SIRIUS
-          #        run: |
-          #          cd ${GITHUB_WORKSPACE}/build
-          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
-
-          #  build_serial:
-          #    runs-on: ubuntu-latest
-          #    container: electronicstructure/sirius
-          #    env:
-          #      SPEC_GCC: sirius@develop %gcc +tests +apps +vdwxc +fortran build_type=RelWithDebInfo ^openblas ^mpich
-          #    steps:
-          #      - uses: actions/checkout@v2
-          #      - name: Show the spec
-          #        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
-          #      - name: Configure SIRIUS
-          #        run: |
-          #          cd ${GITHUB_WORKSPACE}
-          #          mkdir build
-          #          cd build
-          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-          #      - name: Build SIRIUS
-          #        run: |
-          #          cd ${GITHUB_WORKSPACE}/build
-          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
-
-          #  build_cuda:
-          #    runs-on: ubuntu-latest
-          #    container: electronicstructure/sirius
-          #    env:
-          #      SPEC_GCC: sirius@develop %gcc +tests +apps +vdwxc +scalapack +fortran +cuda cuda_arch=60 build_type=RelWithDebInfo ^openblas ^mpich
-          #    steps:
-          #      - uses: actions/checkout@v2
-          #      - name: Show the spec
-          #        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
-          #      - name: Configure SIRIUS
-          #        run: |
-          #          cd ${GITHUB_WORKSPACE}
-          #          mkdir build
-          #          cd build
-          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_SCALAPACK=1 -DUSE_CUDA=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-          #      - name: Build SIRIUS
-          #        run: |
-          #          cd ${GITHUB_WORKSPACE}/build
-          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
-
-          #  build_magma:
-          #    runs-on: ubuntu-latest
-          #    container: electronicstructure/sirius
-          #    env:
-          #      SPEC_GCC: sirius@develop %gcc +tests +apps +vdwxc +scalapack +fortran +magma +cuda cuda_arch=60 build_type=RelWithDebInfo ^openblas ^mpich ^magma +cuda cuda_arch=60
-          #    steps:
-          #      - uses: actions/checkout@v2
-          #      - name: Show the spec
-          #        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
-          #      - name: Configure SIRIUS
-          #        run: |
-          #          cd ${GITHUB_WORKSPACE}
-          #          mkdir build
-          #          cd build
-          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_SCALAPACK=1 -DUSE_MAGMA=1 -DUSE_CUDA=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-          #      - name: Build SIRIUS
-          #        run: |
-          #          cd ${GITHUB_WORKSPACE}/build
-          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
-
-          #  build_cuda_fp32:
-          #    runs-on: ubuntu-latest
-          #    container: electronicstructure/sirius
-          #    env:
-          #      SPEC_GCC: sirius@develop %gcc +tests +apps +vdwxc +scalapack +fortran +cuda cuda_arch=60 +single_precision build_type=RelWithDebInfo ^openblas ^mpich
-          #    steps:
-          #      - uses: actions/checkout@v2
-          #      - name: Show the spec
-          #        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
-          #      - name: Configure SIRIUS
-          #        run: |
-          #          cd ${GITHUB_WORKSPACE}
-          #          mkdir build
-          #          cd build
-          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_SCALAPACK=1 -DUSE_CUDA=1 -DUSE_FP32=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-          #      - name: Build SIRIUS
-          #        run: |
-          #          cd ${GITHUB_WORKSPACE}/build
-          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
-
-  build_nlcglib:
+  build_cuda:
     runs-on: ubuntu-latest
     container: electronicstructure/sirius
     env:
-      SPEC_GCC: sirius@develop %gcc +tests +apps +vdwxc +scalapack +fortran +cuda cuda_arch=60 +nlcglib build_type=RelWithDebInfo ^openblas ^mpich ^nlcglib +cuda +wrapper cuda_arch=60 ^kokkos +wrapper cuda_arch=60
+      DEVSPEC: sirius@develop %gcc +python +cuda +tests +apps +vdwxc +scalapack +fortran build_type=RelWithDebInfo ^openblas ^mpich
     steps:
       - uses: actions/checkout@v2
-      - name: Show the spec
-        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
       - name: Configure SIRIUS
         run: |
+          spack spec -I $DEVSPEC
           cd ${GITHUB_WORKSPACE}
           mkdir build
           cd build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_NLCGLIB=1 -DUSE_SCALAPACK=1 -DUSE_CUDA=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          spack --color always build-env $DEVSPEC -- cmake .. -DUSE_SCALAPACK=1 -DUSE_CUDA=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCREATE_PYTHON_MODULE=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - name: Build SIRIUS
         run: |
           cd ${GITHUB_WORKSPACE}/build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
+          spack --color always build-env $DEVSPEC -- make
 
-  build_clang:
-    runs-on: ubuntu-latest
-    container: electronicstructure/sirius
-    env:
-      SPEC_CLANG: sirius@develop %clang +tests +apps build_type=RelWithDebInfo ^openblas ^mpich ~fortran
-    steps:
-      - uses: actions/checkout@v2
-      - name: Show the spec
-        run: spack --color always -e clang-build-env spec -I $SPEC_CLANG
-      - name: Configure SIRIUS
-        run: |
-          cd ${GITHUB_WORKSPACE}
-          mkdir build
-          cd build
-          spack --color always -e clang-build-env build-env $SPEC_CLANG -- cmake .. -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=0 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - name: Build SIRIUS
-        run: |
-          cd ${GITHUB_WORKSPACE}/build
-          spack --color always -e clang-build-env build-env $SPEC_CLANG -- make
-
-          #  build_rocm:
-          #    runs-on: ubuntu-latest
-          #    container: electronicstructure/sirius_rocm
-          #    env:
-          #      SPEC_ROCM: sirius@develop %gcc build_type=RelWithDebInfo +scalapack +fortran +tests +rocm amdgpu_target=gfx90a ^openblas ^mpich ^spfft+rocm amdgpu_target=gfx90a target=x86_64
-          #    steps:
-          #      - uses: actions/checkout@v2
-          #      - name: Show the spec
-          #        run: |
-          #          spack arch
-          #          spack --color always spec -I $SPEC_ROCM
-          #      - name: Configure SIRIUS
-          #        run: |
-          #          cd ${GITHUB_WORKSPACE}
-          #          mkdir build
-          #          cd build
-          #          spack --color always build-env $SPEC_ROCM -- cmake .. -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DUSE_SCALAPACK=1 -DUSE_ROCM=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-          #      - name: Build SIRIUS
-          #        run: |
-          #          cd ${GITHUB_WORKSPACE}/build
-          #          spack --color always build-env $SPEC_ROCM -- make

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,105 +56,105 @@ jobs:
           cd ${GITHUB_WORKSPACE}/build
           spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
 
-  build_elpa:
-    runs-on: ubuntu-latest
-    container: electronicstructure/sirius
-    env:
-      SPEC_GCC: sirius@develop %gcc +tests +apps +vdwxc +scalapack +elpa +fortran build_type=RelWithDebInfo ^openblas ^mpich
-    steps:
-      - uses: actions/checkout@v2
-      - name: Show the spec
-        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
-      - name: Configure SIRIUS
-        run: |
-          cd ${GITHUB_WORKSPACE}
-          mkdir build
-          cd build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_ELPA=1 -DUSE_SCALAPACK=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - name: Build SIRIUS
-        run: |
-          cd ${GITHUB_WORKSPACE}/build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
+          #  build_elpa:
+          #    runs-on: ubuntu-latest
+          #    container: electronicstructure/sirius
+          #    env:
+          #      SPEC_GCC: sirius@develop %gcc +tests +apps +vdwxc +scalapack +elpa +fortran build_type=RelWithDebInfo ^openblas ^mpich
+          #    steps:
+          #      - uses: actions/checkout@v2
+          #      - name: Show the spec
+          #        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
+          #      - name: Configure SIRIUS
+          #        run: |
+          #          cd ${GITHUB_WORKSPACE}
+          #          mkdir build
+          #          cd build
+          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_ELPA=1 -DUSE_SCALAPACK=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          #      - name: Build SIRIUS
+          #        run: |
+          #          cd ${GITHUB_WORKSPACE}/build
+          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
 
-  build_serial:
-    runs-on: ubuntu-latest
-    container: electronicstructure/sirius
-    env:
-      SPEC_GCC: sirius@develop %gcc +tests +apps +vdwxc +fortran build_type=RelWithDebInfo ^openblas ^mpich
-    steps:
-      - uses: actions/checkout@v2
-      - name: Show the spec
-        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
-      - name: Configure SIRIUS
-        run: |
-          cd ${GITHUB_WORKSPACE}
-          mkdir build
-          cd build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - name: Build SIRIUS
-        run: |
-          cd ${GITHUB_WORKSPACE}/build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
+          #  build_serial:
+          #    runs-on: ubuntu-latest
+          #    container: electronicstructure/sirius
+          #    env:
+          #      SPEC_GCC: sirius@develop %gcc +tests +apps +vdwxc +fortran build_type=RelWithDebInfo ^openblas ^mpich
+          #    steps:
+          #      - uses: actions/checkout@v2
+          #      - name: Show the spec
+          #        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
+          #      - name: Configure SIRIUS
+          #        run: |
+          #          cd ${GITHUB_WORKSPACE}
+          #          mkdir build
+          #          cd build
+          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          #      - name: Build SIRIUS
+          #        run: |
+          #          cd ${GITHUB_WORKSPACE}/build
+          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
 
-  build_cuda:
-    runs-on: ubuntu-latest
-    container: electronicstructure/sirius
-    env:
-      SPEC_GCC: sirius@develop %gcc +tests +apps +vdwxc +scalapack +fortran +cuda cuda_arch=60 build_type=RelWithDebInfo ^openblas ^mpich
-    steps:
-      - uses: actions/checkout@v2
-      - name: Show the spec
-        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
-      - name: Configure SIRIUS
-        run: |
-          cd ${GITHUB_WORKSPACE}
-          mkdir build
-          cd build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_SCALAPACK=1 -DUSE_CUDA=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - name: Build SIRIUS
-        run: |
-          cd ${GITHUB_WORKSPACE}/build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
+          #  build_cuda:
+          #    runs-on: ubuntu-latest
+          #    container: electronicstructure/sirius
+          #    env:
+          #      SPEC_GCC: sirius@develop %gcc +tests +apps +vdwxc +scalapack +fortran +cuda cuda_arch=60 build_type=RelWithDebInfo ^openblas ^mpich
+          #    steps:
+          #      - uses: actions/checkout@v2
+          #      - name: Show the spec
+          #        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
+          #      - name: Configure SIRIUS
+          #        run: |
+          #          cd ${GITHUB_WORKSPACE}
+          #          mkdir build
+          #          cd build
+          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_SCALAPACK=1 -DUSE_CUDA=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          #      - name: Build SIRIUS
+          #        run: |
+          #          cd ${GITHUB_WORKSPACE}/build
+          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
 
-  build_magma:
-    runs-on: ubuntu-latest
-    container: electronicstructure/sirius
-    env:
-      SPEC_GCC: sirius@develop %gcc +tests +apps +vdwxc +scalapack +fortran +magma +cuda cuda_arch=60 build_type=RelWithDebInfo ^openblas ^mpich ^magma +cuda cuda_arch=60
-    steps:
-      - uses: actions/checkout@v2
-      - name: Show the spec
-        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
-      - name: Configure SIRIUS
-        run: |
-          cd ${GITHUB_WORKSPACE}
-          mkdir build
-          cd build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_SCALAPACK=1 -DUSE_MAGMA=1 -DUSE_CUDA=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - name: Build SIRIUS
-        run: |
-          cd ${GITHUB_WORKSPACE}/build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
+          #  build_magma:
+          #    runs-on: ubuntu-latest
+          #    container: electronicstructure/sirius
+          #    env:
+          #      SPEC_GCC: sirius@develop %gcc +tests +apps +vdwxc +scalapack +fortran +magma +cuda cuda_arch=60 build_type=RelWithDebInfo ^openblas ^mpich ^magma +cuda cuda_arch=60
+          #    steps:
+          #      - uses: actions/checkout@v2
+          #      - name: Show the spec
+          #        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
+          #      - name: Configure SIRIUS
+          #        run: |
+          #          cd ${GITHUB_WORKSPACE}
+          #          mkdir build
+          #          cd build
+          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_SCALAPACK=1 -DUSE_MAGMA=1 -DUSE_CUDA=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          #      - name: Build SIRIUS
+          #        run: |
+          #          cd ${GITHUB_WORKSPACE}/build
+          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
 
-  build_cuda_fp32:
-    runs-on: ubuntu-latest
-    container: electronicstructure/sirius
-    env:
-      SPEC_GCC: sirius@develop %gcc +tests +apps +vdwxc +scalapack +fortran +cuda cuda_arch=60 +single_precision build_type=RelWithDebInfo ^openblas ^mpich
-    steps:
-      - uses: actions/checkout@v2
-      - name: Show the spec
-        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
-      - name: Configure SIRIUS
-        run: |
-          cd ${GITHUB_WORKSPACE}
-          mkdir build
-          cd build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_SCALAPACK=1 -DUSE_CUDA=1 -DUSE_FP32=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - name: Build SIRIUS
-        run: |
-          cd ${GITHUB_WORKSPACE}/build
-          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
+          #  build_cuda_fp32:
+          #    runs-on: ubuntu-latest
+          #    container: electronicstructure/sirius
+          #    env:
+          #      SPEC_GCC: sirius@develop %gcc +tests +apps +vdwxc +scalapack +fortran +cuda cuda_arch=60 +single_precision build_type=RelWithDebInfo ^openblas ^mpich
+          #    steps:
+          #      - uses: actions/checkout@v2
+          #      - name: Show the spec
+          #        run: spack --color always -e gcc-build-env spec -I $SPEC_GCC
+          #      - name: Configure SIRIUS
+          #        run: |
+          #          cd ${GITHUB_WORKSPACE}
+          #          mkdir build
+          #          cd build
+          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- cmake .. -DUSE_SCALAPACK=1 -DUSE_CUDA=1 -DUSE_FP32=1 -DUSE_VDWXC=1 -DBUILD_TESTING=1 -DCREATE_FORTRAN_BINDINGS=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo
+          #      - name: Build SIRIUS
+          #        run: |
+          #          cd ${GITHUB_WORKSPACE}/build
+          #          spack --color always -e gcc-build-env build-env $SPEC_GCC -- make
 
   build_nlcglib:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ project(SIRIUS
   VERSION 7.4.4
   LANGUAGES CXX C)
 
+# for CUDA_ARCHITECTURES
+if(POLICY CMP0104)
+  cmake_policy(SET CMP0104 NEW)
+endif()
+
 # user variables
 
 option(CREATE_PYTHON_MODULE    "create sirius Python module" OFF)
@@ -47,7 +52,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CUDA_STANDARD 14)
 
 if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
-  set(CMAKE_CUDA_ARCHITECTURES "60;70;80")
+  set(CMAKE_CUDA_ARCHITECTURES "60;70;80" CACHE STRING "CUDA architectures to generate code for")
 endif()
 
 # This ensures that -std=c++14 is passed to nvcc. See
@@ -205,7 +210,6 @@ if(USE_CUDA)
   # sirius::cuda_libs target is also defined there
   include(cmake/cudalibs_target.cmake)
   message(STATUS "CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES}")
-  message(STATUS "CUDA_ARCHITECTURES ${CUDA_ARCHITECTURES}")
 endif(USE_CUDA)
 
 if(USE_ROCM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,6 +204,8 @@ if(USE_CUDA)
   # note find cudatoolkit is called inside the include file. the
   # sirius::cuda_libs target is also defined there
   include(cmake/cudalibs_target.cmake)
+  message(STATUS "CMAKE_CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES}")
+  message(STATUS "CUDA_ARCHITECTURES ${CUDA_ARCHITECTURES}")
 endif(USE_CUDA)
 
 if(USE_ROCM)

--- a/ci/baseimage.cuda.Dockerfile
+++ b/ci/baseimage.cuda.Dockerfile
@@ -64,15 +64,17 @@ RUN spack install libvdwxc %gcc +mpi ^mpich@${MPICH_VERSION}
 
 RUN spack install magma %gcc +cuda ^openblas
 
+RUN spack install nlcglib %gcc +cuda+wrapper ^kokkos+wrapper
+
 # for the MPI hook
 RUN echo $(spack find --format='{prefix.lib}' mpich) > /etc/ld.so.conf.d/mpich.conf
 RUN ldconfig
 
-ENV SPEC="sirius@develop %gcc build_type=Release +python +fortran +elpa +tests +scalapack +vdwxc +cuda +nlcglib ^mpich@${MPICH_VERSION} ^intel-oneapi-mkl+cluster ^spfft+single_precision+cuda ^elpa+cuda ^nlcglib+cuda+wrapper ^kokkos+wrapper"
+ENV SPEC="sirius@develop %gcc build_type=Release +python +fortran +elpa +tests +scalapack +vdwxc +cuda ^mpich@${MPICH_VERSION} ^intel-oneapi-mkl+cluster ^spfft+single_precision+cuda ^elpa+cuda"
 
 # install all dependencies
 RUN spack install --only=dependencies $SPEC
 
-ENV SPEC_CLANG="sirius@develop %clang build_type=Release ~fortran +tests ^openblas ^mpich^mpich@${MPICH_VERSION} ^spfft+single_precision"
+ENV SPEC_CLANG="sirius@develop %clang build_type=Release ~fortran +tests ^openblas ^mpich@${MPICH_VERSION} ^spfft+single_precision"
 
 RUN spack install --only=dependencies $SPEC_CLANG

--- a/ci/baseimage.cuda.Dockerfile
+++ b/ci/baseimage.cuda.Dockerfile
@@ -57,16 +57,18 @@ RUN spack install --only=dependencies openmpi %gcc
 RUN spack install openmpi %gcc
 
 # install openblas
-RUN spack install openblas+fortran %gcc
+RUN spack install openblas %gcc +fortran
 
 # install libvdwxc
-RUN spack install libvdwxc+mpi %gcc ^mpich@${MPICH_VERSION}
+RUN spack install libvdwxc %gcc +mpi ^mpich@${MPICH_VERSION}
+
+RUN spack install magma %gcc +cuda ^openblas
 
 # for the MPI hook
 RUN echo $(spack find --format='{prefix.lib}' mpich) > /etc/ld.so.conf.d/mpich.conf
 RUN ldconfig
 
-ENV SPEC="sirius@develop %gcc build_type=Release +python +fortran +elpa +tests +scalapack +vdwxc +cuda +nlcglib +magma ^mpich@${MPICH_VERSION} ^intel-oneapi-mkl+cluster ^spfft+single_precision+cuda ^elpa+cuda ^nlcglib+cuda+wrapper ^kokkos+wrapper ^magma+cuda"
+ENV SPEC="sirius@develop %gcc build_type=Release +python +fortran +elpa +tests +scalapack +vdwxc +cuda +nlcglib ^mpich@${MPICH_VERSION} ^intel-oneapi-mkl+cluster ^spfft+single_precision+cuda ^elpa+cuda ^nlcglib+cuda+wrapper ^kokkos+wrapper"
 
 # install all dependencies
 RUN spack install --only=dependencies $SPEC

--- a/ci/baseimage.cuda.Dockerfile
+++ b/ci/baseimage.cuda.Dockerfile
@@ -78,7 +78,7 @@ RUN spack install --only=dependencies --fail-fast \
 
 # gcc + nlcg/openblas/CUDA
 RUN spack install --only=dependencies --fail-fast \
-  "sirius@develop %gcc build_type=Release +fortran +tests +cuda +nlcglib ^mpich@${MPICH_VERSION} ^openblas ^spfft+cuda"
+  "sirius@develop %gcc build_type=Release +fortran +tests +cuda +nlcglib +vdwxc ^mpich@${MPICH_VERSION} ^openblas ^spfft+cuda ^nlcglib +cuda +wrapper ^kokkos+wrapper"
 
 # gcc + openmpi/elpa/scalapack/CUDA/MAGMA
 RUN spack install --only=dependencies --fail-fast \

--- a/ci/baseimage.cuda.Dockerfile
+++ b/ci/baseimage.cuda.Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -y apt-utils
 
 # install basic tools
 RUN apt-get install -y --no-install-recommends gcc g++ gfortran clang libomp-14-dev git make unzip file \
-  vim wget pkg-config python3-pip curl tcl m4 cpio automake xz-utils patch \
+  vim wget pkg-config python3-pip python3-dev curl tcl m4 cpio automake xz-utils patch \
   apt-transport-https ca-certificates gnupg software-properties-common perl tar bzip2
 
 # install CMake

--- a/ci/baseimage.cuda.Dockerfile
+++ b/ci/baseimage.cuda.Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -y apt-utils
 
 # install basic tools
 RUN apt-get install -y --no-install-recommends gcc g++ gfortran clang libomp-14-dev git make unzip file \
-  vim wget pkg-config python3-pip python3-dev curl tcl m4 cpio automake autotools meson xz-utils patch patchelf \
+  vim wget pkg-config python3-pip python3-dev curl tcl m4 cpio automake meson xz-utils patch patchelf \
   apt-transport-https ca-certificates gnupg software-properties-common perl tar bzip2
 
 # install CMake

--- a/ci/baseimage.cuda.Dockerfile
+++ b/ci/baseimage.cuda.Dockerfile
@@ -56,7 +56,7 @@ RUN spack install mpich@${MPICH_VERSION} %gcc
 RUN echo $(spack find --format='{prefix.lib}' mpich) > /etc/ld.so.conf.d/mpich.conf
 RUN ldconfig
 
-ENV SPEC="sirius@develop %gcc build_type=Release +fortran +elpa +tests +scalapack +cuda ^mpich@${MPICH_VERSION} ^intel-oneapi-mkl+cluster ^spfft+single_precision+cuda ^elpa+cuda"
+ENV SPEC="sirius@develop %gcc build_type=Release +python +fortran +elpa +tests +scalapack +vdwxc +cuda +nlcglib +magma ^mpich@${MPICH_VERSION} ^intel-oneapi-mkl+cluster ^spfft+single_precision+cuda ^elpa+cuda ^nlcglib+cuda+wrapper ^kokkos+wrapper ^magma+cuda"
 
 # install all dependencies
 RUN spack install --only=dependencies $SPEC

--- a/ci/baseimage.cuda.Dockerfile
+++ b/ci/baseimage.cuda.Dockerfile
@@ -62,7 +62,7 @@ RUN spack install openmpi %gcc
 # install openblas
 RUN spack install openblas %gcc +fortran
 
-RUN spack install magma %gcc +cuda ^openblas
+RUN spack install magma %gcc +cuda +fortran ^openblas
 
 RUN spack install nlcglib %gcc +cuda+wrapper ^kokkos@3.7.01+wrapper
 
@@ -78,3 +78,4 @@ RUN spack install --only=dependencies $SPEC
 ENV SPEC_CLANG="sirius@develop %clang build_type=Release ~fortran +tests ^openblas%gcc ^mpich@${MPICH_VERSION} ^spfft+single_precision+cuda"
 
 RUN spack install --only=dependencies $SPEC_CLANG
+RUN spack spec -I $SPEC_CLANG

--- a/ci/baseimage.cuda.Dockerfile
+++ b/ci/baseimage.cuda.Dockerfile
@@ -52,6 +52,16 @@ RUN yq -i '.compilers[0].compiler.paths.f77 = "/usr/bin/gfortran"' /root/.spack/
 RUN spack install --only=dependencies mpich@${MPICH_VERSION} %gcc
 RUN spack install mpich@${MPICH_VERSION} %gcc
 
+# install openmpi
+RUN spack install --only=dependencies openmpi %gcc
+RUN spack install openmpi %gcc
+
+# install openblas
+RUN spack install openblas+fortran %gcc
+
+# install libvdwxc
+RUN spack install libvdwxc+mpi %gcc ^mpich@${MPICH_VERSION}
+
 # for the MPI hook
 RUN echo $(spack find --format='{prefix.lib}' mpich) > /etc/ld.so.conf.d/mpich.conf
 RUN ldconfig

--- a/ci/baseimage.cuda.Dockerfile
+++ b/ci/baseimage.cuda.Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get install -y apt-utils
 
 # install basic tools
 RUN apt-get install -y --no-install-recommends gcc g++ gfortran clang libomp-14-dev git make unzip file \
-  vim wget pkg-config python3-pip python3-dev curl tcl m4 cpio automake xz-utils patch \
+  vim wget pkg-config python3-pip python3-dev curl tcl m4 cpio automake autotools meson xz-utils patch patchelf \
   apt-transport-https ca-certificates gnupg software-properties-common perl tar bzip2
 
 # install CMake
@@ -52,15 +52,15 @@ RUN yq -i '.compilers[0].compiler.paths.f77 = "/usr/bin/gfortran"' /root/.spack/
 RUN spack install --only=dependencies mpich@${MPICH_VERSION} %gcc
 RUN spack install mpich@${MPICH_VERSION} %gcc
 
+# install libvdwxc
+RUN spack install libvdwxc %gcc +mpi ^mpich@${MPICH_VERSION}
+
 # install openmpi
 RUN spack install --only=dependencies openmpi %gcc
 RUN spack install openmpi %gcc
 
 # install openblas
 RUN spack install openblas %gcc +fortran
-
-# install libvdwxc
-RUN spack install libvdwxc %gcc +mpi ^mpich@${MPICH_VERSION}
 
 RUN spack install magma %gcc +cuda ^openblas
 
@@ -70,11 +70,11 @@ RUN spack install nlcglib %gcc +cuda+wrapper ^kokkos+wrapper
 RUN echo $(spack find --format='{prefix.lib}' mpich) > /etc/ld.so.conf.d/mpich.conf
 RUN ldconfig
 
-ENV SPEC="sirius@develop %gcc build_type=Release +python +fortran +elpa +tests +scalapack +vdwxc +cuda ^mpich@${MPICH_VERSION} ^intel-oneapi-mkl+cluster ^spfft+single_precision+cuda ^elpa+cuda"
+ENV SPEC="sirius@develop %gcc build_type=Release +python +fortran +elpa +tests +scalapack +cuda ^mpich@${MPICH_VERSION} ^intel-oneapi-mkl+cluster ^spfft+single_precision+cuda ^elpa+cuda"
 
 # install all dependencies
 RUN spack install --only=dependencies $SPEC
 
-ENV SPEC_CLANG="sirius@develop %clang build_type=Release ~fortran +tests ^openblas ^mpich@${MPICH_VERSION} ^spfft+single_precision"
+ENV SPEC_CLANG="sirius@develop %clang build_type=Release ~fortran +tests ^openblas ^mpich@${MPICH_VERSION} ^spfft+single_precision+cuda"
 
 RUN spack install --only=dependencies $SPEC_CLANG

--- a/ci/baseimage.cuda.Dockerfile
+++ b/ci/baseimage.cuda.Dockerfile
@@ -78,7 +78,7 @@ RUN spack install --only=dependencies --fail-fast \
 
 # gcc + nlcg/openblas/CUDA
 RUN spack install --only=dependencies --fail-fast \
-  "sirius@develop %gcc build_type=Release +fortran +tests +cuda +nlcglib +vdwxc ^mpich@${MPICH_VERSION} ^openblas ^spfft+cuda ^nlcglib +cuda +wrapper ^kokkos+wrapper"
+  "sirius@develop %gcc build_type=Release +fortran +tests +cuda +scalapack +nlcglib +vdwxc ^mpich@${MPICH_VERSION} ^openblas ^spfft+cuda ^nlcglib +cuda +wrapper ^kokkos+wrapper"
 
 # gcc + openmpi/elpa/scalapack/CUDA/MAGMA
 RUN spack install --only=dependencies --fail-fast \

--- a/ci/baseimage.cuda.Dockerfile
+++ b/ci/baseimage.cuda.Dockerfile
@@ -18,8 +18,8 @@ RUN apt-get install -y apt-utils
 
 # install basic tools
 RUN apt-get install -y --no-install-recommends gcc g++ gfortran clang libomp-14-dev git make unzip file \
-  vim wget pkg-config python3-pip python3-dev curl tcl m4 cpio automake meson xz-utils patch patchelf \
-  apt-transport-https ca-certificates gnupg software-properties-common perl tar bzip2
+  vim wget pkg-config python3-pip python3-dev cython3 python3-pythran curl tcl m4 cpio automake meson \
+  xz-utils patch patchelf apt-transport-https ca-certificates gnupg software-properties-common perl tar bzip2
 
 # install CMake
 RUN wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz -O cmake.tar.gz && \

--- a/ci/baseimage.cuda.Dockerfile
+++ b/ci/baseimage.cuda.Dockerfile
@@ -52,12 +52,12 @@ RUN yq -i '.compilers[0].compiler.paths.f77 = "/usr/bin/gfortran"' /root/.spack/
 RUN spack install --only=dependencies mpich@${MPICH_VERSION} %gcc
 RUN spack install mpich@${MPICH_VERSION} %gcc
 
-# install libvdwxc
-RUN spack install libvdwxc %gcc +mpi ^mpich@${MPICH_VERSION}
-
 # install openmpi
 RUN spack install --only=dependencies openmpi %gcc
 RUN spack install openmpi %gcc
+
+# install libvdwxc
+RUN spack install libvdwxc %gcc +mpi ^mpich@${MPICH_VERSION}
 
 # install openblas
 RUN spack install openblas %gcc +fortran
@@ -74,9 +74,6 @@ RUN ldconfig
 
 RUN spack install --only=dependencies --fail-fast \
   "sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack ^mpich ^spfft+single_precision+cuda ^intel-oneapi-mkl+cluster"
-
-RUN spack install --only=dependencies --fail-fast \
-  "sirius@develop %gcc build_type=RelWithDebInfo ~fortran+tests +apps +rocm +scalapack ^mpich ^openblas"
 
 RUN spack install --only=dependencies --fail-fast \
   "sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +scalapack +elpa ^mpich ^intel-oneapi-mkl+cluster ^elpa+cuda ^spfft+single_precision+cuda"

--- a/ci/baseimage.cuda.Dockerfile
+++ b/ci/baseimage.cuda.Dockerfile
@@ -64,7 +64,7 @@ RUN spack install openblas %gcc +fortran
 
 RUN spack install magma %gcc +cuda ^openblas
 
-RUN spack install nlcglib %gcc +cuda+wrapper ^kokkos+wrapper
+RUN spack install nlcglib %gcc +cuda+wrapper ^kokkos@3.7.01+wrapper
 
 # for the MPI hook
 RUN echo $(spack find --format='{prefix.lib}' mpich) > /etc/ld.so.conf.d/mpich.conf
@@ -75,6 +75,6 @@ ENV SPEC="sirius@develop %gcc build_type=Release +python +fortran +elpa +tests +
 # install all dependencies
 RUN spack install --only=dependencies $SPEC
 
-ENV SPEC_CLANG="sirius@develop %clang build_type=Release ~fortran +tests ^openblas ^mpich@${MPICH_VERSION} ^spfft+single_precision+cuda"
+ENV SPEC_CLANG="sirius@develop %clang build_type=Release ~fortran +tests ^openblas%gcc ^mpich@${MPICH_VERSION} ^spfft+single_precision+cuda"
 
 RUN spack install --only=dependencies $SPEC_CLANG

--- a/ci/baseimage.cuda.Dockerfile
+++ b/ci/baseimage.cuda.Dockerfile
@@ -72,18 +72,30 @@ RUN ldconfig
 
 # install dependencies of several basic configurations
 
-# gcc + python/elpa/scalapack/MKL/CUDA
 RUN spack install --only=dependencies --fail-fast \
-  "sirius@develop %gcc build_type=Release +fortran +tests +python +elpa +scalapack +cuda ^mpich@${MPICH_VERSION} ^intel-oneapi-mkl+cluster ^spfft+single_precision+cuda ^elpa+cuda"
+  "sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack ^mpich ^spfft+single_precision+cuda ^intel-oneapi-mkl+cluster"
 
-# gcc + nlcg/openblas/CUDA
 RUN spack install --only=dependencies --fail-fast \
-  "sirius@develop %gcc build_type=Release +fortran +tests +cuda +scalapack +nlcglib +vdwxc ^mpich@${MPICH_VERSION} ^openblas ^spfft+cuda ^nlcglib +cuda +wrapper ^kokkos+wrapper"
+  "sirius@develop %gcc build_type=RelWithDebInfo ~fortran+tests +apps +rocm +scalapack ^mpich ^openblas"
 
-# gcc + openmpi/elpa/scalapack/CUDA/MAGMA
 RUN spack install --only=dependencies --fail-fast \
-  "sirius@develop %gcc build_type=Release +fortran +tests +magma +elpa +scalapack +cuda ^openmpi ^openblas ^spfft+cuda ^elpa+cuda"
+  "sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +scalapack +elpa ^mpich ^intel-oneapi-mkl+cluster ^elpa+cuda ^spfft+single_precision+cuda"
 
-# clang + mpich/openblas
-RUN spack install --only=dependencies --fresh --fail-fast \
-  "sirius@develop %clang build_type=Release ~fortran +tests ^openblas%gcc ^mpich@${MPICH_VERSION}"
+RUN spack install --only=dependencies --fail-fast \
+  "sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +magma ^mpich ^openblas ^magma+cuda"
+
+RUN spack install --only=dependencies --fail-fast \
+  "sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack +single_precision ^mpich ^intel-oneapi-mkl+cluster"
+
+RUN spack install --only=dependencies --fail-fast \
+  "sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack +vdwxc ^mpich ^openblas"
+
+RUN spack install --only=dependencies --fail-fast \
+  "sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +vdwxc +cuda +nlcglib ^openblas ^mpich ^nlcglib +cuda +wrapper ^kokkos +wrapper"
+
+RUN spack install --only=dependencies --fail-fast \
+  "sirius@develop %gcc +tests +apps +scalapack +fortran build_type=RelWithDebInfo ^openblas ^openmpi"
+
+RUN spack install --only=dependencies --fail-fast \
+  "sirius@develop %clang build_type=RelWithDebInfo ~fortran +tests ^openblas%gcc ^libxc%gcc ^mpich%gcc"
+

--- a/ci/baseimage.rocm.Dockerfile
+++ b/ci/baseimage.rocm.Dockerfile
@@ -8,7 +8,7 @@ ENV FORCE_UNSAFE_CONFIGURE 1
 
 ENV PATH="/spack/bin:${PATH}"
 
-ENV CMAKE_VERSION=3.25.2
+ENV CMAKE_VERSION=3.26.3
 
 RUN apt-get -y update && apt-get install -y apt-utils
 
@@ -30,7 +30,7 @@ RUN spack config add config:install_tree:root:/opt/local
 # set amdgpu_target for all packages
 RUN spack config add packages:all:variants:amdgpu_target=${ROCM_ARCH}
 # set basic x86_64 architecture
-#RUN spack config add packages:all:target:x86_64
+RUN spack config add packages:all:target:x86_64
 
 # find gcc and clang compilers
 RUN spack compiler find

--- a/ci/build.Dockerfile
+++ b/ci/build.Dockerfile
@@ -19,4 +19,4 @@ RUN spack --color always -e sirius-env dev-build --source-path /sirius-src $SPEC
 # here is a hacky workaround to link ./spack-build-{hash} to ./spack-build
 RUN cd /sirius-src && ln -s $(find . -name "spack-build-*" -type d) spack-build
 
-RUN spack --color always -e sirius-env build-env sirius -- cuobjdump --list-ptx /sirius-src/spack-build/apps/dft_loop/sirius.scf
+RUN $(spack location -i cuda)/bin/cuobjdump --list-ptx /sirius-src/spack-build/apps/dft_loop/sirius.scf

--- a/ci/build.Dockerfile
+++ b/ci/build.Dockerfile
@@ -19,4 +19,4 @@ RUN spack --color always -e sirius-env dev-build --source-path /sirius-src $SPEC
 # here is a hacky workaround to link ./spack-build-{hash} to ./spack-build
 RUN cd /sirius-src && ln -s $(find . -name "spack-build-*" -type d) spack-build
 
-RUN $(spack location -i cuda)/bin/cuobjdump --list-ptx /sirius-src/spack-build/apps/dft_loop/sirius.scf
+RUN $(spack location -i cuda)/bin/cuobjdump --list-ptx /sirius-src/spack-build/src/libsirius.so

--- a/ci/build.Dockerfile
+++ b/ci/build.Dockerfile
@@ -18,5 +18,3 @@ RUN spack --color always -e sirius-env dev-build --source-path /sirius-src $SPEC
 # we need a fixed name for the build directory
 # here is a hacky workaround to link ./spack-build-{hash} to ./spack-build
 RUN cd /sirius-src && ln -s $(find . -name "spack-build-*" -type d) spack-build
-
-RUN $(spack location -i cuda)/bin/cuobjdump --list-ptx /sirius-src/spack-build/src/libsirius.so

--- a/ci/build.Dockerfile
+++ b/ci/build.Dockerfile
@@ -18,3 +18,5 @@ RUN spack --color always -e sirius-env dev-build --source-path /sirius-src $SPEC
 # we need a fixed name for the build directory
 # here is a hacky workaround to link ./spack-build-{hash} to ./spack-build
 RUN cd /sirius-src && ln -s $(find . -name "spack-build-*" -type d) spack-build
+
+RUN spack --color always -e sirius-env build-env sirius -- cuobjdump --list-ptx /sirius-src/spack-build/apps/dft_loop/sirius.scf

--- a/ci/cscs-daint.yml
+++ b/ci/cscs-daint.yml
@@ -69,7 +69,7 @@ build rocm image:
   stage: build
   variables:
     DOCKERFILE: ci/build.Dockerfile
-    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci-rocm:$CI_COMMIT_SHA
+    PERSIST_IMAGE_NAME: discard
     SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo ~fortran+tests +apps +rocm +scalapack ^mpich ^openblas'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
@@ -79,7 +79,7 @@ build elpa cuda image:
   stage: build
   variables:
     DOCKERFILE: ci/build.Dockerfile
-    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci-tmp1:$CI_COMMIT_SHA
+    PERSIST_IMAGE_NAME: discard
     SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +scalapack +elpa ^mpich ^intel-oneapi-mkl+cluster ^elpa+cuda'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
@@ -89,7 +89,7 @@ build sequential eigen-solver cuda image:
   stage: build
   variables:
     DOCKERFILE: ci/build.Dockerfile
-    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci-tmp2:$CI_COMMIT_SHA
+    PERSIST_IMAGE_NAME: discard
     SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +magma ^mpich ^openblas ^magma+cuda'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
@@ -99,7 +99,7 @@ build fp32 cuda image:
   stage: build
   variables:
     DOCKERFILE: ci/build.Dockerfile
-    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci-tmp3:$CI_COMMIT_SHA
+    PERSIST_IMAGE_NAME: discard
     SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack +single_precision ^mpich ^intel-oneapi-mkl+cluster'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
@@ -109,9 +109,19 @@ build vdwxc cuda image:
   stage: build
   variables:
     DOCKERFILE: ci/build.Dockerfile
-    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci-tmp4:$CI_COMMIT_SHA
+    PERSIST_IMAGE_NAME: discard
     # we can't use MKL here because vdwxc needs parallel FFT and MKL doesn't provide it
     SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack +vdwxc ^mpich ^openblas'
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
+
+build nlcg image:
+  extends: .container-builder
+  needs: ["build base cuda image"]
+  stage: build
+  variables:
+    DOCKERFILE: ci/build.Dockerfile
+    PERSIST_IMAGE_NAME: discard
+    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +vdwxc +cuda +nlcglib ^openblas ^mpich ^nlcglib +cuda +wrapper ^kokkos +wrapper'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
 .run_tests:

--- a/ci/cscs-daint.yml
+++ b/ci/cscs-daint.yml
@@ -124,6 +124,26 @@ build nlcg image:
     SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +vdwxc +cuda +nlcglib ^openblas ^mpich ^nlcglib +cuda +wrapper ^kokkos +wrapper'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
+build clang image:
+  extends: .container-builder
+  needs: ["build base cuda image"]
+  stage: build
+  variables:
+    DOCKERFILE: ci/build.Dockerfile
+    PERSIST_IMAGE_NAME: discard
+    SPEC: 'sirius@develop %clang +tests +apps build_type=RelWithDebInfo ^openblas ^mpich ~fortran'
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
+
+build openmpi image:
+  extends: .container-builder
+  needs: ["build base cuda image"]
+  stage: build
+  variables:
+    DOCKERFILE: ci/build.Dockerfile
+    PERSIST_IMAGE_NAME: discard
+    SPEC: 'sirius@develop %gcc +tests +apps +scalapack +fortran build_type=RelWithDebInfo ^openblas ^openmpi'
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
+
 .run_tests:
   extends: .container-runner-daint-gpu
   needs: ["build cuda image"]

--- a/ci/cscs-daint.yml
+++ b/ci/cscs-daint.yml
@@ -9,21 +9,21 @@ stages:
 build base cuda image:
   extends: .container-builder
   stage: baseimage
-  # we create a tag that depends on the SHA value of ci/baseimage.Dockerfile, this way
+  # we create a tag that depends on the SHA value of ci/baseimage.cuda.Dockerfile, this way
   # a new base image is only built when the SHA of this file changes
   # If there are more dependency files that should change the tag-name of the base container
   # image, they can be added too.
   # Since the base image name is runtime dependent, we need to carry the value of it to
   # the following jobs via a dotenv file.
   before_script:
-  - DOCKER_TAG=`sha256sum ci/baseimage.Dockerfile | head -c 16`
+  - DOCKER_TAG=`sha256sum ci/baseimage.cuda.Dockerfile | head -c 16`
   - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/sirius-ci:$DOCKER_TAG
   - echo "BASE_IMAGE=$PERSIST_IMAGE_NAME" >> build.env
   artifacts:
     reports:
       dotenv: build.env
   variables:
-    DOCKERFILE: ci/baseimage.Dockerfile
+    DOCKERFILE: ci/baseimage.cuda.Dockerfile
     # change to 'always' if you want to rebuild, even if target tag exists already (if-not-exists is the default, i.e. we could also skip the variable)
     CSCS_REBUILD_POLICY: if-not-exists
     DOCKER_BUILD_ARGS: '["CUDA_ARCH=60"]'
@@ -31,8 +31,9 @@ build base cuda image:
 build base rocm image:
   extends: .container-builder
   stage: baseimage
+  # rocm takes long to build
   timeout: 4h
-  # we create a tag that depends on the SHA value of ci/baseimage.Dockerfile, this way
+  # we create a tag that depends on the SHA value of ci/baseimage.rocm.Dockerfile, this way
   # a new base image is only built when the SHA of this file changes
   # If there are more dependency files that should change the tag-name of the base container
   # image, they can be added too.
@@ -58,7 +59,7 @@ build cuda image:
   variables:
     DOCKERFILE: ci/build.Dockerfile
     PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci:$CI_COMMIT_SHA
-    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +scalapack ^mpich ^intel-oneapi-mkl+cluster'
+    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +scalapack +vdwxc ^mpich ^intel-oneapi-mkl+cluster'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
 build rocm image:

--- a/ci/cscs-daint.yml
+++ b/ci/cscs-daint.yml
@@ -131,8 +131,8 @@ build clang image:
   variables:
     DOCKERFILE: ci/build.Dockerfile
     PERSIST_IMAGE_NAME: discard
-    # reuse openblas and spfft from gcc build
-    SPEC: 'sirius@develop %clang build_type=RelWithDebInfo ~fortran +tests ^openblas%gcc ^mpich ^spfft+single_precision+cuda'
+    # reuse openblas, libxc and spfft from gcc build
+    SPEC: 'sirius@develop %clang build_type=RelWithDebInfo ~fortran +tests ^openblas%gcc ^libxc%gcc ^mpich ^spfft%gcc+single_precision+cuda'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
 build openmpi image:

--- a/ci/cscs-daint.yml
+++ b/ci/cscs-daint.yml
@@ -79,7 +79,7 @@ build elpa cuda image:
   stage: build
   variables:
     DOCKERFILE: ci/build.Dockerfile
-    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci:$CI_COMMIT_SHA
+    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci-tmp1:$CI_COMMIT_SHA
     SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +scalapack +elpa ^mpich ^intel-oneapi-mkl+cluster ^elpa+cuda'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
@@ -89,7 +89,7 @@ build sequential eigen-solver cuda image:
   stage: build
   variables:
     DOCKERFILE: ci/build.Dockerfile
-    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci:$CI_COMMIT_SHA
+    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci-tmp2:$CI_COMMIT_SHA
     SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +magma ^mpich ^openblas ^magma+cuda'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
@@ -99,7 +99,7 @@ build fp32 cuda image:
   stage: build
   variables:
     DOCKERFILE: ci/build.Dockerfile
-    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci:$CI_COMMIT_SHA
+    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci-tmp3:$CI_COMMIT_SHA
     SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack +single_precision ^mpich ^intel-oneapi-mkl+cluster'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
@@ -109,7 +109,7 @@ build vdwxc cuda image:
   stage: build
   variables:
     DOCKERFILE: ci/build.Dockerfile
-    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci:$CI_COMMIT_SHA
+    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci-tmp4:$CI_COMMIT_SHA
     # we can't use MKL here because vdwxc needs parallel FFT and MKL doesn't provide it
     SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack +vdwxc ^mpich ^openblas'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'

--- a/ci/cscs-daint.yml
+++ b/ci/cscs-daint.yml
@@ -15,6 +15,7 @@ build base cuda image:
   # image, they can be added too.
   # Since the base image name is runtime dependent, we need to carry the value of it to
   # the following jobs via a dotenv file.
+  timeout: 2h
   before_script:
   - DOCKER_TAG=`sha256sum ci/baseimage.cuda.Dockerfile | head -c 16`
   - export PERSIST_IMAGE_NAME=$CSCS_REGISTRY_PATH/base/sirius-ci:$DOCKER_TAG
@@ -89,7 +90,7 @@ build sequential eigen-solver cuda image:
   variables:
     DOCKERFILE: ci/build.Dockerfile
     PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci:$CI_COMMIT_SHA
-    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +magma ^mpich ^intel-oneapi-mkl+cluster ^magma+cuda'
+    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +magma ^mpich ^openblas ^magma+cuda'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
 build fp32 cuda image:

--- a/ci/cscs-daint.yml
+++ b/ci/cscs-daint.yml
@@ -60,7 +60,7 @@ build cuda image:
   variables:
     DOCKERFILE: ci/build.Dockerfile
     PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci:$CI_COMMIT_SHA
-    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack ^mpich ^intel-oneapi-mkl+cluster'
+    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack ^mpich ^spfft+single_precision+cuda ^intel-oneapi-mkl+cluster'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
 build rocm image:

--- a/ci/cscs-daint.yml
+++ b/ci/cscs-daint.yml
@@ -80,7 +80,7 @@ build elpa cuda image:
   variables:
     DOCKERFILE: ci/build.Dockerfile
     PERSIST_IMAGE_NAME: discard
-    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +scalapack +elpa ^mpich ^intel-oneapi-mkl+cluster ^elpa+cuda'
+    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +scalapack +elpa ^mpich ^intel-oneapi-mkl+cluster ^elpa+cuda ^spfft+single_precision+cuda'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
 build sequential eigen-solver cuda image:
@@ -132,7 +132,7 @@ build clang image:
     DOCKERFILE: ci/build.Dockerfile
     PERSIST_IMAGE_NAME: discard
     # reuse openblas, libxc and spfft from gcc build
-    SPEC: 'sirius@develop %clang build_type=RelWithDebInfo ~fortran +tests ^openblas%gcc ^libxc%gcc ^mpich ^spfft%gcc+single_precision+cuda'
+    SPEC: 'sirius@develop %clang build_type=RelWithDebInfo ~fortran +tests ^openblas%gcc ^libxc%gcc ^mpich%gcc'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
 build openmpi image:

--- a/ci/cscs-daint.yml
+++ b/ci/cscs-daint.yml
@@ -71,6 +71,16 @@ build rocm image:
     SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo ~fortran+tests +apps +rocm +scalapack ^mpich ^openblas'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
+build elpa cuda image:
+  extends: .container-builder
+  needs: ["build base cuda image"]
+  stage: build
+  variables:
+    DOCKERFILE: ci/build.Dockerfile
+    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci:$CI_COMMIT_SHA
+    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +scalapack +elpa ^mpich ^intel-oneapi-mkl+cluster ^elpa+cuda'
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
+
 .run_tests:
   extends: .container-runner-daint-gpu
   needs: ["build cuda image"]

--- a/ci/cscs-daint.yml
+++ b/ci/cscs-daint.yml
@@ -59,7 +59,7 @@ build cuda image:
   variables:
     DOCKERFILE: ci/build.Dockerfile
     PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci:$CI_COMMIT_SHA
-    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +scalapack +vdwxc ^mpich ^intel-oneapi-mkl+cluster'
+    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack +vdwxc ^mpich ^intel-oneapi-mkl+cluster'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
 build rocm image:
@@ -80,6 +80,26 @@ build elpa cuda image:
     DOCKERFILE: ci/build.Dockerfile
     PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci:$CI_COMMIT_SHA
     SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +scalapack +elpa ^mpich ^intel-oneapi-mkl+cluster ^elpa+cuda'
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
+
+build sequential eigen-solver cuda image:
+  extends: .container-builder
+  needs: ["build base cuda image"]
+  stage: build
+  variables:
+    DOCKERFILE: ci/build.Dockerfile
+    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci:$CI_COMMIT_SHA
+    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +magma ^mpich ^intel-oneapi-mkl+cluster ^magma+cuda'
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
+
+build cuda fp32 image:
+  extends: .container-builder
+  needs: ["build base cuda image"]
+  stage: build
+  variables:
+    DOCKERFILE: ci/build.Dockerfile
+    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci:$CI_COMMIT_SHA
+    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack +vdwxc +single_precision ^mpich ^intel-oneapi-mkl+cluster'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
 .run_tests:

--- a/ci/cscs-daint.yml
+++ b/ci/cscs-daint.yml
@@ -59,7 +59,7 @@ build cuda image:
   variables:
     DOCKERFILE: ci/build.Dockerfile
     PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci:$CI_COMMIT_SHA
-    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack +vdwxc ^mpich ^intel-oneapi-mkl+cluster'
+    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack ^mpich ^intel-oneapi-mkl+cluster'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
 build rocm image:
@@ -92,14 +92,25 @@ build sequential eigen-solver cuda image:
     SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +tests +apps +cuda +magma ^mpich ^intel-oneapi-mkl+cluster ^magma+cuda'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
-build cuda fp32 image:
+build fp32 cuda image:
   extends: .container-builder
   needs: ["build base cuda image"]
   stage: build
   variables:
     DOCKERFILE: ci/build.Dockerfile
     PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci:$CI_COMMIT_SHA
-    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack +vdwxc +single_precision ^mpich ^intel-oneapi-mkl+cluster'
+    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack +single_precision ^mpich ^intel-oneapi-mkl+cluster'
+    DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
+
+build vdwxc cuda image:
+  extends: .container-builder
+  needs: ["build base cuda image"]
+  stage: build
+  variables:
+    DOCKERFILE: ci/build.Dockerfile
+    PERSIST_IMAGE_NAME: $CSCS_REGISTRY_PATH/sirius/sirius-ci:$CI_COMMIT_SHA
+    # we can't use MKL here because vdwxc needs parallel FFT and MKL doesn't provide it
+    SPEC: 'sirius@develop %gcc build_type=RelWithDebInfo +fortran +tests +apps +cuda +scalapack +vdwxc ^mpich ^openblas'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
 .run_tests:

--- a/ci/cscs-daint.yml
+++ b/ci/cscs-daint.yml
@@ -131,7 +131,8 @@ build clang image:
   variables:
     DOCKERFILE: ci/build.Dockerfile
     PERSIST_IMAGE_NAME: discard
-    SPEC: 'sirius@develop %clang +tests +apps build_type=RelWithDebInfo ^openblas ^mpich ~fortran'
+    # reuse openblas and spfft from gcc build
+    SPEC: 'sirius@develop %clang build_type=RelWithDebInfo ~fortran +tests ^openblas%gcc ^mpich ^spfft+single_precision+cuda'
     DOCKER_BUILD_ARGS: '["BASE_IMAGE=${BASE_IMAGE}", "SPECDEV=$SPEC"]'
 
 build openmpi image:

--- a/ci/github-ci/Dockerfile
+++ b/ci/github-ci/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.4.2-devel-ubuntu20.04
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive \
     PATH="$PATH:/spack/bin"


### PR DESCRIPTION
minor tweaks TODO:
- [x] for clang container spfft is not picked up correctly
 ```
  -       ^spfft@1.0.6%gcc@11.3.0+cuda~fortran~gpu_direct~ipo+mpi+openmp~rocm+single_precision~static build_system=cmake build_type=Release cuda_arch=60 generator=make arch=linux-ubuntu22.04-zen2
  ```
 
 - [x] for elpa image, again spfft is not picked
  ```
   -       ^spfft@1.0.6%gcc@11.3.0+cuda~fortran~gpu_direct~ipo+mpi+openmp~rocm~single_precision~static build_system=cmake build_type=Release cuda_arch=60 generator=make arch=linux-ubuntu22.04-zen2
  ```
  
 - [x] for nlcglib, nlcglib, spla and spfft are not picked
  ```
   -       ^nlcglib@0.9%gcc@11.3.0+cuda~ipo~openmp+wrapper build_system=cmake build_type=Release cuda_arch=60 generator=make arch=linux-ubuntu22.04-zen2
   -       ^spfft@1.0.6%gcc@11.3.0+cuda~fortran~gpu_direct~ipo+mpi+openmp~rocm~single_precision~static build_system=cmake build_type=Release cuda_arch=60 generator=make arch=linux-ubuntu22.04-zen2
   -       ^spla@1.5.4%gcc@11.3.0+cuda~fortran~ipo+openmp~rocm~static build_system=cmake build_type=RelWithDebInfo generator=make arch=linux-ubuntu22.04-zen2
 ```
 
 - [x] for openmpi image: costa, fftw, hdf5, netlib-scalapack, spfft, spla are not picked
```
      -       ^costa@2.1%gcc@11.3.0~ipo~scalapack+shared build_system=cmake build_type=RelWithDebInfo generator=make arch=linux-ubuntu22.04-zen2
       -       ^fftw@3.3.10%gcc@11.3.0+mpi~openmp~pfft_patches build_system=autotools precision=double,float arch=linux-ubuntu22.04-zen2
       -       ^hdf5@1.14.0%gcc@11.3.0~cxx~fortran+hl~ipo~java~map+mpi+shared~szip~threadsafe+tools api=default build_system=cmake build_type=RelWithDebInfo generator=make patches=0b5dd6f arch=linux-ubuntu22.04-zen2
       -       ^netlib-scalapack@2.2.0%gcc@11.3.0~ipo~pic+shared build_system=cmake build_type=Release generator=make patches=072b006,1c9ce5f,244a9aa arch=linux-ubuntu22.04-zen2
       -       ^spfft@1.0.6%gcc@11.3.0~cuda~fortran~gpu_direct~ipo+mpi+openmp~rocm~single_precision~static build_system=cmake build_type=Release generator=make arch=linux-ubuntu22.04-zen2
       -       ^spla@1.5.4%gcc@11.3.0~cuda~fortran~ipo+openmp~rocm~static build_system=cmake build_type=RelWithDebInfo generator=make arch=linux-ubuntu22.04-zen2
```
 - [x] for seqential eigen-solver: magma, spfft, spla are not picked
```
            -       ^magma@2.7.1%gcc@11.3.0+cuda+fortran~ipo~rocm+shared build_system=cmake build_type=RelWithDebInfo cuda_arch=60 generator=make arch=linux-ubuntu22.04-zen2
            -       ^spfft@1.0.6%gcc@11.3.0+cuda~fortran~gpu_direct~ipo+mpi+openmp~rocm~single_precision~static build_system=cmake build_type=Release cuda_arch=60 generator=make arch=linux-ubuntu22.04-zen2
            -       ^spla@1.5.4%gcc@11.3.0+cuda~fortran~ipo+openmp~rocm~static build_system=cmake build_type=RelWithDebInfo generator=make arch=linux-ubuntu22.04-zen2
```
 - [x] for vdwxc build: netlib-scalapack, spfft, spla are not picked
 ```
  -       ^netlib-scalapack@2.2.0%gcc@11.3.0~ipo~pic+shared build_system=cmake build_type=Release generator=make patches=072b006,1c9ce5f,244a9aa arch=linux-ubuntu22.04-zen2
  -       ^spfft@1.0.6%gcc@11.3.0+cuda~fortran~gpu_direct~ipo+mpi+openmp~rocm~single_precision~static build_system=cmake build_type=Release cuda_arch=60 generator=make arch=linux-ubuntu22.04-zen2
  -       ^spla@1.5.4%gcc@11.3.0+cuda~fortran~ipo+openmp~rocm~static build_system=cmake build_type=RelWithDebInfo generator=make arch=linux-ubuntu22.04-zen2
 ``` 
        