### PR TITLE
Add missing ifdef for umpire

### DIFF
--- a/src/SDDK/memory.hpp
+++ b/src/SDDK/memory.hpp
@@ -471,7 +471,9 @@ class memory_pool
         if (M_ == memory_t::none) {
             return;
         }
+#if defined(SIRIUS_USE_MEMORY_POOL)
         memory_pool_allocator_.release();
+#endif
     }
 
     /// Return the type of memory this pool is managing.

--- a/src/gpu/acc_common.hpp
+++ b/src/gpu/acc_common.hpp
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include "acc.hpp"
 #include "acc_runtime.hpp"
+#include "../typedefs.hpp"
 
 const double twopi = 6.2831853071795864769;
 
@@ -167,21 +168,6 @@ inline bool __device__ is_zero(double x)
 {
     return x == 0.0;
 }
-
-template <typename T>
-struct Real;
-
-template<>
-struct Real<float>
-{
-    using type = float;
-};
-
-template<>
-struct Real<double>
-{
-    using type = double;
-};
 
 template<>
 struct Real<gpu_complex_type<float>>


### PR DESCRIPTION
```
spack install sirius~memory_pool
``` 
failed to compile because a missing ifdef in `memory_pool::clear`.

Not related, but `struct Real` has been defined twice. I've included the header `typedefs.hpp` in `acc_common.hpp` and removed the duplicate.