### PR TITLE
[feature] New split index implementation

### DIFF
--- a/apps/tests/test_allgather.cpp
+++ b/apps/tests/test_allgather.cpp
@@ -7,10 +7,10 @@ void test_allgather()
     int N = 11;
     std::vector<double> vec(N, 0.0);
 
-    sddk::splindex<sddk::splindex_t::block> spl(N, mpi::Communicator::world().size(), mpi::Communicator::world().rank());
+    sddk::splindex_block<> spl(N, n_blocks(mpi::Communicator::world().size()), block_id(mpi::Communicator::world().rank()));
 
     for (int i = 0; i < spl.local_size(); i++) {
-        vec[spl[i]] = mpi::Communicator::world().rank() + 1.0;
+        vec[spl.global_index(i)] = mpi::Communicator::world().rank() + 1.0;
     }
 
     {

--- a/apps/tests/test_wf_ortho.cpp
+++ b/apps/tests/test_wf_ortho.cpp
@@ -39,10 +39,9 @@ void test_wf_ortho(BLACS_grid const& blacs_grid__, double cutoff__, int num_band
             for (int igloc = 0; igloc < gvec->count(); igloc++) {
                 phi.pw_coeffs(igloc, s, wf::band_index(i)) = utils::random<std::complex<T>>();
             }
-            for (int ialoc = 0; ialoc < phi.spl_num_atoms().local_size(); ialoc++) {
-                int ia = phi.spl_num_atoms()[ialoc];
-                for (int xi = 0; xi < num_mt_coeffs[ia]; xi++) {
-                    phi.mt_coeffs(xi, wf::atom_index(ialoc), s, wf::band_index(i)) = utils::random<std::complex<T>>();
+            for (auto it : phi.spl_num_atoms()) {
+                for (int xi = 0; xi < num_mt_coeffs[it.i]; xi++) {
+                    phi.mt_coeffs(xi, wf::atom_index(it.li), s, wf::band_index(i)) = utils::random<std::complex<T>>();
                 }
             }
         }

--- a/apps/tests/test_wf_ortho.cpp
+++ b/apps/tests/test_wf_ortho.cpp
@@ -41,7 +41,7 @@ void test_wf_ortho(BLACS_grid const& blacs_grid__, double cutoff__, int num_band
             }
             for (auto it : phi.spl_num_atoms()) {
                 for (int xi = 0; xi < num_mt_coeffs[it.i]; xi++) {
-                    phi.mt_coeffs(xi, wf::atom_index(it.li), s, wf::band_index(i)) = utils::random<std::complex<T>>();
+                    phi.mt_coeffs(xi, it.li, s, wf::band_index(i)) = utils::random<std::complex<T>>();
                 }
             }
         }

--- a/apps/tests/test_wf_trans.cpp
+++ b/apps/tests/test_wf_trans.cpp
@@ -37,10 +37,9 @@ void test_wf_trans(la::BLACS_grid const& blacs_grid__, double cutoff__, int num_
             for (int igloc = 0; igloc < gvec->count(); igloc++) {
                 phi.pw_coeffs(igloc, s, wf::band_index(i)) = utils::random<std::complex<T>>();
             }
-            for (int ialoc = 0; ialoc < phi.spl_num_atoms().local_size(); ialoc++) {
-                int ia = phi.spl_num_atoms()[ialoc];
-                for (int xi = 0; xi < num_mt_coeffs[ia]; xi++) {
-                    phi.mt_coeffs(xi, wf::atom_index(ialoc), s, wf::band_index(i)) = utils::random<std::complex<T>>();
+            for (auto it : phi.spl_num_atoms()) {
+                for (int xi = 0; xi < num_mt_coeffs[it.i]; xi++) {
+                    phi.mt_coeffs(xi, wf::atom_index(it.li), s, wf::band_index(i)) = utils::random<std::complex<T>>();
                 }
             }
         }
@@ -86,12 +85,11 @@ void test_wf_trans(la::BLACS_grid const& blacs_grid__, double cutoff__, int num_
                     phi.pw_coeffs(igloc, s, wf::band_index(i)) -
                     psi.pw_coeffs(igloc, s, wf::band_index(num_bands__ - i - 1)));
             }
-            for (int ialoc = 0; ialoc < phi.spl_num_atoms().local_size(); ialoc++) {
-                int ia = phi.spl_num_atoms()[ialoc];
-                for (int xi = 0; xi < num_mt_coeffs[ia]; xi++) {
+            for (auto it : phi.spl_num_atoms()) {
+                for (int xi = 0; xi < num_mt_coeffs[it.i]; xi++) {
                     diff += std::abs(
-                        phi.mt_coeffs(xi, wf::atom_index(ialoc), s, wf::band_index(i)) -
-                        psi.mt_coeffs(xi, wf::atom_index(ialoc), s, wf::band_index(num_bands__ - i - 1)));
+                        phi.mt_coeffs(xi, wf::atom_index(it.li), s, wf::band_index(i)) -
+                        psi.mt_coeffs(xi, wf::atom_index(it.li), s, wf::band_index(num_bands__ - i - 1)));
                 }
             }
         }

--- a/apps/tests/test_wf_trans.cpp
+++ b/apps/tests/test_wf_trans.cpp
@@ -39,7 +39,7 @@ void test_wf_trans(la::BLACS_grid const& blacs_grid__, double cutoff__, int num_
             }
             for (auto it : phi.spl_num_atoms()) {
                 for (int xi = 0; xi < num_mt_coeffs[it.i]; xi++) {
-                    phi.mt_coeffs(xi, wf::atom_index(it.li), s, wf::band_index(i)) = utils::random<std::complex<T>>();
+                    phi.mt_coeffs(xi, it.li, s, wf::band_index(i)) = utils::random<std::complex<T>>();
                 }
             }
         }
@@ -88,8 +88,8 @@ void test_wf_trans(la::BLACS_grid const& blacs_grid__, double cutoff__, int num_
             for (auto it : phi.spl_num_atoms()) {
                 for (int xi = 0; xi < num_mt_coeffs[it.i]; xi++) {
                     diff += std::abs(
-                        phi.mt_coeffs(xi, wf::atom_index(it.li), s, wf::band_index(i)) -
-                        psi.mt_coeffs(xi, wf::atom_index(it.li), s, wf::band_index(num_bands__ - i - 1)));
+                        phi.mt_coeffs(xi, it.li, s, wf::band_index(i)) -
+                        psi.mt_coeffs(xi, it.li, s, wf::band_index(num_bands__ - i - 1)));
                 }
             }
         }

--- a/apps/unit_tests/test_splindex.cpp
+++ b/apps/unit_tests/test_splindex.cpp
@@ -8,10 +8,10 @@ int test1()
 {
     for (int num_ranks = 1; num_ranks < 20; num_ranks++) {
         for (int N = 1; N < 1130; N++) {
-            splindex<splindex_t::block> spl(N, num_ranks, 0);
+            splindex_block<> spl(N, n_blocks(num_ranks), block_id(0));
             int sz = 0;
             for (int i = 0; i < num_ranks; i++) {
-                sz += (int)spl.local_size(i);
+                sz += spl.local_size(block_id(i));
             }
             if (sz != N) {
                 std::stringstream s;
@@ -20,21 +20,21 @@ int test1()
                 s << "computed global index size: " << sz << std::endl;
                 s << "number of ranks: " << num_ranks << std::endl;
                 for (int i = 0; i < num_ranks; i++) {
-                    s << "i, local_size(i): " << i << ", " << spl.local_size(i) << std::endl;
+                    s << "i, local_size(i): " << i << ", " << spl.local_size(block_id(i)) << std::endl;
                 }
                 throw std::runtime_error(s.str());
             }
             for (int i = 0; i < N; i++) {
-                int rank = spl.local_rank(i);
-                int offset = (int)spl.local_index(i);
-                if (i != (int)spl.global_index(offset, rank)) {
+                int rank = spl.location(block_id(i)).ib;
+                int offset = spl.location(block_id(i)).index_local;
+                if (i != (int)spl.global_index(offset, block_id(rank))) {
                     std::stringstream s;
                     s << "test1: wrong index." << std::endl;
                     s << "global index size: " << N << std::endl;
                     s << "number of ranks: " << num_ranks << std::endl;
                     s << "global index: " << i << std::endl;
                     s << "rank, offset: " << rank << ", " << offset << std::endl;
-                    s << "computed global index: " << spl.global_index(offset, rank) << std::endl;
+                    s << "computed global index: " << spl.global_index(offset, block_id(rank)) << std::endl;
                     throw std::runtime_error(s.str());
                 }
             }
@@ -48,22 +48,28 @@ int test2()
     for (int bs = 1; bs < 17; bs++) {
         for (int num_ranks = 1; num_ranks < 13; num_ranks++) {
             for (int N = 1; N < 1113; N++) {
-                splindex<splindex_t::block_cyclic> spl(N, num_ranks, 0, bs);
+                sddk::splindex_block_cyclic<> spl(N, n_blocks(num_ranks), block_id(0), bs);
                 int sz = 0;
                 for (int i = 0; i < num_ranks; i++) {
-                    sz += (int)spl.local_size(i);
+                    sz += (int)spl.local_size(block_id(i));
                 }
                 if (sz != N) {
                     std::stringstream s;
 
-                    s << "test2: wrong sum of local sizes" << std::endl;
+                    s << "test2: wrong sum of local sizes" << std::endl
+                      << "N : " << N << std::endl
+                      << "num_ranks :" << num_ranks << std::endl
+                      << "block size : " << bs << std::endl;
+                    for (int i = 0; i < num_ranks; i++) {
+                        s << "rank, local_size : " << i << ", " << spl.local_size(block_id(i)) << std::endl;
+                    }
                     throw std::runtime_error(s.str());
                 }
 
                 for (int i = 0; i < N; i++) {
-                    int rank = spl.local_rank(i);
-                    int offset = (int)spl.local_index(i);
-                    if (i != (int)spl.global_index(offset, rank)) {
+                    int rank = spl.location(block_id(i)).ib;
+                    int offset = spl.location(block_id(i)).index_local;
+                    if (i != (int)spl.global_index(offset, block_id(rank))) {
                         std::stringstream s;
                         s << "test2: wrong index" << std::endl;
                         s << "bs = " << bs << std::endl
@@ -72,7 +78,7 @@ int test2()
                           << "idx = " << i << std::endl
                           << "rank = " << rank << std::endl
                           << "offset = " << offset << std::endl
-                          << "computed index = " << spl.global_index(offset, rank) << std::endl;
+                          << "computed index = " << spl.global_index(offset, block_id(rank)) << std::endl;
                         throw std::runtime_error(s.str());
                     }
                 }
@@ -86,14 +92,14 @@ int test3()
 {
     for (int num_ranks = 1; num_ranks < 20; num_ranks++) {
         for (int N = 1; N < 1130; N++) {
-            splindex<splindex_t::block> spl_tmp(N, num_ranks, 0);
+            splindex_block<> spl_tmp(N, n_blocks(num_ranks), block_id(0));
 
-            splindex<splindex_t::chunk> spl(N, num_ranks, 0, spl_tmp.counts());
+            splindex_chunk<> spl(N, n_blocks(num_ranks), block_id(0), spl_tmp.counts());
 
             for (int i = 0; i < N; i++) {
-                int rank = spl.local_rank(i);
-                int offset = spl.local_index(i);
-                if (i != spl.global_index(offset, rank)) {
+                int rank = spl.location(block_id(i)).ib;
+                int offset = spl.location(block_id(i)).index_local;
+                if (i != spl.global_index(offset, block_id(rank))) {
                     std::stringstream s;
                     s << "test3: wrong index" << std::endl;
                     throw std::runtime_error(s.str());

--- a/python_module/py_sirius.cpp
+++ b/python_module/py_sirius.cpp
@@ -435,7 +435,7 @@ PYBIND11_MODULE(py_sirius, m)
             [](K_point_set& ks, int i) -> K_point<double>& {
                 if (i >= ks.spl_num_kpoints().local_size())
                     throw pybind11::index_error("out of bounds");
-                return *ks.get<double>(ks.spl_num_kpoints(i));
+                return *ks.get<double>(ks.spl_num_kpoints().global_index(typename kp_index_t::local(i)));
             },
             py::return_value_policy::reference_internal)
         .def("__len__", [](K_point_set const& ks) { return ks.spl_num_kpoints().local_size(); })

--- a/src/SDDK/splindex.hpp
+++ b/src/SDDK/splindex.hpp
@@ -26,6 +26,7 @@
 #define __SPLINDEX_HPP__
 
 #include "strong_type.hpp"
+#include "utils/rte.hpp"
 
 /// Basic index type.
 template <typename T = int>

--- a/src/SDDK/splindex.hpp
+++ b/src/SDDK/splindex.hpp
@@ -199,6 +199,14 @@ class splindex_iterator_t : public std::iterator<std::random_access_iterator_tag
     using difference_type = typename std::iterator<std::random_access_iterator_tag, Index_t>::difference_type;
     typename Index_t::local li;
     typename Index_t::global i;
+
+    splindex_iterator_t<Index_t>& operator=(splindex_iterator_t<Index_t> const& lhs_) = default;
+    //{
+    //    this->li = lhs_.li;
+    //    this->i = lhs_.i;
+    //    return *this;
+    //}
+
     splindex_iterator_t(splindex<Index_t> const& idx__)
         : idx_{idx__}
         , li{0}

--- a/src/SDDK/splindex.hpp
+++ b/src/SDDK/splindex.hpp
@@ -25,26 +25,55 @@
 #ifndef __SPLINDEX_HPP__
 #define __SPLINDEX_HPP__
 
-#include <algorithm>
-#include <vector>
-#include <sstream>
-#include <limits>
-#include <cassert>
+#include "strong_type.hpp"
+
+/// Basic index type.
+template <typename T = int>
+struct basic_index_t {
+    typedef T value_type;
+    typedef T global;
+    typedef T local;
+};
+
+/// K-point index type.
+struct kp_index_t {
+    typedef int value_type;
+    typedef strong_type<value_type, struct __kp_global_index_tag> global;
+    typedef strong_type<value_type, struct __kp_local_index_tag> local;
+};
+
+struct atom_index_t {
+    typedef int value_type;
+    typedef strong_type<value_type, struct __atom_global_index_tag> global;
+    typedef strong_type<value_type, struct __atom_local_index_tag> local;
+};
+
+struct atom_type_index_t {
+    typedef int value_type;
+    typedef strong_type<value_type, struct __atom_type_global_index_tag> global;
+    typedef strong_type<value_type, struct __atom_type_local_index_tag> local;
+};
+
+struct atom_symmetry_class_index_t {
+    typedef int value_type;
+    typedef strong_type<value_type, struct __atom_symmetry_class_global_index_tag> global;
+    typedef strong_type<value_type, struct __atom_symmetry_class_local_index_tag> local;
+};
+
+struct paw_atom_index_t {
+    typedef int value_type;
+    typedef strong_type<value_type, struct __paw_atom_global_index_tag> global;
+    typedef strong_type<value_type, struct __paw_atom_local_index_tag> local;
+};
+
+/// Number of blocks to which the global index is split.
+using n_blocks = strong_type<int, struct __n_blocks_tag>;
+/// ID of the block.
+/** The id of the block has the range [0, n_blocks) */
+using block_id = strong_type<int, struct __block_id_tag>;
 
 namespace sddk {
 
-/// Type of split index.
-enum class splindex_t
-{
-    /// Block distribution.
-    block,
-    /// Block-cyclic distribution.
-    block_cyclic,
-    /// Custom distribution in continuous chunks of arbitrary size.
-    chunk
-};
-
-/// Type of index domain.
 enum class index_domain_t
 {
     /// Global index.
@@ -54,456 +83,962 @@ enum class index_domain_t
 };
 
 /// Base class for split index.
-template <typename T>
-class splindex_base
+template <typename Index_t = basic_index_t<int>>
+class splindex
 {
+  public:
+    using value_type = typename Index_t::value_type;
   protected:
-    /// Rank of the block with local fraction of the global index.
-    int rank_{-1};
+    /// Number of blocks over which the global index is distributed.
+    n_blocks n_blocks_{-1};
 
-    /// Number of ranks over which the global index is distributed.
-    int num_ranks_{-1};
+    /// Index of the block with local fraction of the global index.
+    block_id block_id_{-1};
 
-    /// size of the global index
-    T global_index_size_;
+    /// Size (aka length) of the global index.
+    value_type size_{-1};
 
-    /// Default constructor.
-    splindex_base()
-    {
-    }
-
-    /// Pair of <local index, rank> describing the location of a global index.
+    /// Pair of <local index, block_id> describing the location of a global index element.
     struct location_t
     {
-        T local_index;
-        int rank;
-        location_t(T local_index__, int rank__)
-            : local_index(local_index__)
-            , rank(rank__)
+        /// Local index inside a block.
+        typename Index_t::local index_local;
+        /// Index of the block.
+        block_id ib;
+        /// Constructor.
+        location_t(typename Index_t::local index_local__, block_id ib__)
+            : index_local(index_local__)
+            , ib(ib__)
         {
         }
     };
 
   public:
-    /// Rank id.
-    inline int rank() const
-    {
-        return rank_;
-    }
+    ///// Rank id.
+    //inline auto block_id() const noexcept
+    //{
+    //    return block_id_;
+    //}
 
-    /// Number of ranks that are participating in the distribution of an index.
-    inline int num_ranks() const
-    {
-        return num_ranks_;
-    }
+    ///// Number of ranks that are participating in the distribution of an index.
+    //inline auto n_blocks() const noexcept
+    //{
+    //    return n_blocks_;
+    //}
 
-    inline T global_index_size() const
-    {
-        return global_index_size_;
-    }
-
-    static inline T block_size(T size__, int num_ranks__)
-    {
-        return size__ / num_ranks__ + std::min(T(1), size__ % num_ranks__);
-    }
-};
-
-/// Split index.
-template <splindex_t type, typename T = int>
-class splindex : public splindex_base<T>
-{
-};
-
-/// Specialization for the block distribution.
-template <typename T>
-class splindex<splindex_t::block, T> : public splindex_base<T>
-{
-  private:
-    T block_size_;
-
-    void init(T global_index_size__, int num_ranks__, int rank__)
-    {
-        this->global_index_size_ = global_index_size__;
-
-        if (num_ranks__ < 0) {
-            std::stringstream s;
-            s << "wrong number of ranks: " << num_ranks__;
-            throw std::runtime_error(s.str());
-        }
-        this->num_ranks_ = num_ranks__;
-
-        if (rank__ < 0 || rank__ >= num_ranks__) {
-            std::stringstream s;
-            s << "wrong rank: " << rank__;
-            throw std::runtime_error(s.str());
-        }
-        this->rank_ = rank__;
-
-        block_size_ = this->block_size(global_index_size__, num_ranks__);
-    }
-
-  public:
-    /// Default constructor
+    /// Default constructor.
     splindex()
     {
     }
 
     /// Constructor.
-    splindex(T global_index_size__, int num_ranks__, int rank__)
+    /** Check and set index size, number of blocks and block id. */
+    splindex(value_type size__, n_blocks n_blocks__, block_id block_id__)
     {
-        init(global_index_size__, num_ranks__, rank__);
-    }
-
-    /// Return "local index, rank" pair for a global index.
-    inline typename splindex_base<T>::location_t location(T idxglob__) const
-    {
-        assert(idxglob__ < this->global_index_size_);
-
-        int rank = int(idxglob__ / block_size_);
-        T idxloc = idxglob__ - rank * block_size_;
-
-        return typename splindex_base<T>::location_t(idxloc, rank);
-    }
-
-    /// Return local size of the split index for an arbitrary rank.
-    inline T local_size(int rank__) const
-    {
-        assert(rank__ >= 0 && rank__ < this->num_ranks_);
-
-        if (this->global_index_size_ == 0) {
-            return 0;
+        if (size__ < 0) {
+            std::stringstream s;
+            s << "wrong size : " << size__;
+            throw std::runtime_error(s.str());
         }
+        this->size_ = size__;
 
-        int n = static_cast<int>(this->global_index_size_ / block_size_);
-        if (rank__ < n) {
-            return block_size_;
-        } else if (rank__ == n) {
-            return this->global_index_size_ - rank__ * block_size_;
-        } else {
-            return 0;
+        if (n_blocks__.get() < 0) {
+            std::stringstream s;
+            s << "wrong number of blocks : " << n_blocks__.get();
+            throw std::runtime_error(s.str());
         }
-    }
+        this->n_blocks_ = n_blocks__;
 
-    /// Return local size of the split index for a current rank.
-    inline T local_size() const
-    {
-        return local_size(this->rank_);
-    }
-
-    /// Return rank which holds the element with the given global index.
-    inline int local_rank(T idxglob__) const
-    {
-        return location(idxglob__).rank;
-    }
-
-    /// Return local index of the element for the rank which handles the given global index.
-    inline T local_index(T idxglob__) const
-    {
-        return location(idxglob__).local_index;
-    }
-
-    /// Return global index of an element by local index and rank.
-    inline T global_index(T idxloc__, int rank__) const
-    {
-        assert(rank__ >= 0 && rank__ < this->num_ranks_);
-
-        if (local_size(rank__) == 0) {
-            return std::numeric_limits<T>::max();
+        if (block_id__.get() < 0 || block_id__.get() >= n_blocks__.get()) {
+            std::stringstream s;
+            s << "wrong rank block id : " << block_id__.get();
+            throw std::runtime_error(s.str());
         }
-
-        assert(idxloc__ < local_size(rank__));
-
-        return rank__ * block_size_ + idxloc__;
+        this->block_id_ = block_id__;
     }
 
-    inline T global_offset() const
+    virtual ~splindex()
     {
-        return global_index(0, this->rank_);
     }
 
-    inline T global_offset(int rank__) const
+    /// Return local size of the split index for a given block.
+    virtual value_type local_size(block_id block_id__) const = 0;
+
+    /// Return location (block_id and local offset) of the global index.
+    virtual location_t location(typename Index_t::global idx__) const = 0;
+
+    /// Return global index by block id and local index.
+    virtual typename Index_t::global global_index(typename Index_t::local idxloc__, block_id block_id__) const = 0;
+
+    /// Return local size for the current block.
+    value_type local_size() const
     {
-        return global_index(0, rank__);
+        return this->local_size(this->block_id_);
     }
 
-    inline T operator[](T idxloc__) const
+    /// Return global index of an element by local index and block id.
+    inline auto global_index(typename splindex<Index_t>::location_t loc__) const
     {
-        return global_index(idxloc__, this->rank_);
+        return this->global_index(loc__.index_local, loc__.ib);
     }
 
-    inline std::vector<T> offsets() const
+    inline auto global_index(typename Index_t::local idxloc__) const
     {
-        std::vector<T> v(this->num_ranks_);
-        for (int i = 0; i < this->num_ranks_; i++) {
-            v[i] = global_offset(i);
-        }
-        return v;
+        return this->global_index(idxloc__, this->block_id_);
     }
 
-    inline std::vector<T> counts() const
+    /// Return total length of the index (global number of elements).
+    inline auto size() const noexcept
     {
-        std::vector<T> v(this->num_ranks_);
-        for (int i = 0; i < this->num_ranks_; i++) {
-            v[i] = local_size(i);
-        }
-        return v;
+        return size_;
+    }
+
+    /// Compute size of the block from global index size and number of blocks.
+    static inline auto block_size(value_type size__, n_blocks n_blocks__)
+    {
+        return size__ / n_blocks__ + std::min(value_type(1), size__ % n_blocks__);
     }
 };
 
-/// Specialization for the block-cyclic distribution.
-template <typename T>
-class splindex<splindex_t::block_cyclic, T> : public splindex_base<T>
+template <typename Index_t>
+class splindex_iterator_t : public std::iterator<std::random_access_iterator_tag, Index_t>
 {
   private:
-    /// cyclic block size of the distribution
-    int block_size_{-1};
-
-    // Check and initialize variables.
-    void init(T global_index_size__, int num_ranks__, int rank__, int block_size__)
-    {
-        this->global_index_size_ = global_index_size__;
-
-        if (num_ranks__ < 0) {
-            std::stringstream s;
-            s << "wrong number of ranks: " << num_ranks__;
-            throw std::runtime_error(s.str());
-        }
-        this->num_ranks_ = num_ranks__;
-
-        if (rank__ < 0 || rank__ >= num_ranks__) {
-            std::stringstream s;
-            s << "wrong rank: " << rank__;
-            throw std::runtime_error(s.str());
-        }
-        this->rank_ = rank__;
-
-        if (block_size__ <= 0) {
-            std::stringstream s;
-            s << "wrong block size: " << block_size__;
-            throw std::runtime_error(s.str());
-        }
-        block_size_ = block_size__;
-    }
-
+    splindex<Index_t> const& idx_;
   public:
-    struct iterator
-    {
-        T idxloc_;
-        T idxglob_;
-        T num_blocks_min_;
-        int block_size_;
-        int rank_;
-        int num_ranks_;
-
-        iterator(T idxglob__, int num_ranks__, int block_size__)
-            : idxglob_(idxglob__)
-            , num_ranks_(num_ranks__)
-            , block_size_(block_size__)
-        {
-            /* number of full blocks */
-            T num_blocks = idxglob__ / block_size_;
-            num_blocks_min_ = num_blocks / num_ranks_;
-            idxloc_ = num_blocks_min_ * block_size_ + idxglob_ % block_size_;
-            rank_ = static_cast<int>(num_blocks % num_ranks_);
-        }
-
-        bool operator!=(iterator const& rhs__) const
-        {
-            return idxglob_ != rhs__.idxglob_;
-        }
-
-        iterator& operator++()
-        {
-            idxglob_++;
-            idxloc_++;
-            if (idxloc_ % block_size_ == 0) {
-                rank_++;
-                if (rank_ % num_ranks_ == 0) {
-                    num_blocks_min_++;
-                    rank_ = 0;
-                }
-                idxloc_ = num_blocks_min_ * block_size_;// + idxglob_ % block_size_;
-            }
-        }
-    };
-
-    /// Default constructor
-    splindex()
+    using difference_type = typename std::iterator<std::random_access_iterator_tag, Index_t>::difference_type;
+    typename Index_t::local li;
+    typename Index_t::global i;
+    splindex_iterator_t(splindex<Index_t> const& idx__)
+        : idx_{idx__}
+        , li{0}
+        , i{0}
     {
     }
-
-    /// Constructor with implicit cyclic block size
-    splindex(T global_index_size__, int num_ranks__, int rank__, int bs__)
+    inline bool operator!=(splindex_iterator_t<Index_t> const& rhs__)
     {
-        init(global_index_size__, num_ranks__, rank__, bs__);
+        return this->li != rhs__.li;
+    }
+    inline splindex_iterator_t<Index_t>& operator++()
+    {
+        this->li++;
+        return *this;
+    }
+    inline splindex_iterator_t<Index_t>& operator++(int)
+    {
+        splindex_iterator_t<Index_t> tmp(this->idx());
+        this->li++;
+        return tmp;
+    }
+    inline splindex_iterator_t<Index_t> const& operator*()
+    {
+        this->i = idx_.global_index(this->li);
+        return *this;
+    }
+    inline difference_type operator-(splindex_iterator_t<Index_t> const& rhs__) const
+    {
+        return li - rhs__.li;
+    }
+    inline splindex_iterator_t<Index_t>& operator+=(difference_type rhs__)
+    {
+        li += rhs__;
+        return *this;
+    }
+};
+
+template <typename Index_t = basic_index_t<int>>
+class splindex_block : public splindex<Index_t>
+{
+  public:
+    using value_type = typename splindex<Index_t>::value_type;
+  private:
+    /// Local index size of a given block.
+    value_type block_size_;
+  public:
+    splindex_block()
+    {
+    }
+    /// Constructor.
+    splindex_block(value_type size__, n_blocks n_blocks__, block_id block_id__)
+        : splindex<Index_t>(size__, n_blocks__, block_id__)
+    {
+        this->block_size_ = this->block_size(size__, n_blocks__);
     }
 
-    iterator at(T idxglob__) const
+    using splindex<Index_t>::local_size;
+
+    /// Return local size of the split index for a given block.
+    inline value_type local_size(block_id block_id__) const
     {
-        return iterator(idxglob__, this->num_ranks_, this->block_size_);
+        RTE_ASSERT(block_id__ >= 0 && block_id__ < this->n_blocks_);
+
+        if (this->size_ == 0) {
+            return 0;
+        }
+
+        auto n = static_cast<int>(this->size_ / block_size_);
+        if (block_id__ < n) {
+            return block_size_;
+        } else {
+            return this->size_ - block_id__ * block_size_;
+        }
     }
 
     /// Return "local index, rank" pair for a global index.
-    inline typename splindex_base<T>::location_t location(T idxglob__) const
+    inline typename splindex<Index_t>::location_t location(typename Index_t::global idx__) const
     {
-        assert(idxglob__ < this->global_index_size_);
+        RTE_ASSERT(idx__ < this->size_);
 
-        /* number of full blocks */
-        T num_blocks = idxglob__ / block_size_;
+        auto ib = static_cast<int>(idx__ / this->block_size_);
+        value_type idxloc = idx__ - ib * this->block_size_;
 
-        /* local index */
-        T idxloc = (num_blocks / this->num_ranks_) * block_size_ + idxglob__ % block_size_;
-
-        /* corresponding rank */
-        int rank = static_cast<int>(num_blocks % this->num_ranks_);
-
-        return typename splindex_base<T>::location_t(idxloc, rank);
+        return typename splindex<Index_t>::location_t(typename Index_t::local(idxloc), block_id(ib));
     }
 
-    /// Return local size of the split index for an arbitrary rank.
-    inline T local_size(int rank__) const
+    using splindex<Index_t>::global_index;
+
+    /// Return global index of an element by local index and block id.
+    inline typename Index_t::global global_index(typename Index_t::local idxloc__, block_id block_id__) const
     {
-        assert(rank__ >= 0 && rank__ < this->num_ranks_);
+        RTE_ASSERT(block_id__ >= 0 && block_id__ < this->n_blocks_);
 
+        if (this->local_size(block_id__) == 0) {
+            return typename Index_t::global(-1);
+        }
+
+        RTE_ASSERT(idxloc__ < local_size(block_id__));
+
+        return typename Index_t::global(this->block_size_ * block_id__ + idxloc__);
+    }
+
+    inline auto global_offset() const
+    {
+        return this->global_index(0, this->block_id_);
+    }
+
+};
+
+template <typename Index_t = basic_index_t<int>>
+class splindex_block_cyclic : public splindex<Index_t>
+{
+  public:
+    using value_type = typename splindex<Index_t>::value_type;
+  private:
+    /// Cyclic block size.
+    value_type block_size_;
+  public:
+    splindex_block_cyclic()
+    {
+    }
+    /// Constructor.
+    splindex_block_cyclic(value_type size__, n_blocks n_blocks__, block_id block_id__, value_type block_size__)
+        : splindex<Index_t>(size__, n_blocks__, block_id__)
+        , block_size_{block_size__}
+    {
+    }
+
+    using splindex<Index_t>::local_size;
+
+    /// Return local size of the split index for a given block.
+    inline value_type local_size(block_id block_id__) const
+    {
+        RTE_ASSERT(block_id__ >= 0 && block_id__ < this->n_blocks_);
+
+        if (this->size_ == 0) {
+            return 0;
+        }
         /* number of full blocks */
-        T num_blocks = this->global_index_size_ / block_size_;
+        auto num_blocks = this->size() / this->block_size_;
 
-        T n = (num_blocks / this->num_ranks_) * block_size_;
+        auto n = (num_blocks / this->n_blocks_) * this->block_size_;
+        auto rank_offs = static_cast<int>(num_blocks % this->n_blocks_);
 
-        int rank_offs = static_cast<int>(num_blocks % this->num_ranks_);
-
-        if (rank__ < rank_offs) {
-            n += block_size_;
-        } else if (rank__ == rank_offs) {
-            n += this->global_index_size_ % block_size_;
+        if (this->block_id_ < rank_offs) {
+            n += this->block_size_;
+        } else if (this->block_id_== rank_offs) {
+            n += this->size_ % this->block_size_;
         }
         return n;
     }
 
-    /// Return local size of the split index for a current rank.
-    inline T local_size() const
+    /// Return "local index, rank" pair for a global index.
+    inline typename splindex<Index_t>::location_t location(typename Index_t::global idx__) const
     {
-        return local_size(this->rank_);
+        RTE_ASSERT(idx__ < this->size_);
+
+        /* number of full blocks */
+        auto num_blocks = idx__ / this->block_size_;
+
+        /* local index */
+        value_type idxloc = (num_blocks / this->n_blocks_) * block_size_ + idx__ % this->block_size_;
+
+        /* corresponding rank */
+        auto ib = static_cast<int>(num_blocks % this->n_blocks_);
+
+        return typename splindex<Index_t>::location_t(typename Index_t::local(idxloc), block_id(ib));
     }
 
-    /// Return rank which holds the element with the given global index.
-    inline int local_rank(T idxglob__) const
+    using splindex<Index_t>::global_index;
+
+    /// Return global index of an element by local index and block id.
+    inline typename Index_t::global global_index(typename Index_t::local idxloc__, block_id block_id__) const
     {
-        return location(idxglob__).rank;
+        RTE_ASSERT(block_id__ >= 0 && block_id__ < this->n_blocks_);
+        RTE_ASSERT(idxloc__ < local_size(block_id__));
+
+        auto nb = idxloc__ / this->block_size_;
+
+        return typename Index_t::global((nb * this->n_blocks_ + block_id__) * this->block_size_ +
+                idxloc__ % this->block_size_);
     }
 
-    /// Return local index of the element for the rank which handles the given global index.
-    inline T local_index(T idxglob__) const
-    {
-        return location(idxglob__).local_index;
-    }
-
-    /// Get a global index by local index of a rank.
-    inline T global_index(T idxloc__, int rank__) const
-    {
-        assert(rank__ >= 0 && rank__ < this->num_ranks_);
-        assert(idxloc__ < local_size(rank__));
-
-        T nb = idxloc__ / block_size_;
-
-        return (nb * this->num_ranks_ + rank__) * block_size_ + idxloc__ % block_size_;
-    }
-
-    /// Get global index of this rank.
-    inline T operator[](T idxloc__) const
-    {
-        return global_index(idxloc__, this->rank_);
-    }
 };
 
-/// Specialization for the block distribution.
-template <typename T>
-class splindex<splindex_t::chunk, T> : public splindex_base<T>
+
+////    inline T operator[](T idxloc__) const
+////    {
+////        return global_index(idxloc__, this->rank_);
+////    }
+////
+////    inline std::vector<T> offsets() const
+////    {
+////        std::vector<T> v(this->num_ranks_);
+////        for (int i = 0; i < this->num_ranks_; i++) {
+////            v[i] = global_offset(i);
+////        }
+////        return v;
+////    }
+////
+////    inline std::vector<T> counts() const
+////    {
+////        std::vector<T> v(this->num_ranks_);
+////        for (int i = 0; i < this->num_ranks_; i++) {
+////            v[i] = local_size(i);
+////        }
+////        return v;
+////    }
+//};
+//
+///// Specialization for the block-cyclic distribution.
+//template <typename Index_t>
+//class splindex<splindex_t::block_cyclic, Index_t> : public splindex<Index_t>
+//{
+//
+////
+////    /// Return rank which holds the element with the given global index.
+////    inline int local_rank(T idxglob__) const
+////    {
+////        return location(idxglob__).rank;
+////    }
+////
+////    /// Return local index of the element for the rank which handles the given global index.
+////    inline T local_index(T idxglob__) const
+////    {
+////        return location(idxglob__).local_index;
+////    }
+////
+////
+////    /// Get global index of this rank.
+////    inline T operator[](T idxloc__) const
+////    {
+////        return global_index(idxloc__, this->rank_);
+////    }
+////};
+
+/// Specialization for the external block distribution.
+template <typename Index_t = basic_index_t<int>>
+class splindex_chunk : public splindex<Index_t>
 {
+  public:
+    using value_type = typename splindex<Index_t>::value_type;
   private:
-    std::vector<std::vector<T>> global_index_;
-    std::vector<typename splindex_base<T>::location_t> locations_;
+    std::vector<std::vector<value_type>> global_index_;
+    std::vector<typename splindex<Index_t>::location_t> locations_;
 
   public:
     /// Default constructor.
-    splindex()
+    splindex_chunk()
     {
     }
 
     /// Constructor with specific partitioning.
-    splindex(T global_index_size__, int num_ranks__, int rank__, std::vector<T> const& counts__)
+    splindex_chunk(value_type size__, n_blocks n_blocks__, block_id block_id__, std::vector<value_type> const counts__)
+        : splindex<Index_t>(size__, n_blocks__, block_id__)
     {
-        this->global_index_size_ = global_index_size__;
-
-        if (num_ranks__ < 0) {
-            std::stringstream s;
-            s << "wrong number of ranks: " << num_ranks__;
-            throw std::runtime_error(s.str());
-        }
-        this->num_ranks_ = num_ranks__;
-
-        if (rank__ < 0 || rank__ >= num_ranks__) {
-            std::stringstream s;
-            s << "wrong rank: " << rank__;
-            throw std::runtime_error(s.str());
-        }
-        this->rank_ = rank__;
-
-        for (int r = 0; r < num_ranks__; r++) {
-            global_index_.push_back(std::vector<T>());
-            for (int i = 0; i < counts__[r]; i++) {
-                global_index_.back().push_back(static_cast<T>(locations_.size()));
-                locations_.push_back(typename splindex_base<T>::location_t(i, r));
+        for (int r = 0; r < n_blocks__.get(); r++) {
+            global_index_.push_back(std::vector<value_type>());
+            for (value_type i = 0; i < counts__[r]; i++) {
+                global_index_.back().push_back(static_cast<value_type>(locations_.size()));
+                locations_.push_back(typename splindex<Index_t>::location_t(typename Index_t::local(i), block_id(r)));
             }
         }
 
-        assert(static_cast<T>(locations_.size()) == global_index_size__);
+        RTE_ASSERT(static_cast<value_type>(locations_.size()) == this->size());
     }
 
-    inline T local_size(int rank__) const
-    {
-        assert(rank__ >= 0);
-        assert(rank__ < this->num_ranks_);
-        return static_cast<T>(global_index_[rank__].size());
-    }
+    using splindex<Index_t>::local_size;
 
-    inline T local_size() const
+    inline value_type local_size(block_id block_id__) const
     {
-        return local_size(this->rank_);
-    }
+        RTE_ASSERT(block_id__ >= 0 && block_id__ < this->n_blocks_);
 
-    inline int local_rank(T idxglob__) const
-    {
-        return locations_[idxglob__].rank;
-    }
-
-    inline T local_index(T idxglob__) const
-    {
-        return locations_[idxglob__].local_index;
-    }
-
-    inline T global_index(T idxloc__, int rank__) const
-    {
-        if (local_size(rank__) == 0) {
-            return std::numeric_limits<T>::max();
+        if (this->size_ == 0) {
+            return 0;
         }
-
-        assert(idxloc__ < local_size(rank__));
-
-        return global_index_[rank__][idxloc__];
+        return static_cast<value_type>(global_index_[block_id__].size());
     }
 
-    inline T operator[](T idxloc__) const
+    inline typename splindex<Index_t>::location_t location(typename Index_t::global idx__) const
     {
-        return global_index(idxloc__, this->rank_);
+        return locations_[idx__];
     }
 
-    inline T global_offset() const
+    using splindex<Index_t>::global_index;
+
+    inline typename Index_t::global global_index(typename Index_t::local idxloc__, block_id block_id__) const
     {
-        return global_index(0, this->rank_);
+        RTE_ASSERT(block_id__ >= 0 && block_id__ < this->n_blocks_);
+        RTE_ASSERT(idxloc__ < local_size(block_id__));
+
+        return typename Index_t::global(global_index_[block_id__][idxloc__]);
     }
 };
 
+
+////    inline int local_rank(T idxglob__) const
+////    {
+////        return locations_[idxglob__].rank;
+////    }
+////
+////    inline T local_index(T idxglob__) const
+////    {
+////        return locations_[idxglob__].local_index;
+////    }
+////
+////    inline T global_index(T idxloc__, int rank__) const
+////    {
+////        if (local_size(rank__) == 0) {
+////            return std::numeric_limits<T>::max();
+////        }
+////
+////        RTE_ASSERT(idxloc__ < local_size(rank__));
+////    }
+////
+////    inline T operator[](T idxloc__) const
+////    {
+////        return global_index(idxloc__, this->rank_);
+////    }
+////
+////    inline T global_offset() const
+////    {
+////        return global_index(0, this->rank_);
+////    }
+////};
+////
+////
+//
+//template <typename Index_t>
+//auto begin_local(splindex<Index_t> const& a__)
+//{
+//    return typename Index_t::local(0);
+//}
+//
+template <typename Index_t>
+auto begin_global(splindex<Index_t> const& a__)
+{
+    return typename Index_t::global(0);
+}
+
+//template <typename Index_t>
+//auto end_local(splindex<Index_t> const& a__)
+//{
+//    return typename Index_t::local(a__.local_size());
+//}
+
+template <typename Index_t>
+auto end_global(splindex<Index_t> const& a__)
+{
+    return typename Index_t::global(a__.size());
+}
+
+template <typename Index_t>
+auto begin(splindex<Index_t> const& a__)
+{
+    splindex_iterator_t<Index_t> it(a__);
+    it.li = typename Index_t::local(0);
+    return it;
+}
+
+template <typename Index_t>
+auto end(splindex<Index_t> const& a__)
+{
+    splindex_iterator_t<Index_t> it(a__);
+    it.li = typename Index_t::local(a__.local_size());
+    return it;
+}
+
+
+//
+///// Type of index domain.
+//enum class index_domain_t
+//{
+//    /// Global index.
+//    global,
+//    /// Local index.
+//    local
+//};
+//
+///// Base class for split index.
+//template <typename T>
+//class splindex_base
+//{
+//  protected:
+//    /// Rank of the block with local fraction of the global index.
+//    int rank_{-1};
+//
+//    /// Number of ranks over which the global index is distributed.
+//    int num_ranks_{-1};
+//
+//    /// size of the global index
+//    T global_index_size_;
+//
+//    /// Default constructor.
+//    splindex_base()
+//    {
+//    }
+//
+//    /// Pair of <local index, rank> describing the location of a global index.
+//    struct location_t
+//    {
+//        T local_index;
+//        int rank;
+//        location_t(T local_index__, int rank__)
+//            : local_index(local_index__)
+//            , rank(rank__)
+//        {
+//        }
+//    };
+//
+//  public:
+//    /// Rank id.
+//    inline int rank() const
+//    {
+//        return rank_;
+//    }
+//
+//    /// Number of ranks that are participating in the distribution of an index.
+//    inline int num_ranks() const
+//    {
+//        return num_ranks_;
+//    }
+//
+//    inline T global_index_size() const
+//    {
+//        return global_index_size_;
+//    }
+//
+//    static inline T block_size(T size__, int num_ranks__)
+//    {
+//        return size__ / num_ranks__ + std::min(T(1), size__ % num_ranks__);
+//    }
+//};
+//
+///// Split index.
+//template <splindex_t type, typename T = int>
+//class splindex : public splindex_base<T>
+//{
+//};
+//
+///// Specialization for the block distribution.
+//template <typename T>
+//class splindex<splindex_t::block, T> : public splindex_base<T>
+//{
+//  private:
+//    T block_size_;
+//
+//    void init(T global_index_size__, int num_ranks__, int rank__)
+//    {
+//        this->global_index_size_ = global_index_size__;
+//
+//        if (num_ranks__ < 0) {
+//            std::stringstream s;
+//            s << "wrong number of ranks: " << num_ranks__;
+//            throw std::runtime_error(s.str());
+//        }
+//        this->num_ranks_ = num_ranks__;
+//
+//        if (rank__ < 0 || rank__ >= num_ranks__) {
+//            std::stringstream s;
+//            s << "wrong rank: " << rank__;
+//            throw std::runtime_error(s.str());
+//        }
+//        this->rank_ = rank__;
+//
+//        block_size_ = this->block_size(global_index_size__, num_ranks__);
+//    }
+//
+//  public:
+//    /// Default constructor
+//    splindex()
+//    {
+//    }
+//
+//    /// Constructor.
+//    splindex(T global_index_size__, int num_ranks__, int rank__)
+//    {
+//        init(global_index_size__, num_ranks__, rank__);
+//    }
+//
+//    /// Return "local index, rank" pair for a global index.
+//    inline typename splindex_base<T>::location_t location(T idxglob__) const
+//    {
+//        RTE_ASSERT(idxglob__ < this->global_index_size_);
+//
+//        int rank = int(idxglob__ / block_size_);
+//        T idxloc = idxglob__ - rank * block_size_;
+//
+//        return typename splindex_base<T>::location_t(idxloc, rank);
+//    }
+//
+//    /// Return local size of the split index for an arbitrary rank.
+//    inline T local_size(int rank__) const
+//    {
+//        RTE_ASSERT(rank__ >= 0 && rank__ < this->num_ranks_);
+//
+//        if (this->global_index_size_ == 0) {
+//            return 0;
+//        }
+//
+//        int n = static_cast<int>(this->global_index_size_ / block_size_);
+//        if (rank__ < n) {
+//            return block_size_;
+//        } else if (rank__ == n) {
+//            return this->global_index_size_ - rank__ * block_size_;
+//        } else {
+//            return 0;
+//        }
+//    }
+//
+//    /// Return local size of the split index for a current rank.
+//    inline T local_size() const
+//    {
+//        return local_size(this->rank_);
+//    }
+//
+//    /// Return rank which holds the element with the given global index.
+//    inline int local_rank(T idxglob__) const
+//    {
+//        return location(idxglob__).rank;
+//    }
+//
+//    /// Return local index of the element for the rank which handles the given global index.
+//    inline T local_index(T idxglob__) const
+//    {
+//        return location(idxglob__).local_index;
+//    }
+//
+//    /// Return global index of an element by local index and rank.
+//    inline T global_index(T idxloc__, int rank__) const
+//    {
+//        RTE_ASSERT(rank__ >= 0 && rank__ < this->num_ranks_);
+//
+//        if (local_size(rank__) == 0) {
+//            return std::numeric_limits<T>::max();
+//        }
+//
+//        RTE_ASSERT(idxloc__ < local_size(rank__));
+//
+//        return rank__ * block_size_ + idxloc__;
+//    }
+//
+//    inline T global_offset() const
+//    {
+//        return global_index(0, this->rank_);
+//    }
+//
+//    inline T global_offset(int rank__) const
+//    {
+//        return global_index(0, rank__);
+//    }
+//
+//    inline T operator[](T idxloc__) const
+//    {
+//        return global_index(idxloc__, this->rank_);
+//    }
+//
+//    inline std::vector<T> offsets() const
+//    {
+//        std::vector<T> v(this->num_ranks_);
+//        for (int i = 0; i < this->num_ranks_; i++) {
+//            v[i] = global_offset(i);
+//        }
+//        return v;
+//    }
+//
+//    inline std::vector<T> counts() const
+//    {
+//        std::vector<T> v(this->num_ranks_);
+//        for (int i = 0; i < this->num_ranks_; i++) {
+//            v[i] = local_size(i);
+//        }
+//        return v;
+//    }
+//};
+//
+///// Specialization for the block-cyclic distribution.
+//template <typename T>
+//class splindex<splindex_t::block_cyclic, T> : public splindex_base<T>
+//{
+//  private:
+//    /// cyclic block size of the distribution
+//    int block_size_{-1};
+//
+//    // Check and initialize variables.
+//    void init(T global_index_size__, int num_ranks__, int rank__, int block_size__)
+//    {
+//        this->global_index_size_ = global_index_size__;
+//
+//        if (num_ranks__ < 0) {
+//            std::stringstream s;
+//            s << "wrong number of ranks: " << num_ranks__;
+//            throw std::runtime_error(s.str());
+//        }
+//        this->num_ranks_ = num_ranks__;
+//
+//        if (rank__ < 0 || rank__ >= num_ranks__) {
+//            std::stringstream s;
+//            s << "wrong rank: " << rank__;
+//            throw std::runtime_error(s.str());
+//        }
+//        this->rank_ = rank__;
+//
+//        if (block_size__ <= 0) {
+//            std::stringstream s;
+//            s << "wrong block size: " << block_size__;
+//            throw std::runtime_error(s.str());
+//        }
+//        block_size_ = block_size__;
+//    }
+//
+//  public:
+//    struct iterator
+//    {
+//        T idxloc_;
+//        T idxglob_;
+//        T num_blocks_min_;
+//        int block_size_;
+//        int rank_;
+//        int num_ranks_;
+//
+//        iterator(T idxglob__, int num_ranks__, int block_size__)
+//            : idxglob_(idxglob__)
+//            , num_ranks_(num_ranks__)
+//            , block_size_(block_size__)
+//        {
+//            /* number of full blocks */
+//            T num_blocks = idxglob__ / block_size_;
+//            num_blocks_min_ = num_blocks / num_ranks_;
+//            idxloc_ = num_blocks_min_ * block_size_ + idxglob_ % block_size_;
+//            rank_ = static_cast<int>(num_blocks % num_ranks_);
+//        }
+//
+//        bool operator!=(iterator const& rhs__) const
+//        {
+//            return idxglob_ != rhs__.idxglob_;
+//        }
+//
+//        iterator& operator++()
+//        {
+//            idxglob_++;
+//            idxloc_++;
+//            if (idxloc_ % block_size_ == 0) {
+//                rank_++;
+//                if (rank_ % num_ranks_ == 0) {
+//                    num_blocks_min_++;
+//                    rank_ = 0;
+//                }
+//                idxloc_ = num_blocks_min_ * block_size_;// + idxglob_ % block_size_;
+//            }
+//        }
+//    };
+//
+//    /// Default constructor
+//    splindex()
+//    {
+//    }
+//
+//    /// Constructor with implicit cyclic block size
+//    splindex(T global_index_size__, int num_ranks__, int rank__, int bs__)
+//    {
+//        init(global_index_size__, num_ranks__, rank__, bs__);
+//    }
+//
+//    iterator at(T idxglob__) const
+//    {
+//        return iterator(idxglob__, this->num_ranks_, this->block_size_);
+//    }
+//
+//    /// Return "local index, rank" pair for a global index.
+//    inline typename splindex_base<T>::location_t location(T idxglob__) const
+//    {
+//        RTE_ASSERT(idxglob__ < this->global_index_size_);
+//
+//        /* number of full blocks */
+//        T num_blocks = idxglob__ / block_size_;
+//
+//        /* local index */
+//        T idxloc = (num_blocks / this->num_ranks_) * block_size_ + idxglob__ % block_size_;
+//
+//        /* corresponding rank */
+//        int rank = static_cast<int>(num_blocks % this->num_ranks_);
+//
+//        return typename splindex_base<T>::location_t(idxloc, rank);
+//    }
+//
+//    /// Return local size of the split index for an arbitrary rank.
+//    inline T local_size(int rank__) const
+//    {
+//        RTE_ASSERT(rank__ >= 0 && rank__ < this->num_ranks_);
+//
+//        /* number of full blocks */
+//        T num_blocks = this->global_index_size_ / block_size_;
+//
+//        T n = (num_blocks / this->num_ranks_) * block_size_;
+//
+//        int rank_offs = static_cast<int>(num_blocks % this->num_ranks_);
+//
+//        if (rank__ < rank_offs) {
+//            n += block_size_;
+//        } else if (rank__ == rank_offs) {
+//            n += this->global_index_size_ % block_size_;
+//        }
+//        return n;
+//    }
+//
+//    /// Return local size of the split index for a current rank.
+//    inline T local_size() const
+//    {
+//        return local_size(this->rank_);
+//    }
+//
+//    /// Return rank which holds the element with the given global index.
+//    inline int local_rank(T idxglob__) const
+//    {
+//        return location(idxglob__).rank;
+//    }
+//
+//    /// Return local index of the element for the rank which handles the given global index.
+//    inline T local_index(T idxglob__) const
+//    {
+//        return location(idxglob__).local_index;
+//    }
+//
+//    /// Get a global index by local index of a rank.
+//    inline T global_index(T idxloc__, int rank__) const
+//    {
+//        RTE_ASSERT(rank__ >= 0 && rank__ < this->num_ranks_);
+//        RTE_ASSERT(idxloc__ < local_size(rank__));
+//
+//        T nb = idxloc__ / block_size_;
+//
+//        return (nb * this->num_ranks_ + rank__) * block_size_ + idxloc__ % block_size_;
+//    }
+//
+//    /// Get global index of this rank.
+//    inline T operator[](T idxloc__) const
+//    {
+//        return global_index(idxloc__, this->rank_);
+//    }
+//};
+//
+///// Specialization for the block distribution.
+//template <typename T>
+//class splindex<splindex_t::chunk, T> : public splindex_base<T>
+//{
+//  private:
+//    std::vector<std::vector<T>> global_index_;
+//    std::vector<typename splindex_base<T>::location_t> locations_;
+//
+//  public:
+//    /// Default constructor.
+//    splindex()
+//    {
+//    }
+//
+//    /// Constructor with specific partitioning.
+//    splindex(T global_index_size__, int num_ranks__, int rank__, std::vector<T> const& counts__)
+//    {
+//        this->global_index_size_ = global_index_size__;
+//
+//        if (num_ranks__ < 0) {
+//            std::stringstream s;
+//            s << "wrong number of ranks: " << num_ranks__;
+//            throw std::runtime_error(s.str());
+//        }
+//        this->num_ranks_ = num_ranks__;
+//
+//        if (rank__ < 0 || rank__ >= num_ranks__) {
+//            std::stringstream s;
+//            s << "wrong rank: " << rank__;
+//            throw std::runtime_error(s.str());
+//        }
+//        this->rank_ = rank__;
+//
+//        for (int r = 0; r < num_ranks__; r++) {
+//            global_index_.push_back(std::vector<T>());
+//            for (int i = 0; i < counts__[r]; i++) {
+//                global_index_.back().push_back(static_cast<T>(locations_.size()));
+//                locations_.push_back(typename splindex_base<T>::location_t(i, r));
+//            }
+//        }
+//
+//        RTE_ASSERT(static_cast<T>(locations_.size()) == global_index_size__);
+//    }
+//
+//    inline T local_size(int rank__) const
+//    {
+//        RTE_ASSERT(rank__ >= 0);
+//        RTE_ASSERT(rank__ < this->num_ranks_);
+//        return static_cast<T>(global_index_[rank__].size());
+//    }
+//
+//    inline T local_size() const
+//    {
+//        return local_size(this->rank_);
+//    }
+//
+//    inline int local_rank(T idxglob__) const
+//    {
+//        return locations_[idxglob__].rank;
+//    }
+//
+//    inline T local_index(T idxglob__) const
+//    {
+//        return locations_[idxglob__].local_index;
+//    }
+//
+//    inline T global_index(T idxloc__, int rank__) const
+//    {
+//        if (local_size(rank__) == 0) {
+//            return std::numeric_limits<T>::max();
+//        }
+//
+//        RTE_ASSERT(idxloc__ < local_size(rank__));
+//
+//        return global_index_[rank__][idxloc__];
+//    }
+//
+//    inline T operator[](T idxloc__) const
+//    {
+//        return global_index(idxloc__, this->rank_);
+//    }
+//
+//    inline T global_offset() const
+//    {
+//        return global_index(0, this->rank_);
+//    }
+//};
+//
 } // namespace sddk
 
 #endif // __SPLINDEX_HPP__

--- a/src/SDDK/splindex.hpp
+++ b/src/SDDK/splindex.hpp
@@ -194,21 +194,16 @@ template <typename Index_t>
 class splindex_iterator_t : public std::iterator<std::random_access_iterator_tag, Index_t>
 {
   private:
-    splindex<Index_t> const& idx_;
+    splindex<Index_t> const* idx_{nullptr};
   public:
     using difference_type = typename std::iterator<std::random_access_iterator_tag, Index_t>::difference_type;
     typename Index_t::local li;
     typename Index_t::global i;
 
     splindex_iterator_t<Index_t>& operator=(splindex_iterator_t<Index_t> const& lhs_) = default;
-    //{
-    //    this->li = lhs_.li;
-    //    this->i = lhs_.i;
-    //    return *this;
-    //}
 
     splindex_iterator_t(splindex<Index_t> const& idx__)
-        : idx_{idx__}
+        : idx_{&idx__}
         , li{0}
         , i{0}
     {
@@ -230,7 +225,7 @@ class splindex_iterator_t : public std::iterator<std::random_access_iterator_tag
     }
     inline splindex_iterator_t<Index_t> const& operator*()
     {
-        this->i = idx_.global_index(this->li);
+        this->i = idx_->global_index(this->li);
         return *this;
     }
     inline difference_type operator-(splindex_iterator_t<Index_t> const& rhs__) const

--- a/src/SDDK/splindex.hpp
+++ b/src/SDDK/splindex.hpp
@@ -115,17 +115,6 @@ class splindex
     };
 
   public:
-    ///// Rank id.
-    //inline auto block_id() const noexcept
-    //{
-    //    return block_id_;
-    //}
-
-    ///// Number of ranks that are participating in the distribution of an index.
-    //inline auto n_blocks() const noexcept
-    //{
-    //    return n_blocks_;
-    //}
 
     /// Default constructor.
     splindex()
@@ -281,7 +270,7 @@ class splindex_block : public splindex<Index_t>
         if (block_id__ < n) {
             return block_size_;
         } else {
-            return this->size_ - block_id__ * block_size_;
+            return std::max(0, this->size_ - block_id__ * block_size_);
         }
     }
 
@@ -314,9 +303,22 @@ class splindex_block : public splindex<Index_t>
 
     inline auto global_offset() const
     {
-        return this->global_index(0, this->block_id_);
+        return this->global_index(typename Index_t::local(0), this->block_id_);
     }
 
+    inline auto global_offset(block_id iblock__) const
+    {
+        return this->global_index(typename Index_t::local(0), iblock__);
+    }
+
+    inline auto counts() const
+    {
+        std::vector<value_type> v(this->n_blocks_);
+        for (int i = 0; i < this->n_blocks_; i++) {
+            v[i] = local_size(block_id(i));
+        }
+        return v;
+    }
 };
 
 template <typename Index_t = basic_index_t<int>>
@@ -354,9 +356,9 @@ class splindex_block_cyclic : public splindex<Index_t>
         auto n = (num_blocks / this->n_blocks_) * this->block_size_;
         auto rank_offs = static_cast<int>(num_blocks % this->n_blocks_);
 
-        if (this->block_id_ < rank_offs) {
+        if (block_id__ < rank_offs) {
             n += this->block_size_;
-        } else if (this->block_id_== rank_offs) {
+        } else if (block_id__ == rank_offs) {
             n += this->size_ % this->block_size_;
         }
         return n;
@@ -395,58 +397,7 @@ class splindex_block_cyclic : public splindex<Index_t>
 
 };
 
-
-////    inline T operator[](T idxloc__) const
-////    {
-////        return global_index(idxloc__, this->rank_);
-////    }
-////
-////    inline std::vector<T> offsets() const
-////    {
-////        std::vector<T> v(this->num_ranks_);
-////        for (int i = 0; i < this->num_ranks_; i++) {
-////            v[i] = global_offset(i);
-////        }
-////        return v;
-////    }
-////
-////    inline std::vector<T> counts() const
-////    {
-////        std::vector<T> v(this->num_ranks_);
-////        for (int i = 0; i < this->num_ranks_; i++) {
-////            v[i] = local_size(i);
-////        }
-////        return v;
-////    }
-//};
-//
-///// Specialization for the block-cyclic distribution.
-//template <typename Index_t>
-//class splindex<splindex_t::block_cyclic, Index_t> : public splindex<Index_t>
-//{
-//
-////
-////    /// Return rank which holds the element with the given global index.
-////    inline int local_rank(T idxglob__) const
-////    {
-////        return location(idxglob__).rank;
-////    }
-////
-////    /// Return local index of the element for the rank which handles the given global index.
-////    inline T local_index(T idxglob__) const
-////    {
-////        return location(idxglob__).local_index;
-////    }
-////
-////
-////    /// Get global index of this rank.
-////    inline T operator[](T idxloc__) const
-////    {
-////        return global_index(idxloc__, this->rank_);
-////    }
-////};
-
-/// Specialization for the external block distribution.
+/// Externally defined block distribution.
 template <typename Index_t = basic_index_t<int>>
 class splindex_chunk : public splindex<Index_t>
 {
@@ -503,58 +454,18 @@ class splindex_chunk : public splindex<Index_t>
 
         return typename Index_t::global(global_index_[block_id__][idxloc__]);
     }
+
+    inline auto global_offset() const
+    {
+        return this->global_index(typename Index_t::local(0), this->block_id_);
+    }
 };
 
-
-////    inline int local_rank(T idxglob__) const
-////    {
-////        return locations_[idxglob__].rank;
-////    }
-////
-////    inline T local_index(T idxglob__) const
-////    {
-////        return locations_[idxglob__].local_index;
-////    }
-////
-////    inline T global_index(T idxloc__, int rank__) const
-////    {
-////        if (local_size(rank__) == 0) {
-////            return std::numeric_limits<T>::max();
-////        }
-////
-////        RTE_ASSERT(idxloc__ < local_size(rank__));
-////    }
-////
-////    inline T operator[](T idxloc__) const
-////    {
-////        return global_index(idxloc__, this->rank_);
-////    }
-////
-////    inline T global_offset() const
-////    {
-////        return global_index(0, this->rank_);
-////    }
-////};
-////
-////
-//
-//template <typename Index_t>
-//auto begin_local(splindex<Index_t> const& a__)
-//{
-//    return typename Index_t::local(0);
-//}
-//
 template <typename Index_t>
 auto begin_global(splindex<Index_t> const& a__)
 {
     return typename Index_t::global(0);
 }
-
-//template <typename Index_t>
-//auto end_local(splindex<Index_t> const& a__)
-//{
-//    return typename Index_t::local(a__.local_size());
-//}
 
 template <typename Index_t>
 auto end_global(splindex<Index_t> const& a__)
@@ -578,468 +489,6 @@ auto end(splindex<Index_t> const& a__)
     return it;
 }
 
-
-//
-///// Type of index domain.
-//enum class index_domain_t
-//{
-//    /// Global index.
-//    global,
-//    /// Local index.
-//    local
-//};
-//
-///// Base class for split index.
-//template <typename T>
-//class splindex_base
-//{
-//  protected:
-//    /// Rank of the block with local fraction of the global index.
-//    int rank_{-1};
-//
-//    /// Number of ranks over which the global index is distributed.
-//    int num_ranks_{-1};
-//
-//    /// size of the global index
-//    T global_index_size_;
-//
-//    /// Default constructor.
-//    splindex_base()
-//    {
-//    }
-//
-//    /// Pair of <local index, rank> describing the location of a global index.
-//    struct location_t
-//    {
-//        T local_index;
-//        int rank;
-//        location_t(T local_index__, int rank__)
-//            : local_index(local_index__)
-//            , rank(rank__)
-//        {
-//        }
-//    };
-//
-//  public:
-//    /// Rank id.
-//    inline int rank() const
-//    {
-//        return rank_;
-//    }
-//
-//    /// Number of ranks that are participating in the distribution of an index.
-//    inline int num_ranks() const
-//    {
-//        return num_ranks_;
-//    }
-//
-//    inline T global_index_size() const
-//    {
-//        return global_index_size_;
-//    }
-//
-//    static inline T block_size(T size__, int num_ranks__)
-//    {
-//        return size__ / num_ranks__ + std::min(T(1), size__ % num_ranks__);
-//    }
-//};
-//
-///// Split index.
-//template <splindex_t type, typename T = int>
-//class splindex : public splindex_base<T>
-//{
-//};
-//
-///// Specialization for the block distribution.
-//template <typename T>
-//class splindex<splindex_t::block, T> : public splindex_base<T>
-//{
-//  private:
-//    T block_size_;
-//
-//    void init(T global_index_size__, int num_ranks__, int rank__)
-//    {
-//        this->global_index_size_ = global_index_size__;
-//
-//        if (num_ranks__ < 0) {
-//            std::stringstream s;
-//            s << "wrong number of ranks: " << num_ranks__;
-//            throw std::runtime_error(s.str());
-//        }
-//        this->num_ranks_ = num_ranks__;
-//
-//        if (rank__ < 0 || rank__ >= num_ranks__) {
-//            std::stringstream s;
-//            s << "wrong rank: " << rank__;
-//            throw std::runtime_error(s.str());
-//        }
-//        this->rank_ = rank__;
-//
-//        block_size_ = this->block_size(global_index_size__, num_ranks__);
-//    }
-//
-//  public:
-//    /// Default constructor
-//    splindex()
-//    {
-//    }
-//
-//    /// Constructor.
-//    splindex(T global_index_size__, int num_ranks__, int rank__)
-//    {
-//        init(global_index_size__, num_ranks__, rank__);
-//    }
-//
-//    /// Return "local index, rank" pair for a global index.
-//    inline typename splindex_base<T>::location_t location(T idxglob__) const
-//    {
-//        RTE_ASSERT(idxglob__ < this->global_index_size_);
-//
-//        int rank = int(idxglob__ / block_size_);
-//        T idxloc = idxglob__ - rank * block_size_;
-//
-//        return typename splindex_base<T>::location_t(idxloc, rank);
-//    }
-//
-//    /// Return local size of the split index for an arbitrary rank.
-//    inline T local_size(int rank__) const
-//    {
-//        RTE_ASSERT(rank__ >= 0 && rank__ < this->num_ranks_);
-//
-//        if (this->global_index_size_ == 0) {
-//            return 0;
-//        }
-//
-//        int n = static_cast<int>(this->global_index_size_ / block_size_);
-//        if (rank__ < n) {
-//            return block_size_;
-//        } else if (rank__ == n) {
-//            return this->global_index_size_ - rank__ * block_size_;
-//        } else {
-//            return 0;
-//        }
-//    }
-//
-//    /// Return local size of the split index for a current rank.
-//    inline T local_size() const
-//    {
-//        return local_size(this->rank_);
-//    }
-//
-//    /// Return rank which holds the element with the given global index.
-//    inline int local_rank(T idxglob__) const
-//    {
-//        return location(idxglob__).rank;
-//    }
-//
-//    /// Return local index of the element for the rank which handles the given global index.
-//    inline T local_index(T idxglob__) const
-//    {
-//        return location(idxglob__).local_index;
-//    }
-//
-//    /// Return global index of an element by local index and rank.
-//    inline T global_index(T idxloc__, int rank__) const
-//    {
-//        RTE_ASSERT(rank__ >= 0 && rank__ < this->num_ranks_);
-//
-//        if (local_size(rank__) == 0) {
-//            return std::numeric_limits<T>::max();
-//        }
-//
-//        RTE_ASSERT(idxloc__ < local_size(rank__));
-//
-//        return rank__ * block_size_ + idxloc__;
-//    }
-//
-//    inline T global_offset() const
-//    {
-//        return global_index(0, this->rank_);
-//    }
-//
-//    inline T global_offset(int rank__) const
-//    {
-//        return global_index(0, rank__);
-//    }
-//
-//    inline T operator[](T idxloc__) const
-//    {
-//        return global_index(idxloc__, this->rank_);
-//    }
-//
-//    inline std::vector<T> offsets() const
-//    {
-//        std::vector<T> v(this->num_ranks_);
-//        for (int i = 0; i < this->num_ranks_; i++) {
-//            v[i] = global_offset(i);
-//        }
-//        return v;
-//    }
-//
-//    inline std::vector<T> counts() const
-//    {
-//        std::vector<T> v(this->num_ranks_);
-//        for (int i = 0; i < this->num_ranks_; i++) {
-//            v[i] = local_size(i);
-//        }
-//        return v;
-//    }
-//};
-//
-///// Specialization for the block-cyclic distribution.
-//template <typename T>
-//class splindex<splindex_t::block_cyclic, T> : public splindex_base<T>
-//{
-//  private:
-//    /// cyclic block size of the distribution
-//    int block_size_{-1};
-//
-//    // Check and initialize variables.
-//    void init(T global_index_size__, int num_ranks__, int rank__, int block_size__)
-//    {
-//        this->global_index_size_ = global_index_size__;
-//
-//        if (num_ranks__ < 0) {
-//            std::stringstream s;
-//            s << "wrong number of ranks: " << num_ranks__;
-//            throw std::runtime_error(s.str());
-//        }
-//        this->num_ranks_ = num_ranks__;
-//
-//        if (rank__ < 0 || rank__ >= num_ranks__) {
-//            std::stringstream s;
-//            s << "wrong rank: " << rank__;
-//            throw std::runtime_error(s.str());
-//        }
-//        this->rank_ = rank__;
-//
-//        if (block_size__ <= 0) {
-//            std::stringstream s;
-//            s << "wrong block size: " << block_size__;
-//            throw std::runtime_error(s.str());
-//        }
-//        block_size_ = block_size__;
-//    }
-//
-//  public:
-//    struct iterator
-//    {
-//        T idxloc_;
-//        T idxglob_;
-//        T num_blocks_min_;
-//        int block_size_;
-//        int rank_;
-//        int num_ranks_;
-//
-//        iterator(T idxglob__, int num_ranks__, int block_size__)
-//            : idxglob_(idxglob__)
-//            , num_ranks_(num_ranks__)
-//            , block_size_(block_size__)
-//        {
-//            /* number of full blocks */
-//            T num_blocks = idxglob__ / block_size_;
-//            num_blocks_min_ = num_blocks / num_ranks_;
-//            idxloc_ = num_blocks_min_ * block_size_ + idxglob_ % block_size_;
-//            rank_ = static_cast<int>(num_blocks % num_ranks_);
-//        }
-//
-//        bool operator!=(iterator const& rhs__) const
-//        {
-//            return idxglob_ != rhs__.idxglob_;
-//        }
-//
-//        iterator& operator++()
-//        {
-//            idxglob_++;
-//            idxloc_++;
-//            if (idxloc_ % block_size_ == 0) {
-//                rank_++;
-//                if (rank_ % num_ranks_ == 0) {
-//                    num_blocks_min_++;
-//                    rank_ = 0;
-//                }
-//                idxloc_ = num_blocks_min_ * block_size_;// + idxglob_ % block_size_;
-//            }
-//        }
-//    };
-//
-//    /// Default constructor
-//    splindex()
-//    {
-//    }
-//
-//    /// Constructor with implicit cyclic block size
-//    splindex(T global_index_size__, int num_ranks__, int rank__, int bs__)
-//    {
-//        init(global_index_size__, num_ranks__, rank__, bs__);
-//    }
-//
-//    iterator at(T idxglob__) const
-//    {
-//        return iterator(idxglob__, this->num_ranks_, this->block_size_);
-//    }
-//
-//    /// Return "local index, rank" pair for a global index.
-//    inline typename splindex_base<T>::location_t location(T idxglob__) const
-//    {
-//        RTE_ASSERT(idxglob__ < this->global_index_size_);
-//
-//        /* number of full blocks */
-//        T num_blocks = idxglob__ / block_size_;
-//
-//        /* local index */
-//        T idxloc = (num_blocks / this->num_ranks_) * block_size_ + idxglob__ % block_size_;
-//
-//        /* corresponding rank */
-//        int rank = static_cast<int>(num_blocks % this->num_ranks_);
-//
-//        return typename splindex_base<T>::location_t(idxloc, rank);
-//    }
-//
-//    /// Return local size of the split index for an arbitrary rank.
-//    inline T local_size(int rank__) const
-//    {
-//        RTE_ASSERT(rank__ >= 0 && rank__ < this->num_ranks_);
-//
-//        /* number of full blocks */
-//        T num_blocks = this->global_index_size_ / block_size_;
-//
-//        T n = (num_blocks / this->num_ranks_) * block_size_;
-//
-//        int rank_offs = static_cast<int>(num_blocks % this->num_ranks_);
-//
-//        if (rank__ < rank_offs) {
-//            n += block_size_;
-//        } else if (rank__ == rank_offs) {
-//            n += this->global_index_size_ % block_size_;
-//        }
-//        return n;
-//    }
-//
-//    /// Return local size of the split index for a current rank.
-//    inline T local_size() const
-//    {
-//        return local_size(this->rank_);
-//    }
-//
-//    /// Return rank which holds the element with the given global index.
-//    inline int local_rank(T idxglob__) const
-//    {
-//        return location(idxglob__).rank;
-//    }
-//
-//    /// Return local index of the element for the rank which handles the given global index.
-//    inline T local_index(T idxglob__) const
-//    {
-//        return location(idxglob__).local_index;
-//    }
-//
-//    /// Get a global index by local index of a rank.
-//    inline T global_index(T idxloc__, int rank__) const
-//    {
-//        RTE_ASSERT(rank__ >= 0 && rank__ < this->num_ranks_);
-//        RTE_ASSERT(idxloc__ < local_size(rank__));
-//
-//        T nb = idxloc__ / block_size_;
-//
-//        return (nb * this->num_ranks_ + rank__) * block_size_ + idxloc__ % block_size_;
-//    }
-//
-//    /// Get global index of this rank.
-//    inline T operator[](T idxloc__) const
-//    {
-//        return global_index(idxloc__, this->rank_);
-//    }
-//};
-//
-///// Specialization for the block distribution.
-//template <typename T>
-//class splindex<splindex_t::chunk, T> : public splindex_base<T>
-//{
-//  private:
-//    std::vector<std::vector<T>> global_index_;
-//    std::vector<typename splindex_base<T>::location_t> locations_;
-//
-//  public:
-//    /// Default constructor.
-//    splindex()
-//    {
-//    }
-//
-//    /// Constructor with specific partitioning.
-//    splindex(T global_index_size__, int num_ranks__, int rank__, std::vector<T> const& counts__)
-//    {
-//        this->global_index_size_ = global_index_size__;
-//
-//        if (num_ranks__ < 0) {
-//            std::stringstream s;
-//            s << "wrong number of ranks: " << num_ranks__;
-//            throw std::runtime_error(s.str());
-//        }
-//        this->num_ranks_ = num_ranks__;
-//
-//        if (rank__ < 0 || rank__ >= num_ranks__) {
-//            std::stringstream s;
-//            s << "wrong rank: " << rank__;
-//            throw std::runtime_error(s.str());
-//        }
-//        this->rank_ = rank__;
-//
-//        for (int r = 0; r < num_ranks__; r++) {
-//            global_index_.push_back(std::vector<T>());
-//            for (int i = 0; i < counts__[r]; i++) {
-//                global_index_.back().push_back(static_cast<T>(locations_.size()));
-//                locations_.push_back(typename splindex_base<T>::location_t(i, r));
-//            }
-//        }
-//
-//        RTE_ASSERT(static_cast<T>(locations_.size()) == global_index_size__);
-//    }
-//
-//    inline T local_size(int rank__) const
-//    {
-//        RTE_ASSERT(rank__ >= 0);
-//        RTE_ASSERT(rank__ < this->num_ranks_);
-//        return static_cast<T>(global_index_[rank__].size());
-//    }
-//
-//    inline T local_size() const
-//    {
-//        return local_size(this->rank_);
-//    }
-//
-//    inline int local_rank(T idxglob__) const
-//    {
-//        return locations_[idxglob__].rank;
-//    }
-//
-//    inline T local_index(T idxglob__) const
-//    {
-//        return locations_[idxglob__].local_index;
-//    }
-//
-//    inline T global_index(T idxloc__, int rank__) const
-//    {
-//        if (local_size(rank__) == 0) {
-//            return std::numeric_limits<T>::max();
-//        }
-//
-//        RTE_ASSERT(idxloc__ < local_size(rank__));
-//
-//        return global_index_[rank__][idxloc__];
-//    }
-//
-//    inline T operator[](T idxloc__) const
-//    {
-//        return global_index(idxloc__, this->rank_);
-//    }
-//
-//    inline T global_offset() const
-//    {
-//        return global_index(0, this->rank_);
-//    }
-//};
-//
 } // namespace sddk
 
 #endif // __SPLINDEX_HPP__

--- a/src/SDDK/wave_functions.hpp
+++ b/src/SDDK/wave_functions.hpp
@@ -114,7 +114,7 @@ auto checksum_gpu(std::complex<T> const* wf__, int ld__, int num_rows_loc__, int
 namespace wf {
 
 using spin_index = strong_type<int, struct __spin_index_tag>;
-using atom_index = strong_type<int, struct __atom_index_tag>;
+//using atom_index = strong_type<int, struct __atom_index_tag>;
 using band_index = strong_type<int, struct __band_index_tag>;
 
 using num_bands = strong_type<int, struct __num_bands_tag>;
@@ -555,14 +555,14 @@ class Wave_functions_mt : public Wave_functions_base<T>
 
     /// Return reference to the coefficient by atomic orbital index, atom, spin and band indices.
     inline auto&
-    mt_coeffs(int xi__, atom_index ia__, spin_index ispn__, band_index i__)
+    mt_coeffs(int xi__, atom_index_t::local ia__, spin_index ispn__, band_index i__)
     {
         return this->data_[ispn__.get()](this->num_pw_ + xi__ + offset_in_local_mt_coeffs_[ia__.get()], i__.get());
     }
 
     /// Return const reference to the coefficient by atomic orbital index, atom, spin and band indices.
     inline auto const&
-    mt_coeffs(int xi__, atom_index ia__, spin_index ispn__, band_index i__) const
+    mt_coeffs(int xi__, atom_index_t::local ia__, spin_index ispn__, band_index i__) const
     {
         return this->data_[ispn__.get()](this->num_pw_ + xi__ + offset_in_local_mt_coeffs_[ia__.get()], i__.get());
     }
@@ -571,14 +571,14 @@ class Wave_functions_mt : public Wave_functions_base<T>
 
     /// Return const pointer to the coefficient by atomic orbital index, atom, spin and band indices.
     inline std::complex<T> const*
-    at(sddk::memory_t mem__, int xi__, atom_index ia__, spin_index s__, band_index b__) const
+    at(sddk::memory_t mem__, int xi__, atom_index_t::local ia__, spin_index s__, band_index b__) const
     {
         return this->data_[s__.get()].at(mem__, this->num_pw_ + xi__ + offset_in_local_mt_coeffs_[ia__.get()], b__.get());
     }
 
     /// Return pointer to the coefficient by atomic orbital index, atom, spin and band indices.
     inline auto
-    at(sddk::memory_t mem__, int xi__, atom_index ia__, spin_index s__, band_index b__)
+    at(sddk::memory_t mem__, int xi__, atom_index_t::local ia__, spin_index s__, band_index b__)
     {
         return this->data_[s__.get()].at(mem__, this->num_pw_ + xi__ + offset_in_local_mt_coeffs_[ia__.get()], b__.get());
     }

--- a/src/SDDK/wave_functions.hpp
+++ b/src/SDDK/wave_functions.hpp
@@ -113,8 +113,6 @@ auto checksum_gpu(std::complex<T> const* wf__, int ld__, int num_rows_loc__, int
 /// Namespace for the wave-functions.
 namespace wf {
 
-using sirius::strong_type;
-
 using spin_index = strong_type<int, struct __spin_index_tag>;
 using atom_index = strong_type<int, struct __atom_index_tag>;
 using band_index = strong_type<int, struct __band_index_tag>;
@@ -494,7 +492,7 @@ class Wave_functions_mt : public Wave_functions_base<T>
     /// Total number of atoms.
     int num_atoms_{0};
     /// Distribution of atoms between MPI ranks.
-    sddk::splindex<sddk::splindex_t::block> spl_num_atoms_;
+    sddk::splindex_block<atom_index_t> spl_num_atoms_;
     /// Local size of muffin-tin coefficients for each rank.
     /** Each rank stores local fraction of atoms. Each atom has a set of MT coefficients. */
     mpi::block_data_descriptor mt_coeffs_distr_;
@@ -509,7 +507,7 @@ class Wave_functions_mt : public Wave_functions_base<T>
     static int get_local_num_mt_coeffs(std::vector<int> num_mt_coeffs__, mpi::Communicator const& comm__)
     {
         int num_atoms = static_cast<int>(num_mt_coeffs__.size());
-        sddk::splindex<sddk::splindex_t::block> spl_atoms(num_atoms, comm__.size(), comm__.rank());
+        sddk::splindex_block<atom_index_t> spl_atoms(num_atoms, n_blocks(comm__.size()), block_id(comm__.rank()));
         auto it_begin = num_mt_coeffs__.begin() + spl_atoms.global_offset();
         auto it_end = it_begin + spl_atoms.local_size();
         return std::accumulate(it_begin, it_end, 0);
@@ -520,7 +518,7 @@ class Wave_functions_mt : public Wave_functions_base<T>
             sddk::memory_t default_mem__, int num_pw__)
         : Wave_functions_base<T>(num_pw__, 0, num_md__, num_wf__, default_mem__)
         , comm_{comm__}
-        , spl_num_atoms_{sddk::splindex<sddk::splindex_t::block>(num_atoms_, comm_.size(), comm_.rank())}
+        , spl_num_atoms_{sddk::splindex_block<atom_index_t>(num_atoms_, comm_.size(), comm_.rank())}
     {
     }
 
@@ -537,13 +535,13 @@ class Wave_functions_mt : public Wave_functions_base<T>
                                  default_mem__)
         , comm_{comm__}
         , num_atoms_{static_cast<int>(num_mt_coeffs__.size())}
-        , spl_num_atoms_{sddk::splindex<sddk::splindex_t::block>(num_atoms_, comm_.size(), comm_.rank())}
+        , spl_num_atoms_{sddk::splindex_block<atom_index_t>(num_atoms_, n_blocks(comm_.size()), block_id(comm_.rank()))}
         , num_mt_coeffs_{num_mt_coeffs__}
     {
         mt_coeffs_distr_ = mpi::block_data_descriptor(comm_.size());
 
         for (int ia = 0; ia < num_atoms_; ia++) {
-            int rank = spl_num_atoms_.local_rank(ia);
+            auto rank = spl_num_atoms_.location(atom_index_t::global(ia)).ib;
             if (rank == comm_.rank()) {
                 offset_in_local_mt_coeffs_.push_back(mt_coeffs_distr_.counts[rank]);
             }
@@ -832,7 +830,7 @@ class Wave_functions_fft : public Wave_functions_base<T>
     /// Pointer to FFT-friendly G+k vector deistribution.
     std::shared_ptr<fft::Gvec_fft> gkvec_fft_;
     /// Split number of wave-functions between column communicator.
-    sddk::splindex<sddk::splindex_t::block> spl_num_wf_;
+    sddk::splindex_block<> spl_num_wf_;
     /// Pointer to the original wave-functions.
     Wave_functions<T>* wf_{nullptr};
     /// Spin-index of the wave-function component
@@ -861,7 +859,7 @@ class Wave_functions_fft : public Wave_functions_base<T>
         std::vector<int> colsplit(comm_col.size() + 1);
         colsplit[0] = 0;
         for (int i = 0; i < comm_col.size(); i++) {
-            colsplit[i + 1] = colsplit[i] + spl_num_wf_.local_size(i);
+            colsplit[i + 1] = colsplit[i] + spl_num_wf_.local_size(block_id(i));
         }
 
         std::vector<int> owners(gkvec_fft_->gvec().comm().size());
@@ -925,8 +923,8 @@ class Wave_functions_fft : public Wave_functions_base<T>
             /* send and receive dimensions */
             mpi::block_data_descriptor sd(comm_col.size()), rd(comm_col.size());
             for (int j = 0; j < comm_col.size(); j++) {
-                sd.counts[j] = spl_num_wf_.local_size(j) * row_distr.counts[comm_col.rank()];
-                rd.counts[j] = spl_num_wf_.local_size(comm_col.rank()) * row_distr.counts[j];
+                sd.counts[j] = spl_num_wf_.local_size(block_id(j)) * row_distr.counts[comm_col.rank()];
+                rd.counts[j] = spl_num_wf_.local_size(block_id(comm_col.rank())) * row_distr.counts[j];
             }
             sd.calc_offsets();
             rd.calc_offsets();
@@ -998,8 +996,8 @@ class Wave_functions_fft : public Wave_functions_base<T>
             /* send and receive dimensions */
             mpi::block_data_descriptor sd(comm_col.size()), rd(comm_col.size());
             for (int j = 0; j < comm_col.size(); j++) {
-                sd.counts[j] = spl_num_wf_.local_size(comm_col.rank()) * row_distr.counts[j];
-                rd.counts[j] = spl_num_wf_.local_size(j) * row_distr.counts[comm_col.rank()];
+                sd.counts[j] = spl_num_wf_.local_size(block_id(comm_col.rank())) * row_distr.counts[j];
+                rd.counts[j] = spl_num_wf_.local_size(block_id(j)) * row_distr.counts[comm_col.rank()];
             }
             sd.calc_offsets();
             rd.calc_offsets();
@@ -1064,7 +1062,7 @@ class Wave_functions_fft : public Wave_functions_base<T>
         , shuffle_flag_{shuffle_flag___}
     {
         auto& comm_col = gkvec_fft_->comm_ortho_fft();
-        spl_num_wf_ = sddk::splindex<sddk::splindex_t::block>(br__.size(), comm_col.size(), comm_col.rank());
+        spl_num_wf_ = sddk::splindex_block<>(br__.size(), n_blocks(comm_col.size()), block_id(comm_col.rank()));
         this->num_mt_ = 0;
         this->num_md_ = wf::num_mag_dims(0);
         this->num_sc_ = wf::num_spins(1);

--- a/src/SDDK/wave_functions.hpp
+++ b/src/SDDK/wave_functions.hpp
@@ -508,9 +508,11 @@ class Wave_functions_mt : public Wave_functions_base<T>
     {
         int num_atoms = static_cast<int>(num_mt_coeffs__.size());
         sddk::splindex_block<atom_index_t> spl_atoms(num_atoms, n_blocks(comm__.size()), block_id(comm__.rank()));
-        auto it_begin = num_mt_coeffs__.begin() + spl_atoms.global_offset();
-        auto it_end = it_begin + spl_atoms.local_size();
-        return std::accumulate(it_begin, it_end, 0);
+        int result{0};
+        for (auto it : spl_atoms) {
+            result += num_mt_coeffs__[it.i];
+        }
+        return result;
     }
 
     /// Construct without muffin-tin part.
@@ -518,7 +520,7 @@ class Wave_functions_mt : public Wave_functions_base<T>
             sddk::memory_t default_mem__, int num_pw__)
         : Wave_functions_base<T>(num_pw__, 0, num_md__, num_wf__, default_mem__)
         , comm_{comm__}
-        , spl_num_atoms_{sddk::splindex_block<atom_index_t>(num_atoms_, comm_.size(), comm_.rank())}
+        , spl_num_atoms_{sddk::splindex_block<atom_index_t>(num_atoms_, n_blocks(comm_.size()), block_id(comm_.rank()))}
     {
     }
 

--- a/src/band/band.cpp
+++ b/src/band/band.cpp
@@ -53,9 +53,8 @@ Band::initialize_subspace(K_point_set& kset__, Hamiltonian0<T>& H0__) const
         N = unit_cell_.num_ps_atomic_wf().first;
     }
 
-    for (int ikloc = 0; ikloc < kset__.spl_num_kpoints().local_size(); ikloc++) {
-        int ik  = kset__.spl_num_kpoints(ikloc);
-        auto kp = kset__.get<T>(ik);
+    for (auto it: kset__.spl_num_kpoints()) {
+        auto kp = kset__.get<T>(it.i);
         auto Hk = H0__(*kp);
         if (ctx_.gamma_point() && (ctx_.so_correction() == false)) {
             ::sirius::initialize_subspace<T, T>(Hk, N);

--- a/src/band/band.hpp
+++ b/src/band/band.hpp
@@ -88,10 +88,12 @@ class Band // TODO: Band class is lightweight and in principle can be converted 
 
         /* copy old N - num_locked x N - num_locked distributed matrix */
         if (N__ > 0) {
-            sddk::splindex<sddk::splindex_t::block_cyclic> spl_row(N__ - num_locked__,
-                    mtrx__.blacs_grid().num_ranks_row(), mtrx__.blacs_grid().rank_row(), mtrx__.bs_row());
-            sddk::splindex<sddk::splindex_t::block_cyclic> spl_col(N__ - num_locked__,
-                    mtrx__.blacs_grid().num_ranks_col(), mtrx__.blacs_grid().rank_col(), mtrx__.bs_col());
+            sddk::splindex_block_cyclic<> spl_row(N__ - num_locked__,
+                    n_blocks(mtrx__.blacs_grid().num_ranks_row()), block_id(mtrx__.blacs_grid().rank_row()),
+                    mtrx__.bs_row());
+            sddk::splindex_block_cyclic<> spl_col(N__ - num_locked__,
+                    n_blocks(mtrx__.blacs_grid().num_ranks_col()), block_id(mtrx__.blacs_grid().rank_col()),
+                    mtrx__.bs_col());
 
             if (mtrx_old__) {
                 if (spl_row.local_size()) {
@@ -135,10 +137,12 @@ class Band // TODO: Band class is lightweight and in principle can be converted 
         }
 
         if (ctx_.print_checksum()) {
-            sddk::splindex<sddk::splindex_t::block_cyclic> spl_row(N__ + n__ - num_locked__,
-                    mtrx__.blacs_grid().num_ranks_row(), mtrx__.blacs_grid().rank_row(), mtrx__.bs_row());
-            sddk::splindex<sddk::splindex_t::block_cyclic> spl_col(N__ + n__ - num_locked__,
-                    mtrx__.blacs_grid().num_ranks_col(), mtrx__.blacs_grid().rank_col(), mtrx__.bs_col());
+            sddk::splindex_block_cyclic<> spl_row(N__ + n__ - num_locked__,
+                    n_blocks(mtrx__.blacs_grid().num_ranks_row()), block_id(mtrx__.blacs_grid().rank_row()),
+                    mtrx__.bs_row());
+            sddk::splindex_block_cyclic<> spl_col(N__ + n__ - num_locked__,
+                    n_blocks(mtrx__.blacs_grid().num_ranks_col()), block_id(mtrx__.blacs_grid().rank_col()),
+                    mtrx__.bs_col());
             auto cs = mtrx__.checksum(N__ + n__ - num_locked__, N__ + n__ - num_locked__);
             if (ctx_.comm_band().rank() == 0) {
                 utils::print_checksum("subspace_mtrx", cs, RTE_OUT(std::cout));
@@ -150,10 +154,12 @@ class Band // TODO: Band class is lightweight and in principle can be converted 
 
         /* save new matrix */
         if (mtrx_old__) {
-            sddk::splindex<sddk::splindex_t::block_cyclic> spl_row(N__ + n__ - num_locked__,
-                    mtrx__.blacs_grid().num_ranks_row(), mtrx__.blacs_grid().rank_row(), mtrx__.bs_row());
-            sddk::splindex<sddk::splindex_t::block_cyclic> spl_col(N__ + n__ - num_locked__,
-                    mtrx__.blacs_grid().num_ranks_col(), mtrx__.blacs_grid().rank_col(), mtrx__.bs_col());
+            sddk::splindex_block_cyclic<> spl_row(N__ + n__ - num_locked__,
+                    n_blocks(mtrx__.blacs_grid().num_ranks_row()), block_id(mtrx__.blacs_grid().rank_row()),
+                    mtrx__.bs_row());
+            sddk::splindex_block_cyclic<> spl_col(N__ + n__ - num_locked__,
+                    n_blocks(mtrx__.blacs_grid().num_ranks_col()), block_id(mtrx__.blacs_grid().rank_col()),
+                    mtrx__.bs_col());
 
             if (spl_row.local_size()) {
                 #pragma omp parallel for schedule(static)

--- a/src/band/diag_full_potential.cpp
+++ b/src/band/diag_full_potential.cpp
@@ -300,11 +300,10 @@ void Band::diag_full_potential_first_variation_davidson(Hamiltonian_k<double>& H
 
     /* add pure local orbitals to the basis staring from ncomp index */
     if (nlo) {
-        for (int ialoc = 0; ialoc < phi_extra_new->spl_num_atoms().local_size(); ialoc++) {
-            int ia = phi_extra_new->spl_num_atoms()[ialoc];
-            for (int xi = 0; xi < unit_cell_.atom(ia).mt_lo_basis_size(); xi++) {
-                phi_extra_new->mt_coeffs(xi, wf::atom_index(ialoc), wf::spin_index(0),
-                        wf::band_index(offset_lo[ia] + xi + ncomp)) = 1.0;
+        for (auto it : phi_extra_new->spl_num_atoms()) {
+            for (int xi = 0; xi < unit_cell_.atom(it.i).mt_lo_basis_size(); xi++) {
+                phi_extra_new->mt_coeffs(xi, wf::atom_index(it.li), wf::spin_index(0),
+                        wf::band_index(offset_lo[it.i] + xi + ncomp)) = 1.0;
             }
         }
     }

--- a/src/band/diag_full_potential.cpp
+++ b/src/band/diag_full_potential.cpp
@@ -302,7 +302,7 @@ void Band::diag_full_potential_first_variation_davidson(Hamiltonian_k<double>& H
     if (nlo) {
         for (auto it : phi_extra_new->spl_num_atoms()) {
             for (int xi = 0; xi < unit_cell_.atom(it.i).mt_lo_basis_size(); xi++) {
-                phi_extra_new->mt_coeffs(xi, wf::atom_index(it.li), wf::spin_index(0),
+                phi_extra_new->mt_coeffs(xi, it.li, wf::spin_index(0),
                         wf::band_index(offset_lo[it.i] + xi + ncomp)) = 1.0;
             }
         }

--- a/src/band/residuals.hpp
+++ b/src/band/residuals.hpp
@@ -340,11 +340,13 @@ residuals(Simulation_context& ctx__, sddk::memory_t mem__, wf::spin_range sr__,
                 auto pos_src  = evec__.spl_col().location(ev_idx[j]);
                 auto pos_dest = evec_tmp.spl_col().location(j);
                 /* do MPI send / receive */
-                if (pos_src.rank == evec__.blacs_grid().comm_col().rank() && num_rows_local) {
-                    evec__.blacs_grid().comm_col().isend(&evec__(0, pos_src.local_index), num_rows_local, pos_dest.rank, ev_idx[j]);
+                if (pos_src.ib == evec__.blacs_grid().comm_col().rank() && num_rows_local) {
+                    evec__.blacs_grid().comm_col().isend(&evec__(0, pos_src.index_local), num_rows_local, pos_dest.ib,
+                            ev_idx[j]);
                 }
-                if (pos_dest.rank == evec__.blacs_grid().comm_col().rank() && num_rows_local) {
-                    evec__.blacs_grid().comm_col().recv(&evec_tmp(0, pos_dest.local_index), num_rows_local, pos_src.rank, ev_idx[j]);
+                if (pos_dest.ib == evec__.blacs_grid().comm_col().rank() && num_rows_local) {
+                    evec__.blacs_grid().comm_col().recv(&evec_tmp(0, pos_dest.index_local), num_rows_local, pos_src.ib,
+                            ev_idx[j]);
                 }
             }
         }

--- a/src/band/solve.cpp
+++ b/src/band/solve.cpp
@@ -144,9 +144,8 @@ Band::solve(K_point_set& kset__, Hamiltonian0<T>& H0__, double itsol_tol__) cons
 
     int num_dav_iter{0};
     /* solve secular equation and generate wave functions */
-    for (int ikloc = 0; ikloc < kset__.spl_num_kpoints().local_size(); ikloc++) {
-        int ik  = kset__.spl_num_kpoints(ikloc);
-        auto kp = kset__.get<T>(ik);
+    for (auto it : kset__.spl_num_kpoints()) {
+        auto kp = kset__.get<T>(it.i);
 
         auto Hk = H0__(*kp);
         if (ctx_.full_potential()) {

--- a/src/density/density.cpp
+++ b/src/density/density.cpp
@@ -794,10 +794,11 @@ add_k_point_contribution_dm_fplapw(Simulation_context const& ctx__, K_point<T> c
         for (int ispn = 0; ispn < ctx__.num_spins(); ispn++) {
             for (int j = 0; j < kp__.num_occupied_bands(ispn); j++) {
                 for (int xi = 0; xi < mt_basis_size; xi++) {
-                    auto z = kp__.spinor_wave_functions().mt_coeffs(xi, wf::atom_index(it.li),
-                            wf::spin_index(ispn), wf::band_index(j));
+                    auto z = kp__.spinor_wave_functions().mt_coeffs(xi, it.li, wf::spin_index(ispn),
+                            wf::band_index(j));
                     wf1(xi, j, ispn) = std::conj(z);
-                    wf2(xi, j, ispn) = static_cast<std::complex<double>>(z) * kp__.band_occupancy(j, ispn) * kp__.weight();
+                    wf2(xi, j, ispn) = static_cast<std::complex<double>>(z) * kp__.band_occupancy(j, ispn) *
+                        kp__.weight();
                 }
             }
         }

--- a/src/density/density.cpp
+++ b/src/density/density.cpp
@@ -433,7 +433,7 @@ Density::init_density_matrix_for_paw()
     density_matrix_.zero();
 
     for (int ipaw = 0; ipaw < unit_cell_.num_paw_atoms(); ipaw++) {
-        int ia = unit_cell_.paw_atom_index(ipaw);
+        int ia = unit_cell_.paw_atom_index(sirius::experimental::paw_atom_index_t::global(ipaw));
 
         auto& atom      = unit_cell_.atom(ia);
         auto& atom_type = atom.type();
@@ -473,10 +473,10 @@ Density::init_density_matrix_for_paw()
 }
 
 void
-Density::generate_paw_atom_density(int ialoc__)
+Density::generate_paw_atom_density(sirius::experimental::paw_atom_index_t::local ialoc__)
 {
-    int ia_paw = ctx_.unit_cell().spl_num_paw_atoms(ialoc__);
-    int ia     = ctx_.unit_cell().paw_atom_index(ia_paw);
+    auto ia_paw = ctx_.unit_cell().spl_num_paw_atoms(ialoc__);
+    auto ia     = ctx_.unit_cell().paw_atom_index(ia_paw);
 
     auto& atom_type = ctx_.unit_cell().atom(ia).type();
 
@@ -565,7 +565,7 @@ Density::generate_paw_loc_density()
 
     #pragma omp parallel for
     for (int ialoc = 0; ialoc < unit_cell_.spl_num_paw_atoms().local_size(); ialoc++) {
-        generate_paw_atom_density(ialoc);
+        generate_paw_atom_density(sirius::experimental::paw_atom_index_t::local(ialoc));
     }
 }
 

--- a/src/density/density.hpp
+++ b/src/density/density.hpp
@@ -249,7 +249,7 @@ class Density : public Field4D
                                  Hubbard_matrix>> mixer_;
 
     /// Generate atomic densities in the case of PAW.
-    void generate_paw_atom_density(int iapaw__);
+    void generate_paw_atom_density(paw_atom_index_t::local iapaw__);
 
     /// Initialize PAW density matrix.
     void init_density_matrix_for_paw();
@@ -309,13 +309,14 @@ class Density : public Field4D
     {
         PROFILE("sirius::Density::generate_core_charge_density");
 
-        for (int icloc = 0; icloc < unit_cell_.spl_num_atom_symmetry_classes().local_size(); icloc++) {
-            int ic = unit_cell_.spl_num_atom_symmetry_classes(icloc);
-            unit_cell_.atom_symmetry_class(ic).generate_core_charge_density(ctx_.core_relativity());
+        auto& spl_idx = unit_cell_.spl_num_atom_symmetry_classes();
+
+        for (auto it : spl_idx) {
+            unit_cell_.atom_symmetry_class(it.i).generate_core_charge_density(ctx_.core_relativity());
         }
 
-        for (int ic = 0; ic < unit_cell_.num_atom_symmetry_classes(); ic++) {
-            int rank = unit_cell_.spl_num_atom_symmetry_classes().local_rank(ic);
+        for (auto ic = begin_global(spl_idx); ic != end_global(spl_idx); ic++) {
+            auto rank = spl_idx.location(ic).ib;
             unit_cell_.atom_symmetry_class(ic).sync_core_charge_density(ctx_.comm(), rank);
         }
     }
@@ -439,9 +440,9 @@ class Density : public Field4D
         return *rho_pseudo_core_;
     }
 
-    inline auto const& density_mt(int ialoc) const
+    inline auto const& density_mt(atom_index_t::local ialoc__) const
     {
-        int ia = ctx_.unit_cell().spl_num_atoms(ialoc);
+        auto ia = ctx_.unit_cell().spl_num_atoms(ialoc__);
         return rho().mt()[ia];
     }
 

--- a/src/density/density.hpp
+++ b/src/density/density.hpp
@@ -442,7 +442,7 @@ class Density : public Field4D
 
     inline auto const& density_mt(atom_index_t::local ialoc__) const
     {
-        auto ia = ctx_.unit_cell().spl_num_atoms(ialoc__);
+        auto ia = ctx_.unit_cell().spl_num_atoms().global_index(ialoc__);
         return rho().mt()[ia];
     }
 

--- a/src/dft/dft_ground_state.cpp
+++ b/src/dft/dft_ground_state.cpp
@@ -280,12 +280,11 @@ DFT_ground_state::find(double density_tol__, double energy_tol__, double iter_so
                     ctx_.cfg().parameters().precision_hs("fp64");
                     ctx_.cfg().lock();
 
-                    for (int ikloc = 0; ikloc < kset_.spl_num_kpoints().local_size(); ikloc++) {
-                        int ik = kset_.spl_num_kpoints(ikloc);
+                    for (auto it : kset_.spl_num_kpoints()) {
                         for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
-                            wf::copy(sddk::memory_t::host, kset_.get<float>(ik)->spinor_wave_functions(),
+                            wf::copy(sddk::memory_t::host, kset_.get<float>(it.i)->spinor_wave_functions(),
                                     wf::spin_index(ispn), wf::band_range(0, ctx_.num_bands()),
-                                    kset_.get<double>(ik)->spinor_wave_functions(), wf::spin_index(ispn),
+                                    kset_.get<double>(it.i)->spinor_wave_functions(), wf::spin_index(ispn),
                                     wf::band_range(0, ctx_.num_bands()));
                         }
                     }

--- a/src/dft/dft_ground_state.cpp
+++ b/src/dft/dft_ground_state.cpp
@@ -79,9 +79,8 @@ DFT_ground_state::energy_kin_sum_pw() const
 {
     double ekin{0};
 
-    for (int ikloc = 0; ikloc < kset_.spl_num_kpoints().local_size(); ikloc++) {
-        int ik  = kset_.spl_num_kpoints(ikloc);
-        auto kp = kset_.get<double>(ik);
+    for (auto it : kset_.spl_num_kpoints()) {
+        auto kp = kset_.get<double>(it.i);
 
         #pragma omp parallel for schedule(static) reduction(+:ekin)
         for (int igloc = 0; igloc < kp->num_gkvec_loc(); igloc++) {

--- a/src/dft/energy.cpp
+++ b/src/dft/energy.cpp
@@ -106,10 +106,9 @@ energy_enuc(Simulation_context const& ctx, Potential const& potential)
     auto& unit_cell = ctx.unit_cell();
     double enuc{0};
     if (ctx.full_potential()) {
-        for (int ialoc = 0; ialoc < unit_cell.spl_num_atoms().local_size(); ialoc++) {
-            int ia = unit_cell.spl_num_atoms(ialoc);
-            int zn = unit_cell.atom(ia).zn();
-            enuc -= 0.5 * zn * potential.vh_el(ia);
+        for (auto it : unit_cell.spl_num_atoms()) {
+            int zn = unit_cell.atom(it.i).zn();
+            enuc -= 0.5 * zn * potential.vh_el(it.i);
         }
         ctx.comm().allreduce(&enuc, 1);
     }

--- a/src/fft/fft.hpp
+++ b/src/fft/fft.hpp
@@ -232,7 +232,7 @@ inline size_t spfft_grid_size_local(T const& spfft__)
  *  using block distribution. */
 inline auto split_z_dimension(int size_z__, mpi::Communicator const& comm_fft__)
 {
-    return sddk::splindex<sddk::splindex_t::block>(size_z__, comm_fft__.size(), comm_fft__.rank());
+    return sddk::splindex_block<>(size_z__, n_blocks(comm_fft__.size()), block_id(comm_fft__.rank()));
 }
 
 } // namespace fft

--- a/src/fft/gvec.hpp
+++ b/src/fft/gvec.hpp
@@ -920,7 +920,7 @@ class Gvec_shells
     mpi::block_data_descriptor a2a_recv_;
 
     /// Split global index of G-shells between MPI ranks.
-    sddk::splindex<sddk::splindex_t::block_cyclic> spl_num_gsh_;
+    sddk::splindex_block_cyclic<> spl_num_gsh_;
 
     /// List of G-vectors in the remapped storage.
     sddk::mdarray<int, 2> gvec_remapped_;
@@ -996,7 +996,7 @@ class Gvec_shells
         for (int igloc = 0; igloc < gvec_.count(); igloc++) {
             int ig                                     = gvec_.offset() + igloc;
             int igsh                                   = gvec_.shell(ig);
-            int r                                      = spl_num_gsh_.local_rank(igsh);
+            int r                                      = spl_num_gsh_.location(igsh).ib;
             send_buf[a2a_send_.offsets[r] + counts[r]] = data__[igloc];
             counts[r]++;
         }
@@ -1023,7 +1023,7 @@ class Gvec_shells
         for (int igloc = 0; igloc < gvec_.count(); igloc++) {
             int ig        = gvec_.offset() + igloc;
             int igsh      = gvec_.shell(ig);
-            int r         = spl_num_gsh_.local_rank(igsh);
+            int r         = spl_num_gsh_.location(igsh).ib;
             data__[igloc] = recv_buf[a2a_send_.offsets[r] + counts[r]];
             counts[r]++;
         }

--- a/src/function3d/field4d.cpp
+++ b/src/function3d/field4d.cpp
@@ -96,7 +96,7 @@ void Field4D::symmetrize(Periodic_function<double>* f__, Periodic_function<doubl
     }
 
     if (ctx_.full_potential()) {
-        std::vector<Spheric_function_set<double>*> frlm;
+        std::vector<Spheric_function_set<double, atom_index_t>*> frlm;
         frlm.push_back(&f__->mt());
         switch (ctx_.num_mag_dims()) {
             case 1: {

--- a/src/function3d/paw_field4d.hpp
+++ b/src/function3d/paw_field4d.hpp
@@ -38,9 +38,9 @@ class PAW_field4D
     /// Unit cell.
     Unit_cell const& uc_;
     /// All-electron part.
-    std::array<Spheric_function_set<T>, 4> ae_components_;
+    std::array<Spheric_function_set<T, paw_atom_index_t>, 4> ae_components_;
     /// Pseudo-potential part.
-    std::array<Spheric_function_set<T>, 4> ps_components_;
+    std::array<Spheric_function_set<T, paw_atom_index_t>, 4> ps_components_;
     /* copy constructor is forbidden */
     PAW_field4D(PAW_field4D const& src__) = delete;
     /* copy assignment operator is forbidden */
@@ -57,9 +57,9 @@ class PAW_field4D
         auto ptr = (is_global__) ? nullptr : &uc__.spl_num_paw_atoms();
 
         for (int j = 0; j < uc__.parameters().num_mag_dims() + 1; j++) {
-            ae_components_[j] = Spheric_function_set<T>(uc__, uc__.paw_atoms(),
+            ae_components_[j] = Spheric_function_set<T, paw_atom_index_t>(uc__, uc__.paw_atoms(),
                     [&uc__](int ia){return lmax_t(2 * uc__.atom(ia).type().indexr().lmax());}, ptr);
-            ps_components_[j] = Spheric_function_set<T>(uc__, uc__.paw_atoms(),
+            ps_components_[j] = Spheric_function_set<T, paw_atom_index_t>(uc__, uc__.paw_atoms(),
                     [&uc__](int ia){return lmax_t(2 * uc__.atom(ia).type().indexr().lmax());}, ptr);
         }
     }

--- a/src/function3d/periodic_function.hpp
+++ b/src/function3d/periodic_function.hpp
@@ -64,7 +64,7 @@ class Periodic_function
     Smooth_periodic_function<T> rg_component_;
 
     /// Muffin-tin part of the periodic function.
-    Spheric_function_set<T> mt_component_;
+    Spheric_function_set<T, atom_index_t> mt_component_;
 
     /// Alias to G-vectors.
     fft::Gvec const& gvec_;
@@ -88,7 +88,7 @@ class Periodic_function
 
     /// Constructor for interstitial and muffin-tin parts (FP-LAPW case).
     Periodic_function(Simulation_context const& ctx__, std::function<lmax_t(int)> lmax__,
-            sddk::splindex<sddk::splindex_t::block> const* spl_atoms__ = nullptr,
+            sddk::splindex_block<atom_index_t> const* spl_atoms__ = nullptr,
             smooth_periodic_function_ptr_t<T> const* rg_ptr__ = nullptr,
             spheric_function_set_ptr_t<T> const* mt_ptr__ = nullptr)
         : ctx_(ctx__)
@@ -162,9 +162,8 @@ class Periodic_function
         if (ctx_.full_potential()) {
             mt_val = std::vector<T>(unit_cell_.num_atoms(), 0);
 
-            for (int ialoc = 0; ialoc < unit_cell_.spl_num_atoms().local_size(); ialoc++) {
-                int ia     = unit_cell_.spl_num_atoms(ialoc);
-                mt_val[ia] = mt_component_[ia].component(0).integrate(2) * fourpi * y00;
+            for (auto it : unit_cell_.spl_num_atoms()) {
+                mt_val[it.i] = mt_component_[it.i].component(0).integrate(2) * fourpi * y00;
             }
 
             comm_.allreduce(&mt_val[0], unit_cell_.num_atoms());

--- a/src/geometry/stress.cpp
+++ b/src/geometry/stress.cpp
@@ -50,9 +50,8 @@ Stress::calc_stress_nonloc_aux()
 
     print_memory_usage(ctx_.out(), FILE_LINE);
 
-    for (int ikloc = 0; ikloc < kset_.spl_num_kpoints().local_size(); ikloc++) {
-        int ik  = kset_.spl_num_kpoints(ikloc);
-        auto kp = kset_.get<T>(ik);
+    for (auto it : kset_.spl_num_kpoints()) {
+        auto kp = kset_.get<T>(it.i);
         auto mem = ctx_.processing_unit_memory_t();
         auto mg = kp->spinor_wave_functions().memory_guard(mem, wf::copy_to::device);
         Beta_projectors_strain_deriv<T> bp_strain_deriv(ctx_, kp->gkvec());
@@ -131,9 +130,8 @@ Stress::calc_stress_hubbard()
     if (is_device_memory(ctx_.processing_unit_memory_t())) {
         dn.allocate(ctx_.processing_unit_memory_t());
     }
-    for (int ikloc = 0; ikloc < kset_.spl_num_kpoints().local_size(); ikloc++) {
-        int ik  = kset_.spl_num_kpoints(ikloc);
-        auto kp = kset_.get<double>(ik);
+    for (auto it : kset_.spl_num_kpoints()) {
+        auto kp = kset_.get<double>(it.i);
         dn.zero();
         if (is_device_memory(ctx_.processing_unit_memory_t())) {
             dn.zero(ctx_.processing_unit_memory_t());
@@ -650,9 +648,8 @@ Stress::calc_stress_kin_aux()
 {
     stress_kin_.zero();
 
-    for (int ikloc = 0; ikloc < kset_.spl_num_kpoints().local_size(); ikloc++) {
-        int ik  = kset_.spl_num_kpoints(ikloc);
-        auto kp = kset_.get<T>(ik);
+    for (auto it : kset_.spl_num_kpoints()) {
+        auto kp = kset_.get<T>(it.i);
 
         double fact = kp->gkvec().reduced() ? 2.0 : 1.0;
         fact *=  kp->weight();

--- a/src/hamiltonian/hamiltonian.cpp
+++ b/src/hamiltonian/hamiltonian.cpp
@@ -158,9 +158,8 @@ Hamiltonian0<T>::apply_bmt(wf::Wave_functions<T>& psi__, std::vector<wf::Wave_fu
     sddk::mdarray<std::complex<T>, 3> zm(unit_cell_.max_mt_basis_size(), unit_cell_.max_mt_basis_size(), ctx_.num_mag_dims());
 
     for (int ialoc = 0; ialoc < psi__.spl_num_atoms().local_size(); ialoc++) {
-        int ia            = psi__.spl_num_atoms()[ialoc];
+        auto ia           = psi__.spl_num_atoms().global_index(atom_index_t::local(ialoc));
         auto& atom        = unit_cell_.atom(ia);
-        //int offset        = psi__.offset_mt_coeffs(ialoc);
         int mt_basis_size = atom.type().mt_basis_size();
 
         zm.zero();
@@ -220,7 +219,7 @@ Hamiltonian0<T>::apply_so_correction(wf::Wave_functions<T>& psi__, std::vector<w
     wf::spin_index s(0);
 
     for (int ialoc = 0; ialoc < psi__.spl_num_atoms().local_size(); ialoc++) {
-        int ia     = psi__.spl_num_atoms()[ialoc];
+        auto ia    = psi__.spl_num_atoms().global_index(atom_index_t::local(ialoc));
         auto& atom = unit_cell_.atom(ia);
         wf::atom_index a(ialoc);
 

--- a/src/hamiltonian/hamiltonian.cpp
+++ b/src/hamiltonian/hamiltonian.cpp
@@ -157,8 +157,8 @@ Hamiltonian0<T>::apply_bmt(wf::Wave_functions<T>& psi__, std::vector<wf::Wave_fu
 {
     sddk::mdarray<std::complex<T>, 3> zm(unit_cell_.max_mt_basis_size(), unit_cell_.max_mt_basis_size(), ctx_.num_mag_dims());
 
-    for (int ialoc = 0; ialoc < psi__.spl_num_atoms().local_size(); ialoc++) {
-        auto ia           = psi__.spl_num_atoms().global_index(atom_index_t::local(ialoc));
+    for (auto it : psi__.spl_num_atoms()) {
+        auto ia           = it.i;
         auto& atom        = unit_cell_.atom(ia);
         int mt_basis_size = atom.type().mt_basis_size();
 
@@ -182,9 +182,9 @@ Hamiltonian0<T>::apply_bmt(wf::Wave_functions<T>& psi__, std::vector<wf::Wave_fu
         /* compute bwf = B_z*|wf_j> */
         la::wrap(la::lib_t::blas).hemm(
             'L', 'U', mt_basis_size, ctx_.num_fv_states(), &la::constant<std::complex<T>>::one(),
-            zm.at(sddk::memory_t::host), zm.ld(), &psi__.mt_coeffs(0, wf::atom_index(ialoc), wf::spin_index(0), wf::band_index(0)),
+            zm.at(sddk::memory_t::host), zm.ld(), &psi__.mt_coeffs(0, it.li, wf::spin_index(0), wf::band_index(0)),
             psi__.ld(), &la::constant<std::complex<T>>::zero(),
-            &bpsi__[0].mt_coeffs(0, wf::atom_index(ialoc), wf::spin_index(0), wf::band_index(0)), bpsi__[0].ld());
+            &bpsi__[0].mt_coeffs(0, it.li, wf::spin_index(0), wf::band_index(0)), bpsi__[0].ld());
 
         /* compute bwf = (B_x - iB_y)|wf_j> */
         if (bpsi__.size() == 3) {
@@ -203,9 +203,9 @@ Hamiltonian0<T>::apply_bmt(wf::Wave_functions<T>& psi__, std::vector<wf::Wave_fu
 
             la::wrap(la::lib_t::blas).gemm(
                'N', 'N', mt_basis_size, ctx_.num_fv_states(), mt_basis_size, &la::constant<std::complex<T>>::one(),
-               zm.at(sddk::memory_t::host), zm.ld(), &psi__.mt_coeffs(0, wf::atom_index(ialoc), wf::spin_index(0), wf::band_index(0)),
+               zm.at(sddk::memory_t::host), zm.ld(), &psi__.mt_coeffs(0, it.li, wf::spin_index(0), wf::band_index(0)),
                psi__.ld(), &la::constant<std::complex<T>>::zero(),
-               &bpsi__[2].mt_coeffs(0, wf::atom_index(ialoc), wf::spin_index(0), wf::band_index(0)), bpsi__[2].ld());
+               &bpsi__[2].mt_coeffs(0, it.li, wf::spin_index(0), wf::band_index(0)), bpsi__[2].ld());
         }
     }
 }
@@ -218,10 +218,10 @@ Hamiltonian0<T>::apply_so_correction(wf::Wave_functions<T>& psi__, std::vector<w
 
     wf::spin_index s(0);
 
-    for (int ialoc = 0; ialoc < psi__.spl_num_atoms().local_size(); ialoc++) {
-        auto ia    = psi__.spl_num_atoms().global_index(atom_index_t::local(ialoc));
+    for (auto it : psi__.spl_num_atoms()) {
+        auto ia    = it.i;
         auto& atom = unit_cell_.atom(ia);
-        wf::atom_index a(ialoc);
+        auto a     = it.li;
 
         for (int l = 0; l <= atom.type().lmax_apw(); l++) {
             /* number of radial functions for this l */

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -896,7 +896,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
             int naw    = type.mt_aw_basis_size();
             int nlo    = type.mt_lo_basis_size();
 
-            auto aidx  = wf::atom_index(it.li);
+            auto aidx  = it.li;
 
             auto& hmt = this->H0_.hmt(ia);
 
@@ -926,7 +926,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
             int naw    = type.mt_aw_basis_size();
             int nlo    = type.mt_lo_basis_size();
 
-            auto aidx  = wf::atom_index(it.li);
+            auto aidx  = it.li;
 
             for (int j = 0; j < b__.size(); j++) {
                 for (int ilo = 0; ilo < nlo; ilo++) {
@@ -958,7 +958,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
             int naw    = type.mt_aw_basis_size();
             int nlo    = type.mt_lo_basis_size();
 
-            auto aidx  = wf::atom_index(it.li);
+            auto aidx  = it.li;
 
             auto& hmt = H0_.hmt(ia);
 
@@ -980,7 +980,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
             auto& atom = ctx.unit_cell().atom(ia);
             auto& type = atom.type();
 
-            auto aidx  = wf::atom_index(it.li);
+            auto aidx  = it.li;
 
             for (int ilo = 0; ilo < type.mt_lo_basis_size(); ilo++) {
                 int xi_lo = type.mt_aw_basis_size() + ilo;
@@ -1017,7 +1017,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
             auto& type = atom.type();
             int naw    = type.mt_aw_basis_size();
 
-            auto aidx  = wf::atom_index(it.li);
+            auto aidx  = it.li;
 
             auto& hmt = H0_.hmt(ia);
 
@@ -1042,7 +1042,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
             int naw    = type.mt_aw_basis_size();
             int nlo    = type.mt_lo_basis_size();
 
-            auto aidx  = wf::atom_index(it.li);
+            auto aidx  = it.li;
 
             auto& hmt = H0_.hmt(ia);
 
@@ -1067,7 +1067,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
             int naw    = type.mt_aw_basis_size();
             int nlo    = type.mt_lo_basis_size();
 
-            auto aidx  = wf::atom_index(it.li);
+            auto aidx  = it.li;
 
             for (int ilo = 0; ilo < nlo; ilo++) {
                 int xi_lo = naw + ilo;

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -210,11 +210,10 @@ Hamiltonian_k<T>::get_h_o_diag_lapw() const
 
     auto const& uc = H0_.ctx().unit_cell();
 
-    sddk::splindex<sddk::splindex_t::block> spl_num_atoms(uc.num_atoms(), kp_.comm().size(), kp_.comm().rank());
+    sddk::splindex_block<atom_index_t> spl_num_atoms(uc.num_atoms(), n_blocks(kp_.comm().size()), block_id(kp_.comm().rank()));
     int nlo{0};
-    for (int ialoc = 0; ialoc < spl_num_atoms.local_size(); ialoc++) {
-        int ia = spl_num_atoms[ialoc];
-        nlo += uc.atom(ia).mt_lo_basis_size();
+    for (auto it : spl_num_atoms) {
+        nlo += uc.atom(it.i).mt_lo_basis_size();
     }
 
     auto h_diag = (what & 1) ? sddk::mdarray<T, 2>(kp_.num_gkvec_loc() + nlo, 1) : sddk::mdarray<T, 2>();
@@ -283,11 +282,10 @@ Hamiltonian_k<T>::get_h_o_diag_lapw() const
     }
 
     nlo = 0;
-    for (int ialoc = 0; ialoc < spl_num_atoms.local_size(); ialoc++) {
-        int ia     = spl_num_atoms[ialoc];
-        auto& atom = uc.atom(ia);
+    for (auto it : spl_num_atoms) {
+        auto& atom = uc.atom(it.i);
         auto& type = atom.type();
-        auto& hmt = H0_.hmt(ia);
+        auto& hmt = H0_.hmt(it.i);
         #pragma omp parallel for
         for (int ilo = 0; ilo < type.mt_lo_basis_size(); ilo++) {
             int xi_lo = type.mt_aw_basis_size() + ilo;
@@ -890,15 +888,15 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
     auto apply_hmt_apw_lo = [this, &ctx, &phi__, la, mem, &b__, &spl_atoms](wf::Wave_functions_mt<T>& h_apw_lo__)
     {
         #pragma omp parallel for
-        for (int ialoc = 0; ialoc < spl_atoms.local_size(); ialoc++) {
+        for (auto it: spl_atoms) {
             int tid    = omp_get_thread_num();
-            int ia     = spl_atoms[ialoc];
+            int ia     = it.li;
             auto& atom = ctx.unit_cell().atom(ia);
             auto& type = atom.type();
             int naw    = type.mt_aw_basis_size();
             int nlo    = type.mt_lo_basis_size();
 
-            auto aidx  = wf::atom_index(ialoc);
+            auto aidx  = wf::atom_index(it.li);
 
             auto& hmt = this->H0_.hmt(ia);
 
@@ -921,14 +919,14 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
         o_apw_lo__.zero(sddk::memory_t::host, wf::spin_index(0), wf::band_range(0, b__.size()));
 
         #pragma omp parallel for
-        for (int ialoc = 0; ialoc < spl_atoms.local_size(); ialoc++) {
-            int ia     = spl_atoms[ialoc];
+        for (auto it : spl_atoms) {
+            int ia     = it.i;
             auto& atom = ctx.unit_cell().atom(ia);
             auto& type = atom.type();
             int naw    = type.mt_aw_basis_size();
             int nlo    = type.mt_lo_basis_size();
 
-            auto aidx  = wf::atom_index(ialoc);
+            auto aidx  = wf::atom_index(it.li);
 
             for (int j = 0; j < b__.size(); j++) {
                 for (int ilo = 0; ilo < nlo; ilo++) {
@@ -952,15 +950,15 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
     {
         /* lo-lo contribution */
         #pragma omp parallel for
-        for (int ialoc = 0; ialoc < spl_atoms.local_size(); ialoc++) {
+        for (auto it : spl_atoms) {
             int tid    = omp_get_thread_num();
-            int ia     = spl_atoms[ialoc];
+            auto ia    = it.i;
             auto& atom = ctx.unit_cell().atom(ia);
             auto& type = atom.type();
             int naw    = type.mt_aw_basis_size();
             int nlo    = type.mt_lo_basis_size();
 
-            auto aidx  = wf::atom_index(ialoc);
+            auto aidx  = wf::atom_index(it.li);
 
             auto& hmt = H0_.hmt(ia);
 
@@ -977,12 +975,12 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
     {
         /* lo-lo contribution */
         #pragma omp parallel for
-        for (int ialoc = 0; ialoc < spl_atoms.local_size(); ialoc++) {
-            int ia     = spl_atoms[ialoc];
+        for (auto it : spl_atoms) {
+            auto ia    = it.i;
             auto& atom = ctx.unit_cell().atom(ia);
             auto& type = atom.type();
 
-            auto aidx  = wf::atom_index(ialoc);
+            auto aidx  = wf::atom_index(it.li);
 
             for (int ilo = 0; ilo < type.mt_lo_basis_size(); ilo++) {
                 int xi_lo = type.mt_aw_basis_size() + ilo;
@@ -1012,14 +1010,14 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
             wf::Wave_functions_mt<T>& halm_phi__)
     {
         #pragma omp parallel for
-        for (int ialoc = 0; ialoc < alm_phi__.spl_num_atoms().local_size(); ialoc++) {
+        for (auto it : alm_phi__.spl_num_atoms()) {
             int tid = omp_get_thread_num();
-            int ia = atom_begin__ + alm_phi__.spl_num_atoms()[ialoc];
+            int ia = atom_begin__ + it.i;
             auto& atom = ctx.unit_cell().atom(ia);
             auto& type = atom.type();
             int naw    = type.mt_aw_basis_size();
 
-            auto aidx  = wf::atom_index(ialoc);
+            auto aidx  = wf::atom_index(it.li);
 
             auto& hmt = H0_.hmt(ia);
 
@@ -1036,15 +1034,15 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
     auto apply_hmt_lo_apw = [this, &ctx, la, mem, &b__, &spl_atoms](wf::Wave_functions_mt<T> const& alm_phi__, wf::Wave_functions<T>& hphi__)
     {
         #pragma omp parallel for
-        for (int ialoc = 0; ialoc < spl_atoms.local_size(); ialoc++) {
+        for (auto it : spl_atoms) {
             int tid = omp_get_thread_num();
-            int ia     = spl_atoms[ialoc];
+            int ia     = it.i;
             auto& atom = ctx.unit_cell().atom(ia);
             auto& type = atom.type();
             int naw    = type.mt_aw_basis_size();
             int nlo    = type.mt_lo_basis_size();
 
-            auto aidx  = wf::atom_index(ialoc);
+            auto aidx  = wf::atom_index(it.li);
 
             auto& hmt = H0_.hmt(ia);
 
@@ -1062,14 +1060,14 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
     auto apply_omt_lo_apw = [this, &ctx, mem, &b__, &spl_atoms](wf::Wave_functions_mt<T> const& alm_phi__, wf::Wave_functions<T>& ophi__)
     {
         #pragma omp parallel for
-        for (int ialoc = 0; ialoc < spl_atoms.local_size(); ialoc++) {
-            int ia     = spl_atoms[ialoc];
+        for (auto it : spl_atoms) {
+            int ia     = it.i;
             auto& atom = ctx.unit_cell().atom(ia);
             auto& type = atom.type();
             int naw    = type.mt_aw_basis_size();
             int nlo    = type.mt_lo_basis_size();
 
-            auto aidx  = wf::atom_index(ialoc);
+            auto aidx  = wf::atom_index(it.li);
 
             for (int ilo = 0; ilo < nlo; ilo++) {
                 int xi_lo = naw + ilo;
@@ -1213,7 +1211,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
     /* loop over blocks of atoms */
     for (auto na : utils::split_in_blocks(ctx.unit_cell().num_atoms(), 64)) {
 
-        sddk::splindex<sddk::splindex_t::block> spl_atoms(na, comm.size(), comm.rank());
+        sddk::splindex_block<> spl_atoms(na, n_blocks(comm.size()), block_id(comm.rank()));
 
         /* actual number of AW radial functions in a block of atoms */
         int num_mt_aw{0};

--- a/src/hamiltonian/non_local_operator.hpp
+++ b/src/hamiltonian/non_local_operator.hpp
@@ -27,13 +27,10 @@
 
 #include "SDDK/omp.hpp"
 #include "SDDK/memory.hpp"
-// #include "beta_projectors/beta_projectors.hpp"
-// #include "beta_projectors/beta_projectors_base.hpp"
-// #include "beta_projectors/beta_projectors_strain_deriv.hpp"
 #include "non_local_operator_base.hpp"
 #include "context/simulation_context.hpp"
 #include "hubbard/hubbard_matrix.hpp"
-#include "traits.hpp"
+//#include "traits.hpp"
 #include "utils/rte.hpp"
 
 namespace sirius {

--- a/src/hamiltonian/non_local_operator_base.hpp
+++ b/src/hamiltonian/non_local_operator_base.hpp
@@ -27,7 +27,7 @@
 
 #include "context/simulation_context.hpp"
 #include "beta_projectors/beta_projectors_base.hpp"
-//#include "traits.hpp"
+#include "traits.hpp"
 
 namespace sirius {
 
@@ -80,12 +80,12 @@ class Non_local_operator
     /// computes α B*Q + β out
     template <typename F>
     void lmatmul(sddk::matrix<F>& out, const sddk::matrix<F>& B__, int ispn_block__, sddk::memory_t mem_t,
-                 F alpha = F{1}, F beta = F{0}) const;
+                 identity_t<F> alpha = F{1}, identity_t<F> beta = F{0}) const;
 
     /// computes α Q*B + β out
     template <typename F>
     void rmatmul(sddk::matrix<F>& out, const sddk::matrix<F>& B__, int ispn_block__, sddk::memory_t mem_t,
-                 F alpha = F{1}, F beta = F{0}) const;
+                 identity_t<F> alpha = F{1}, identity_t<F> beta = F{0}) const;
 
     template <typename F, typename = std::enable_if_t<std::is_same<T, real_type<F>>::value>>
     inline F value(int xi1__, int xi2__, int ia__)
@@ -264,7 +264,7 @@ template <class T>
 template <class F>
 void
 Non_local_operator<T>::lmatmul(sddk::matrix<F>& out, const sddk::matrix<F>& B__, int ispn_block__, sddk::memory_t mem_t,
-                               F alpha, F beta) const
+                               identity_t<F> alpha, identity_t<F> beta) const
 {
     /* Computes Cᵢⱼ =∑ₖ Bᵢₖ Qₖⱼ = Bᵢⱼ Qⱼⱼ
      * Note that Q is block-diagonal. */
@@ -303,7 +303,7 @@ template <class T>
 template <class F>
 void
 Non_local_operator<T>::rmatmul(sddk::matrix<F>& out, const sddk::matrix<F>& B__, int ispn_block__, sddk::memory_t mem_t,
-                               F alpha, F beta) const
+                               identity_t<F> alpha, identity_t<F> beta) const
 {
     /* Computes Cᵢⱼ =  ∑ₖ Qᵢₖ * Bₖⱼ = Qᵢᵢ * Bᵢⱼ
      * Note that Q is block-diagonal. */

--- a/src/hamiltonian/non_local_operator_base.hpp
+++ b/src/hamiltonian/non_local_operator_base.hpp
@@ -74,17 +74,17 @@ class Non_local_operator
     /// Apply beta projectors from one atom in a chunk of beta projectors to all wave-functions.
     template <typename F>
     std::enable_if_t<std::is_same<std::complex<T>, F>::value, void>
-    apply(sddk::memory_t mem__, int chunk__, wf::atom_index ia__, int ispn_block__, wf::Wave_functions<T>& op_phi__,
-          wf::band_range br__, const beta_projectors_coeffs_t<T>& beta_coeffs__, sddk::matrix<F>& beta_phi__);
+    apply(sddk::memory_t mem__, int chunk__, atom_index_t::local ia__, int ispn_block__, wf::Wave_functions<T>& op_phi__,
+          wf::band_range br__, beta_projectors_coeffs_t<T> const& beta_coeffs__, sddk::matrix<F>& beta_phi__);
 
     /// computes α B*Q + β out
     template <typename F>
-    void lmatmul(sddk::matrix<F>& out, const sddk::matrix<F>& B__, int ispn_block__, sddk::memory_t mem_t,
+    void lmatmul(sddk::matrix<F>& out, sddk::matrix<F> const& B__, int ispn_block__, sddk::memory_t mem_t,
                  identity_t<F> alpha = F{1}, identity_t<F> beta = F{0}) const;
 
     /// computes α Q*B + β out
     template <typename F>
-    void rmatmul(sddk::matrix<F>& out, const sddk::matrix<F>& B__, int ispn_block__, sddk::memory_t mem_t,
+    void rmatmul(sddk::matrix<F>& out, sddk::matrix<F> const& B__, int ispn_block__, sddk::memory_t mem_t,
                  identity_t<F> alpha = F{1}, identity_t<F> beta = F{0}) const;
 
     template <typename F, typename = std::enable_if_t<std::is_same<T, real_type<F>>::value>>
@@ -207,9 +207,9 @@ Non_local_operator<T>::apply(sddk::memory_t mem__, int chunk__, int ispn_block__
 template <class T>
 template <class F>
 std::enable_if_t<std::is_same<std::complex<T>, F>::value, void>
-Non_local_operator<T>::apply(sddk::memory_t mem__, int chunk__, wf::atom_index ia__, int ispn_block__,
+Non_local_operator<T>::apply(sddk::memory_t mem__, int chunk__, atom_index_t::local ia__, int ispn_block__,
                              wf::Wave_functions<T>& op_phi__, wf::band_range br__,
-                             const beta_projectors_coeffs_t<T>& beta_coeffs__, sddk::matrix<F>& beta_phi__)
+                             beta_projectors_coeffs_t<T> const& beta_coeffs__, sddk::matrix<F>& beta_phi__)
 {
     if (is_null_) {
         return;

--- a/src/hamiltonian/non_local_operator_base.hpp
+++ b/src/hamiltonian/non_local_operator_base.hpp
@@ -27,7 +27,7 @@
 
 #include "context/simulation_context.hpp"
 #include "beta_projectors/beta_projectors_base.hpp"
-#include "traits.hpp"
+//#include "traits.hpp"
 
 namespace sirius {
 
@@ -80,12 +80,12 @@ class Non_local_operator
     /// computes α B*Q + β out
     template <typename F>
     void lmatmul(sddk::matrix<F>& out, const sddk::matrix<F>& B__, int ispn_block__, sddk::memory_t mem_t,
-                 identity_t<F> alpha = F{1}, identity_t<F> beta = F{0}) const;
+                 F alpha = F{1}, F beta = F{0}) const;
 
     /// computes α Q*B + β out
     template <typename F>
     void rmatmul(sddk::matrix<F>& out, const sddk::matrix<F>& B__, int ispn_block__, sddk::memory_t mem_t,
-                 identity_t<F> alpha = F{1}, identity_t<F> beta = F{0}) const;
+                 F alpha = F{1}, F beta = F{0}) const;
 
     template <typename F, typename = std::enable_if_t<std::is_same<T, real_type<F>>::value>>
     inline F value(int xi1__, int xi2__, int ia__)
@@ -264,7 +264,7 @@ template <class T>
 template <class F>
 void
 Non_local_operator<T>::lmatmul(sddk::matrix<F>& out, const sddk::matrix<F>& B__, int ispn_block__, sddk::memory_t mem_t,
-                               identity_t<F> alpha, identity_t<F> beta) const
+                               F alpha, F beta) const
 {
     /* Computes Cᵢⱼ =∑ₖ Bᵢₖ Qₖⱼ = Bᵢⱼ Qⱼⱼ
      * Note that Q is block-diagonal. */
@@ -275,8 +275,8 @@ Non_local_operator<T>::lmatmul(sddk::matrix<F>& out, const sddk::matrix<F>& B__,
     }
 
     // check shapes
-    assert(out.size(0) == B__.size(0) && static_cast<int>(out.size(1)) == this->size_);
-    assert(static_cast<int>(B__.size(1)) == this->size_);
+    RTE_ASSERT(out.size(0) == B__.size(0) && static_cast<int>(out.size(1)) == this->size_);
+    RTE_ASSERT(static_cast<int>(B__.size(1)) == this->size_);
 
     int num_atoms = uc.num_atoms();
 
@@ -303,7 +303,7 @@ template <class T>
 template <class F>
 void
 Non_local_operator<T>::rmatmul(sddk::matrix<F>& out, const sddk::matrix<F>& B__, int ispn_block__, sddk::memory_t mem_t,
-                               identity_t<F> alpha, identity_t<F> beta) const
+                               F alpha, F beta) const
 {
     /* Computes Cᵢⱼ =  ∑ₖ Qᵢₖ * Bₖⱼ = Qᵢᵢ * Bᵢⱼ
      * Note that Q is block-diagonal. */
@@ -314,8 +314,8 @@ Non_local_operator<T>::rmatmul(sddk::matrix<F>& out, const sddk::matrix<F>& B__,
     }
 
     // check shapes
-    assert(static_cast<int>(out.size(0)) == this->size_ && out.size(1) == B__.size(1));
-    assert(static_cast<int>(B__.size(0)) == this->size_);
+    RTE_ASSERT(static_cast<int>(out.size(0)) == this->size_ && out.size(1) == B__.size(1));
+    RTE_ASSERT(static_cast<int>(B__.size(0)) == this->size_);
 
     int num_atoms = uc.num_atoms();
 

--- a/src/hubbard/hubbard_occupancies_derivatives.cpp
+++ b/src/hubbard/hubbard_occupancies_derivatives.cpp
@@ -298,9 +298,9 @@ Hubbard::compute_occupancies_derivatives(K_point<double>& kp__, Q_operator<doubl
                  *   | d beta / dr > Q < beta        | phi_atomic > */
                 phi_atomic_tmp->zero(mt, wf::spin_index(0), wf::band_range(0, nawf));
                 if (ctx_.unit_cell().atom(ja).type().augment()) {
-                    q_op__.apply(mt, ichunk, wf::atom_index(i), 0, *phi_atomic_tmp, wf::band_range(0, nawf),
+                    q_op__.apply(mt, ichunk, atom_index_t::local(i), 0, *phi_atomic_tmp, wf::band_range(0, nawf),
                             bp_grad_coeffs, beta_phi_atomic);
-                    q_op__.apply(mt, ichunk, wf::atom_index(i), 0, *phi_atomic_tmp, wf::band_range(0, nawf),
+                    q_op__.apply(mt, ichunk, atom_index_t::local(i), 0, *phi_atomic_tmp, wf::band_range(0, nawf),
                             bp_coeffs, grad_beta_phi_atomic);
                 }
 

--- a/src/k_point/generate_fv_states.cpp
+++ b/src/k_point/generate_fv_states.cpp
@@ -97,18 +97,17 @@ void K_point<T>::generate_fv_states()
         auto out_ptr = &fv_states_->pw_coeffs(0, wf::spin_index(0), wf::band_index(i));
         std::copy(in_ptr, in_ptr + gkvec().count(), out_ptr);
 
-        for (int ialoc = 0; ialoc < alm_fv_slab.spl_num_atoms().local_size(); ialoc++) {
-            int ia = alm_fv_slab.spl_num_atoms()[ialoc];
-            int num_mt_aw = uc.atom(ia).type().mt_aw_basis_size();
+        for (auto it : alm_fv_slab.spl_num_atoms()) {
+            int num_mt_aw = uc.atom(it.i).type().mt_aw_basis_size();
             /* aw part of the muffin-tin coefficients */
             for (int xi = 0; xi < num_mt_aw; xi++) {
-                fv_states_->mt_coeffs(xi, wf::atom_index(ialoc), wf::spin_index(0), wf::band_index(i)) =
-                    alm_fv_slab.mt_coeffs(xi, wf::atom_index(ialoc), wf::spin_index(0), wf::band_index(i));
+                fv_states_->mt_coeffs(xi, wf::atom_index(it.li), wf::spin_index(0), wf::band_index(i)) =
+                    alm_fv_slab.mt_coeffs(xi, wf::atom_index(it.li), wf::spin_index(0), wf::band_index(i));
             }
             /* lo part of muffin-tin coefficients */
-            for (int xi = 0; xi < uc.atom(ia).type().mt_lo_basis_size(); xi++) {
-                fv_states_->mt_coeffs(num_mt_aw + xi, wf::atom_index(ialoc), wf::spin_index(0), wf::band_index(i)) =
-                    fv_eigen_vectors_slab().mt_coeffs(xi, wf::atom_index(ialoc), wf::spin_index(0), wf::band_index(i));
+            for (int xi = 0; xi < uc.atom(it.i).type().mt_lo_basis_size(); xi++) {
+                fv_states_->mt_coeffs(num_mt_aw + xi, wf::atom_index(it.li), wf::spin_index(0), wf::band_index(i)) =
+                    fv_eigen_vectors_slab().mt_coeffs(xi, wf::atom_index(it.li), wf::spin_index(0), wf::band_index(i));
             }
         }
     }

--- a/src/k_point/generate_fv_states.cpp
+++ b/src/k_point/generate_fv_states.cpp
@@ -101,13 +101,13 @@ void K_point<T>::generate_fv_states()
             int num_mt_aw = uc.atom(it.i).type().mt_aw_basis_size();
             /* aw part of the muffin-tin coefficients */
             for (int xi = 0; xi < num_mt_aw; xi++) {
-                fv_states_->mt_coeffs(xi, wf::atom_index(it.li), wf::spin_index(0), wf::band_index(i)) =
-                    alm_fv_slab.mt_coeffs(xi, wf::atom_index(it.li), wf::spin_index(0), wf::band_index(i));
+                fv_states_->mt_coeffs(xi, it.li, wf::spin_index(0), wf::band_index(i)) =
+                    alm_fv_slab.mt_coeffs(xi, it.li, wf::spin_index(0), wf::band_index(i));
             }
             /* lo part of muffin-tin coefficients */
             for (int xi = 0; xi < uc.atom(it.i).type().mt_lo_basis_size(); xi++) {
-                fv_states_->mt_coeffs(num_mt_aw + xi, wf::atom_index(it.li), wf::spin_index(0), wf::band_index(i)) =
-                    fv_eigen_vectors_slab().mt_coeffs(xi, wf::atom_index(it.li), wf::spin_index(0), wf::band_index(i));
+                fv_states_->mt_coeffs(num_mt_aw + xi, it.li, wf::spin_index(0), wf::band_index(i)) =
+                    fv_eigen_vectors_slab().mt_coeffs(xi, it.li, wf::spin_index(0), wf::band_index(i));
             }
         }
     }

--- a/src/k_point/k_point.cpp
+++ b/src/k_point/k_point.cpp
@@ -477,7 +477,7 @@ K_point<T>::get_fv_eigen_vectors(sddk::mdarray<std::complex<T>, 2>& fv_evec__) c
                 if (loc.ib == this->comm().rank()) {
                     for (int xi = 0; xi < nlo; xi++) {
                         fv_evec__(this->num_gkvec() + offs + xi, ist) =
-                            fv_eigen_vectors_slab_->mt_coeffs(xi, wf::atom_index(loc.index_local), wf::spin_index(0),
+                            fv_eigen_vectors_slab_->mt_coeffs(xi, atom_index_t::local(loc.index_local), wf::spin_index(0),
                                     wf::band_index(ist));
                     }
                 }

--- a/src/k_point/k_point.cpp
+++ b/src/k_point/k_point.cpp
@@ -371,11 +371,13 @@ K_point<T>::generate_gkvec(double gk_cutoff__)
         ctx_.spfft_coarse<double>().local_z_length(), gkvec_partition_->count(), SPFFT_INDEX_TRIPLETS,
         gv.at(sddk::memory_t::host))));
 
-    sddk::splindex<sddk::splindex_t::block_cyclic> spl_ngk_row(num_gkvec(), num_ranks_row_, rank_row_, ctx_.cyclic_block_size());
+    sddk::splindex_block_cyclic<> spl_ngk_row(num_gkvec(), n_blocks(num_ranks_row_), block_id(rank_row_),
+            ctx_.cyclic_block_size());
     num_gkvec_row_ = spl_ngk_row.local_size();
     sddk::mdarray<int, 2> gkvec_row(3, num_gkvec_row_);
 
-    sddk::splindex<sddk::splindex_t::block_cyclic> spl_ngk_col(num_gkvec(), num_ranks_col_, rank_col_, ctx_.cyclic_block_size());
+    sddk::splindex_block_cyclic<> spl_ngk_col(num_gkvec(), n_blocks(num_ranks_col_), block_id(rank_col_),
+            ctx_.cyclic_block_size());
     num_gkvec_col_ = spl_ngk_col.local_size();
     sddk::mdarray<int, 2> gkvec_col(3, num_gkvec_col_);
 
@@ -385,14 +387,14 @@ K_point<T>::generate_gkvec(double gk_cutoff__)
             int ig = gkvec_->gvec_offset(rank) + igloc;
             auto loc_row = spl_ngk_row.location(ig);
             auto loc_col = spl_ngk_col.location(ig);
-            if (loc_row.rank == comm_row().rank()) {
+            if (loc_row.ib == comm_row().rank()) {
                 for (int x : {0, 1, 2}) {
-                    gkvec_row(x, loc_row.local_index) = gv(x, igloc);
+                    gkvec_row(x, loc_row.index_local) = gv(x, igloc);
                 }
             }
-            if (loc_col.rank == comm_col().rank()) {
+            if (loc_col.ib == comm_col().rank()) {
                 for (int x : {0, 1, 2}) {
-                    gkvec_col(x, loc_col.local_index) = gv(x, igloc);
+                    gkvec_col(x, loc_col.index_local) = gv(x, igloc);
                 }
             }
         }
@@ -471,11 +473,12 @@ K_point<T>::get_fv_eigen_vectors(sddk::mdarray<std::complex<T>, 2>& fv_evec__) c
             for (int ia = 0; ia < ctx_.unit_cell().num_atoms(); ia++) {
                 /* number of atom local orbitals */
                 int nlo = ctx_.unit_cell().atom(ia).mt_lo_basis_size();
-                auto loc = fv_eigen_vectors_slab_->spl_num_atoms().location(ia);
-                if (loc.rank == this->comm().rank()) {
+                auto loc = fv_eigen_vectors_slab_->spl_num_atoms().location(typename atom_index_t::global(ia));
+                if (loc.ib == this->comm().rank()) {
                     for (int xi = 0; xi < nlo; xi++) {
                         fv_evec__(this->num_gkvec() + offs + xi, ist) =
-                            fv_eigen_vectors_slab_->mt_coeffs(xi, wf::atom_index(loc.local_index), wf::spin_index(0), wf::band_index(ist));
+                            fv_eigen_vectors_slab_->mt_coeffs(xi, wf::atom_index(loc.index_local), wf::spin_index(0),
+                                    wf::band_index(ist));
                     }
                 }
                 offs += nlo;
@@ -781,18 +784,20 @@ void
 K_point<T>::generate_gklo_basis()
 {
     /* find local number of row G+k vectors */
-    sddk::splindex<sddk::splindex_t::block_cyclic> spl_ngk_row(num_gkvec(), num_ranks_row_, rank_row_, ctx_.cyclic_block_size());
+    sddk::splindex_block_cyclic<> spl_ngk_row(num_gkvec(), n_blocks(num_ranks_row_), block_id(rank_row_),
+            ctx_.cyclic_block_size());
     num_gkvec_row_ = spl_ngk_row.local_size();
 
     /* find local number of column G+k vectors */
-    sddk::splindex<sddk::splindex_t::block_cyclic> spl_ngk_col(num_gkvec(), num_ranks_col_, rank_col_, ctx_.cyclic_block_size());
+    sddk::splindex_block_cyclic<> spl_ngk_col(num_gkvec(), n_blocks(num_ranks_col_), block_id(rank_col_),
+            ctx_.cyclic_block_size());
     num_gkvec_col_ = spl_ngk_col.local_size();
 
     if (ctx_.full_potential()) {
-        sddk::splindex<sddk::splindex_t::block_cyclic> spl_nlo_row(num_gkvec() + unit_cell_.mt_lo_basis_size(),
-                num_ranks_row_, rank_row_, ctx_.cyclic_block_size());
-        sddk::splindex<sddk::splindex_t::block_cyclic> spl_nlo_col(num_gkvec() + unit_cell_.mt_lo_basis_size(),
-                num_ranks_col_, rank_col_, ctx_.cyclic_block_size());
+        sddk::splindex_block_cyclic<> spl_nlo_row(num_gkvec() + unit_cell_.mt_lo_basis_size(),
+                n_blocks(num_ranks_row_), block_id(rank_row_), ctx_.cyclic_block_size());
+        sddk::splindex_block_cyclic<> spl_nlo_col(num_gkvec() + unit_cell_.mt_lo_basis_size(),
+                n_blocks(num_ranks_col_), block_id(rank_col_), ctx_.cyclic_block_size());
 
         lo_basis_descriptor lo_desc;
 
@@ -815,10 +820,10 @@ K_point<T>::generate_gklo_basis()
                 lo_desc.order = static_cast<uint8_t>(order);
                 lo_desc.idxrf = static_cast<uint8_t>(idxrf);
 
-                if (spl_nlo_row.local_rank(num_gkvec() + idx) == rank_row_) {
+                if (spl_nlo_row.location(num_gkvec() + idx).ib == rank_row_) {
                     lo_basis_descriptors_row_.push_back(lo_desc);
                 }
-                if (spl_nlo_col.local_rank(num_gkvec() + idx) == rank_col_) {
+                if (spl_nlo_col.location(num_gkvec() + idx).ib == rank_col_) {
                     lo_basis_descriptors_col_.push_back(lo_desc);
                 }
 

--- a/src/k_point/k_point_set.cpp
+++ b/src/k_point/k_point_set.cpp
@@ -33,6 +33,7 @@ void K_point_set::sync_band()
 
     sddk::mdarray<double, 3> data(ctx_.num_bands(), ctx_.num_spinors(), num_kpoints(),
             get_memory_pool(sddk::memory_t::host), "K_point_set::sync_band.data");
+    data.zero();
 
     int nb = ctx_.num_bands() * ctx_.num_spinors();
     #pragma omp parallel
@@ -50,8 +51,7 @@ void K_point_set::sync_band()
         }
     }
 
-    comm().allgather(data.at(sddk::memory_t::host), nb * spl_num_kpoints_.local_size(),
-        nb * spl_num_kpoints_.global_offset());
+    comm().allreduce(data.at(sddk::memory_t::host), static_cast<int>(data.size()));
 
     #pragma omp parallel for
     for (int ik = 0; ik < num_kpoints(); ik++) {

--- a/src/k_point/k_point_set.cpp
+++ b/src/k_point/k_point_set.cpp
@@ -36,16 +36,15 @@ void K_point_set::sync_band()
 
     int nb = ctx_.num_bands() * ctx_.num_spinors();
     #pragma omp parallel
-    for (int ikloc = 0; ikloc < spl_num_kpoints_.local_size(); ikloc++) {
-        int ik = spl_num_kpoints_[ikloc];
-        auto kp = this->get<T>(ik);
+    for (auto it : spl_num_kpoints_) {
+        auto kp = this->get<T>(it.i);
         switch (what) {
             case sync_band_t::energy: {
-                std::copy(&kp->band_energies_(0, 0), &kp->band_energies_(0, 0) + nb, &data(0, 0, ik));
+                std::copy(&kp->band_energies_(0, 0), &kp->band_energies_(0, 0) + nb, &data(0, 0, it.i));
                 break;
             }
             case sync_band_t::occupancy: {
-                std::copy(&kp->band_occupancies_(0, 0), &kp->band_occupancies_(0, 0) + nb, &data(0, 0, ik));
+                std::copy(&kp->band_occupancies_(0, 0), &kp->band_occupancies_(0, 0) + nb, &data(0, 0, it.i));
                 break;
             }
         }
@@ -139,16 +138,18 @@ void K_point_set::initialize(std::vector<int> const& counts)
     PROFILE("sirius::K_point_set::initialize");
     /* distribute k-points along the 1-st dimension of the MPI grid */
     if (counts.empty()) {
-        sddk::splindex<sddk::splindex_t::block> spl_tmp(num_kpoints(), comm().size(), comm().rank());
-        spl_num_kpoints_ = sddk::splindex<sddk::splindex_t::chunk>(num_kpoints(), comm().size(), comm().rank(), spl_tmp.counts());
+        sddk::splindex_block<> spl_tmp(num_kpoints(), n_blocks(comm().size()), block_id(comm().rank()));
+        spl_num_kpoints_ = sddk::splindex_chunk<kp_index_t>(num_kpoints(), n_blocks(comm().size()),
+                block_id(comm().rank()), spl_tmp.counts());
     } else {
-        spl_num_kpoints_ = sddk::splindex<sddk::splindex_t::chunk>(num_kpoints(), comm().size(), comm().rank(), counts);
+        spl_num_kpoints_ = sddk::splindex_chunk<kp_index_t>(num_kpoints(), n_blocks(comm().size()),
+                block_id(comm().rank()), counts);
     }
 
-    for (int ikloc = 0; ikloc < spl_num_kpoints_.local_size(); ikloc++) {
-        kpoints_[spl_num_kpoints_[ikloc]]->initialize();
+    for (auto it : spl_num_kpoints_) {
+        kpoints_[it.i]->initialize();
 #if defined(USE_FP32)
-        kpoints_float_[spl_num_kpoints_[ikloc]]->initialize();
+        kpoints_float_[it.i]->initialize();
 #endif
     }
 
@@ -301,12 +302,11 @@ void K_point_set::find_band_occupancies()
                 }
             }
         }
-        for (int ikloc = 0; ikloc < spl_num_kpoints_.local_size(); ikloc++) {
-            int ik = spl_num_kpoints_[ikloc];
+        for (auto it : spl_num_kpoints_) {
             for (int ispn = 0; ispn < ctx_.num_spinors(); ispn++) {
                 #pragma omp parallel for
                 for (int j = 0; j < ctx_.num_bands(); j++) {
-                    this->get<T>(ik)->band_occupancy(j, ispn, ctx_.max_occupancy());
+                    this->get<T>(it.i)->band_occupancy(j, ispn, ctx_.max_occupancy());
                 }
             }
         }
@@ -325,32 +325,30 @@ void K_point_set::find_band_occupancies()
     auto emax = std::numeric_limits<double>::lowest();
 
     #pragma omp parallel for reduction(min:emin) reduction(max:emax)
-    for (int ikloc = 0; ikloc < spl_num_kpoints_.local_size(); ikloc++) {
-        int ik = spl_num_kpoints_[ikloc];
+    for (auto it : spl_num_kpoints_) {
         for (int ispn = 0; ispn < ctx_.num_spinors(); ispn++) {
-            emin = std::min(emin, this->get<T>(ik)->band_energy(0, ispn));
-            emax = std::max(emax, this->get<T>(ik)->band_energy(ctx_.num_bands() - 1, ispn));
+            emin = std::min(emin, this->get<T>(it.i)->band_energy(0, ispn));
+            emax = std::max(emax, this->get<T>(it.i)->band_energy(ctx_.num_bands() - 1, ispn));
         }
     }
     comm().allreduce<double, mpi::op_t::min>(&emin, 1);
     comm().allreduce<double, mpi::op_t::max>(&emax, 1);
 
-    sddk::splindex<sddk::splindex_t::block> splb(ctx_.num_bands(), ctx_.comm_band().size(), ctx_.comm_band().rank());
+    sddk::splindex_block<> splb(ctx_.num_bands(), n_blocks(ctx_.comm_band().size()), block_id(ctx_.comm_band().rank()));
 
     /* computes N(ef; f) = \sum_{i,k} f(ef - e_{k,i}) */
     auto compute_ne = [&](double ef, auto&& f) {
         double ne{0};
-        for (int ikloc = 0; ikloc < spl_num_kpoints_.local_size(); ikloc++) {
-            int ik = spl_num_kpoints_[ikloc];
+        for (auto it : spl_num_kpoints_) {
             double tmp{0};
             #pragma omp parallel reduction(+ : tmp)
             for (int ispn = 0; ispn < ctx_.num_spinors(); ispn++) {
                 #pragma omp for
                 for (int j = 0; j < splb.local_size(); j++) {
-                    tmp += f(ef - this->get<T>(ik)->band_energy(splb[j], ispn)) * ctx_.max_occupancy();
+                    tmp += f(ef - this->get<T>(it.i)->band_energy(splb.global_index(j), ispn)) * ctx_.max_occupancy();
                 }
             }
-            ne += tmp * kpoints_[ik]->weight();
+            ne += tmp * kpoints_[it.i]->weight();
         }
         ctx_.comm().allreduce(&ne, 1);
         return ne;
@@ -393,13 +391,12 @@ void K_point_set::find_band_occupancies()
         energy_fermi_ = bisection_search(F, emin, emax, tol);
     }
 
-    for (int ikloc = 0; ikloc < spl_num_kpoints_.local_size(); ikloc++) {
-        int ik = spl_num_kpoints_[ikloc];
+    for (auto it : spl_num_kpoints_) {
         for (int ispn = 0; ispn < ctx_.num_spinors(); ispn++) {
             #pragma omp parallel for
             for (int j = 0; j < ctx_.num_bands(); j++) {
-                auto o = f(energy_fermi_ - this->get<T>(ik)->band_energy(j, ispn)) * ctx_.max_occupancy();
-                this->get<T>(ik)->band_occupancy(j, ispn, o);
+                auto o = f(energy_fermi_ - this->get<T>(it.i)->band_energy(j, ispn)) * ctx_.max_occupancy();
+                this->get<T>(it.i)->band_occupancy(j, ispn, o);
             }
         }
     }
@@ -454,16 +451,15 @@ double K_point_set::valence_eval_sum() const
 {
     double eval_sum{0};
 
-    sddk::splindex<sddk::splindex_t::block> splb(ctx_.num_bands(), ctx_.comm_band().size(), ctx_.comm_band().rank());
+    sddk::splindex_block<> splb(ctx_.num_bands(), n_blocks(ctx_.comm_band().size()), block_id(ctx_.comm_band().rank()));
 
-    for (int ikloc = 0; ikloc < spl_num_kpoints_.local_size(); ikloc++) {
-        auto ik = spl_num_kpoints_[ikloc];
-        auto const& kp = this->get<T>(ik);
+    for (auto it : spl_num_kpoints_) {
+        auto const& kp = this->get<T>(it.i);
         double tmp{0};
         #pragma omp parallel for reduction(+:tmp)
         for (int j = 0; j < splb.local_size(); j++) {
             for (int ispn = 0; ispn < ctx_.num_spinors(); ispn++) {
-                tmp += kp->band_energy(splb[j], ispn) * kp->band_occupancy(splb[j], ispn);
+                tmp += kp->band_energy(splb.global_index(j), ispn) * kp->band_occupancy(splb.global_index(j), ispn);
             }
         }
         eval_sum += kp->weight() * tmp;
@@ -503,16 +499,15 @@ double K_point_set::entropy_sum() const
 
     auto f = smearing::entropy(ctx_.smearing(), ctx_.smearing_width());
 
-    sddk::splindex<sddk::splindex_t::block> splb(ctx_.num_bands(), ctx_.comm_band().size(), ctx_.comm_band().rank());
+    sddk::splindex_block<> splb(ctx_.num_bands(), n_blocks(ctx_.comm_band().size()), block_id(ctx_.comm_band().rank()));
 
-    for (int ikloc = 0; ikloc < spl_num_kpoints_.local_size(); ikloc++) {
-        auto ik = spl_num_kpoints_[ikloc];
-        auto const& kp = this->get<T>(ik);
+    for (auto it : spl_num_kpoints_) {
+        auto const& kp = this->get<T>(it.i);
         double tmp{0};
         #pragma omp parallel for reduction(+:tmp)
         for (int j = 0; j < splb.local_size(); j++) {
             for (int ispn = 0; ispn < ctx_.num_spinors(); ispn++) {
-                tmp += ctx_.max_occupancy() * f(energy_fermi_ - kp->band_energy(splb[j], ispn));
+                tmp += ctx_.max_occupancy() * f(energy_fermi_ - kp->band_energy(splb.global_index(j), ispn));
             }
         }
         s_sum += kp->weight() * tmp;
@@ -552,8 +547,8 @@ void K_point_set::print_info()
         pout << std::endl << utils::hbar(80, '-') << std::endl;
     }
 
-    for (int ikloc = 0; ikloc < spl_num_kpoints().local_size(); ikloc++) {
-        int ik = spl_num_kpoints(ikloc);
+    for (auto it : spl_num_kpoints()) {
+        int ik = it.i;
         pout << std::setw(4) << ik << utils::ffmt(9, 4) << kpoints_[ik]->vk()[0] << utils::ffmt(9, 4)
              << kpoints_[ik]->vk()[1] << utils::ffmt(9, 4) << kpoints_[ik]->vk()[2] << utils::ffmt(17, 6)
              << kpoints_[ik]->weight() << std::setw(11) << kpoints_[ik]->num_gkvec();
@@ -579,7 +574,7 @@ void K_point_set::save(std::string const& name__) const
     ctx_.comm().barrier();
     for (int ik = 0; ik < num_kpoints(); ik++) {
         /* check if this ranks stores the k-point */
-        if (ctx_.comm_k().rank() == spl_num_kpoints_.local_rank(ik)) {
+        if (ctx_.comm_k().rank() == spl_num_kpoints_.location(typename kp_index_t::global(ik)).ib) {
             this->get<double>(ik)->save(name__, ik);
         }
         /* wait for all */

--- a/src/k_point/k_point_set.hpp
+++ b/src/k_point/k_point_set.hpp
@@ -52,7 +52,7 @@ class K_point_set
 #endif
 
     /// Split index of k-points.
-    sddk::splindex<sddk::splindex_t::chunk> spl_num_kpoints_;
+    sddk::splindex_chunk<kp_index_t> spl_num_kpoints_;
 
     /// Fermi energy which is searched in find_band_occupancies().
     double energy_fermi_{0};
@@ -144,11 +144,10 @@ class K_point_set
     void update()
     {
         /* update k-points */
-        for (int ikloc = 0; ikloc < spl_num_kpoints().local_size(); ikloc++) {
-            int ik = spl_num_kpoints(ikloc);
-            kpoints_[ik]->update();
+        for (auto it : spl_num_kpoints_) {
+            kpoints_[it.i]->update();
 #if defined(USE_FP32)
-            kpoints_float_[ik]->update();
+            kpoints_float_[it.i]->update();
 #endif
         }
     }
@@ -161,9 +160,8 @@ class K_point_set
     int max_num_gkvec() const
     {
         int max_num_gkvec{0};
-        for (int ikloc = 0; ikloc < spl_num_kpoints_.local_size(); ikloc++) {
-            auto ik       = spl_num_kpoints_[ikloc];
-            max_num_gkvec = std::max(max_num_gkvec, kpoints_[ik]->num_gkvec());
+        for (auto it : spl_num_kpoints_) {
+            max_num_gkvec = std::max(max_num_gkvec, kpoints_[it.i]->num_gkvec());
         }
         comm().allreduce<int, mpi::op_t::max>(&max_num_gkvec, 1);
         return max_num_gkvec;
@@ -201,9 +199,9 @@ class K_point_set
         return static_cast<int>(kpoints_.size());
     }
 
-    inline int spl_num_kpoints(int ikloc) const
+    inline auto spl_num_kpoints(kp_index_t::local ikloc__) const
     {
-        return spl_num_kpoints_[ikloc];
+        return spl_num_kpoints_.global_index(ikloc__);
     }
 
     inline double energy_fermi() const
@@ -244,13 +242,13 @@ class K_point_set
 
     /// Send G+k vectors of k-point jk to a given rank.
     /** Other ranks receive an empty Gvec placeholder */
-    inline fft::Gvec get_gkvec(int jk__, int rank__)
+    inline fft::Gvec get_gkvec(kp_index_t::global jk__, int rank__)
     {
         /* rank in the k-point communicator */
         int my_rank = comm().rank();
 
         /* rank that stores jk */
-        int jrank = spl_num_kpoints().local_rank(jk__);
+        int jrank = spl_num_kpoints().location(jk__).ib;
 
         /* need this to pass communicator */
         fft::Gvec gkvec(ctx_.comm_band());
@@ -269,7 +267,7 @@ class K_point_set
 template<>
 inline K_point<double>* K_point_set::get<double>(int ik__) const
 {
-    assert(ik__ >= 0 && ik__ < (int)kpoints_.size());
+    RTE_ASSERT(ik__ >= 0 && ik__ < (int)kpoints_.size());
     return kpoints_[ik__].get();
 }
 
@@ -277,7 +275,7 @@ template<>
 inline K_point<float>* K_point_set::get<float>(int ik__) const
 {
 #if defined(USE_FP32)
-    assert(ik__ >= 0 && ik__ < (int)kpoints_float_.size());
+    RTE_ASSERT(ik__ >= 0 && ik__ < (int)kpoints_float_.size());
     return kpoints_float_[ik__].get();
 #else
     RTE_THROW("not compiled with FP32 support");

--- a/src/linalg/dmatrix.cpp
+++ b/src/linalg/dmatrix.cpp
@@ -29,17 +29,17 @@ namespace la {
 template <typename T>
 dmatrix<T>::dmatrix(int num_rows__, int num_cols__, BLACS_grid const& blacs_grid__, int bs_row__, int bs_col__,
                     sddk::memory_t mem_type__)
-    : sddk::matrix<T>(sddk::splindex<sddk::splindex_t::block_cyclic>(num_rows__, blacs_grid__.num_ranks_row(),
-                blacs_grid__.rank_row(), bs_row__).local_size(),
-            sddk::splindex<sddk::splindex_t::block_cyclic>(num_cols__, blacs_grid__.num_ranks_col(),
-                blacs_grid__.rank_col(), bs_col__).local_size(), mem_type__)
+    : sddk::matrix<T>(sddk::splindex_block_cyclic<>(num_rows__, n_blocks(blacs_grid__.num_ranks_row()),
+                block_id(blacs_grid__.rank_row()), bs_row__).local_size(),
+            sddk::splindex_block_cyclic<>(num_cols__, n_blocks(blacs_grid__.num_ranks_col()),
+                block_id(blacs_grid__.rank_col()), bs_col__).local_size(), mem_type__)
     , num_rows_(num_rows__)
     , num_cols_(num_cols__)
     , bs_row_(bs_row__)
     , bs_col_(bs_col__)
     , blacs_grid_(&blacs_grid__)
-    , spl_row_(num_rows_, blacs_grid__.num_ranks_row(), blacs_grid__.rank_row(), bs_row_)
-    , spl_col_(num_cols_, blacs_grid__.num_ranks_col(), blacs_grid__.rank_col(), bs_col_)
+    , spl_row_(num_rows_, n_blocks(blacs_grid__.num_ranks_row()), block_id(blacs_grid__.rank_row()), bs_row_)
+    , spl_col_(num_cols_, n_blocks(blacs_grid__.num_ranks_col()), block_id(blacs_grid__.rank_col()), bs_col_)
     , spla_dist_(spla::MatrixDistribution::create_blacs_block_cyclic_from_mapping(
           blacs_grid__.comm().native(), blacs_grid__.rank_map().data(), blacs_grid__.num_ranks_row(),
           blacs_grid__.num_ranks_col(), bs_row__,bs_col__))
@@ -51,17 +51,17 @@ template <typename T>
 dmatrix<T>::dmatrix(T* ptr__, int num_rows__, int num_cols__, BLACS_grid const& blacs_grid__, int bs_row__,
                     int bs_col__)
     : sddk::matrix<T>(ptr__,
-                sddk::splindex<sddk::splindex_t::block_cyclic>(num_rows__, blacs_grid__.num_ranks_row(), blacs_grid__.rank_row(),
-                                                   bs_row__).local_size(),
-                sddk::splindex<sddk::splindex_t::block_cyclic>(num_cols__, blacs_grid__.num_ranks_col(), blacs_grid__.rank_col(),
-                                                   bs_col__).local_size())
+                sddk::splindex_block_cyclic<>(num_rows__, n_blocks(blacs_grid__.num_ranks_row()),
+                    block_id(blacs_grid__.rank_row()), bs_row__).local_size(),
+                sddk::splindex_block_cyclic<>(num_cols__, n_blocks(blacs_grid__.num_ranks_col()),
+                    block_id(blacs_grid__.rank_col()), bs_col__).local_size())
     , num_rows_(num_rows__)
     , num_cols_(num_cols__)
     , bs_row_(bs_row__)
     , bs_col_(bs_col__)
     , blacs_grid_(&blacs_grid__)
-    , spl_row_(num_rows_, blacs_grid__.num_ranks_row(), blacs_grid__.rank_row(), bs_row_)
-    , spl_col_(num_cols_, blacs_grid__.num_ranks_col(), blacs_grid__.rank_col(), bs_col_)
+    , spl_row_(num_rows_, n_blocks(blacs_grid__.num_ranks_row()), block_id(blacs_grid__.rank_row()), bs_row_)
+    , spl_col_(num_cols_, n_blocks(blacs_grid__.num_ranks_col()), block_id(blacs_grid__.rank_col()), bs_col_)
     , spla_dist_(spla::MatrixDistribution::create_blacs_block_cyclic_from_mapping(
           blacs_grid__.comm().native(), blacs_grid__.rank_map().data(), blacs_grid__.num_ranks_row(),
           blacs_grid__.num_ranks_col(), bs_row__, bs_col__))
@@ -76,8 +76,8 @@ dmatrix<T>::dmatrix(int num_rows__, int num_cols__, sddk::memory_t mem_type__)
     , num_cols_(num_cols__)
     , bs_row_(1)
     , bs_col_(1)
-    , spl_row_(num_rows_, 1, 0, bs_row_)
-    , spl_col_(num_cols_, 1, 0, bs_col_)
+    , spl_row_(num_rows_, n_blocks(1), block_id(0), bs_row_)
+    , spl_col_(num_cols_, n_blocks(1), block_id(0), bs_col_)
 {
 }
 
@@ -88,8 +88,8 @@ dmatrix<T>::dmatrix(int num_rows__, int num_cols__, sddk::memory_pool& mp__, std
     , num_cols_(num_cols__)
     , bs_row_(1)
     , bs_col_(1)
-    , spl_row_(num_rows_, 1, 0, bs_row_)
-    , spl_col_(num_cols_, 1, 0, bs_col_)
+    , spl_row_(num_rows_, n_blocks(1), block_id(0), bs_row_)
+    , spl_col_(num_cols_, n_blocks(1), block_id(0), bs_col_)
 {
 }
 
@@ -101,8 +101,8 @@ dmatrix<T>::dmatrix(T* ptr__, int num_rows__, int num_cols__)
     , num_cols_(num_cols__)
     , bs_row_(1)
     , bs_col_(1)
-    , spl_row_(num_rows_, 1, 0, bs_row_)
-    , spl_col_(num_cols_, 1, 0, bs_col_)
+    , spl_row_(num_rows_, n_blocks(1), block_id(0), bs_row_)
+    , spl_col_(num_cols_, n_blocks(1), block_id(0), bs_col_)
 {
     init();
 }
@@ -110,17 +110,17 @@ dmatrix<T>::dmatrix(T* ptr__, int num_rows__, int num_cols__)
 template <typename T>
 dmatrix<T>::dmatrix(int num_rows__, int num_cols__, BLACS_grid const& blacs_grid__, int bs_row__, int bs_col__,
                     sddk::memory_pool& mp__)
-    : sddk::matrix<T>(sddk::splindex<sddk::splindex_t::block_cyclic>(num_rows__, blacs_grid__.num_ranks_row(), blacs_grid__.rank_row(),
-                                                   bs_row__).local_size(),
-                sddk::splindex<sddk::splindex_t::block_cyclic>(num_cols__, blacs_grid__.num_ranks_col(), blacs_grid__.rank_col(),
-                                                   bs_col__).local_size(), mp__)
+    : sddk::matrix<T>(sddk::splindex_block_cyclic<>(num_rows__, n_blocks(blacs_grid__.num_ranks_row()),
+                block_id(blacs_grid__.rank_row()), bs_row__).local_size(),
+                sddk::splindex_block_cyclic<>(num_cols__, n_blocks(blacs_grid__.num_ranks_col()),
+                    block_id(blacs_grid__.rank_col()), bs_col__).local_size(), mp__)
     , num_rows_(num_rows__)
     , num_cols_(num_cols__)
     , bs_row_(bs_row__)
     , bs_col_(bs_col__)
     , blacs_grid_(&blacs_grid__)
-    , spl_row_(num_rows_, blacs_grid__.num_ranks_row(), blacs_grid__.rank_row(), bs_row_)
-    , spl_col_(num_cols_, blacs_grid__.num_ranks_col(), blacs_grid__.rank_col(), bs_col_)
+    , spl_row_(num_rows_, n_blocks(blacs_grid__.num_ranks_row()), block_id(blacs_grid__.rank_row()), bs_row_)
+    , spl_col_(num_cols_, n_blocks(blacs_grid__.num_ranks_col()), block_id(blacs_grid__.rank_col()), bs_col_)
     , spla_dist_(spla::MatrixDistribution::create_blacs_block_cyclic_from_mapping(
           blacs_grid__.comm().native(), blacs_grid__.rank_map().data(), blacs_grid__.num_ranks_row(),
           blacs_grid__.num_ranks_col(), bs_row__, bs_col__))
@@ -131,13 +131,15 @@ dmatrix<T>::dmatrix(int num_rows__, int num_cols__, BLACS_grid const& blacs_grid
 template <typename T>
 void dmatrix<T>::set(int ir0__, int jc0__, int mr__, int nc__, T* ptr__, int ld__)
 {
-    sddk::splindex<sddk::splindex_t::block_cyclic> spl_r0(ir0__, blacs_grid().num_ranks_row(), blacs_grid().rank_row(), bs_row_);
-    sddk::splindex<sddk::splindex_t::block_cyclic> spl_r1(ir0__ + mr__, blacs_grid().num_ranks_row(), blacs_grid().rank_row(),
-                                              bs_row_);
+    sddk::splindex_block_cyclic<> spl_r0(ir0__, n_blocks(blacs_grid().num_ranks_row()),
+            block_id(blacs_grid().rank_row()), bs_row_);
+    sddk::splindex_block_cyclic<> spl_r1(ir0__ + mr__, n_blocks(blacs_grid().num_ranks_row()),
+            block_id(blacs_grid().rank_row()), bs_row_);
 
-    sddk::splindex<sddk::splindex_t::block_cyclic> spl_c0(jc0__, blacs_grid().num_ranks_col(), blacs_grid().rank_col(), bs_col_);
-    sddk::splindex<sddk::splindex_t::block_cyclic> spl_c1(jc0__ + nc__, blacs_grid().num_ranks_col(), blacs_grid().rank_col(),
-                                              bs_col_);
+    sddk::splindex_block_cyclic<> spl_c0(jc0__, n_blocks(blacs_grid().num_ranks_col()),
+            block_id(blacs_grid().rank_col()), bs_col_);
+    sddk::splindex_block_cyclic<> spl_c1(jc0__ + nc__, n_blocks(blacs_grid().num_ranks_col()),
+            block_id(blacs_grid().rank_col()), bs_col_);
 
     int m0 = spl_r0.local_size();
     int m1 = spl_r1.local_size();
@@ -147,10 +149,10 @@ void dmatrix<T>::set(int ir0__, int jc0__, int mr__, int nc__, T* ptr__, int ld_
     std::vector<int> map_col(n1 - n0);
 
     for (int i = 0; i < m1 - m0; i++) {
-        map_row[i] = spl_r1[m0 + i] - ir0__;
+        map_row[i] = spl_r1.global_index(m0 + i) - ir0__;
     }
     for (int j = 0; j < n1 - n0; j++) {
-        map_col[j] = spl_c1[n0 + j] - jc0__;
+        map_col[j] = spl_c1.global_index(n0 + j) - jc0__;
     }
 
     //#pragma omp parallel for
@@ -165,10 +167,10 @@ template <typename T>
 void dmatrix<T>::set(const int irow_glob, const int icol_glob, T val)
 {
     auto r = spl_row_.location(irow_glob);
-    if (blacs_grid_->rank_row() == r.rank) {
+    if (blacs_grid_->rank_row() == r.ib) {
         auto c = spl_col_.location(icol_glob);
-        if (blacs_grid_->rank_col() == c.rank) {
-            (*this)(r.local_index, c.local_index) = val;
+        if (blacs_grid_->rank_col() == c.ib) {
+            (*this)(r.index_local, c.index_local) = val;
         }
     }
 }
@@ -177,10 +179,10 @@ template <typename T>
 void dmatrix<T>::add(const int irow_glob, const int icol_glob, T val)
 {
     auto r = spl_row_.location(irow_glob);
-    if (blacs_grid_->rank_row() == r.rank) {
+    if (blacs_grid_->rank_row() == r.ib) {
         auto c = spl_col_.location(icol_glob);
-        if (blacs_grid_->rank_col() == c.rank) {
-            (*this)(r.local_index, c.local_index) += val;
+        if (blacs_grid_->rank_col() == c.ib) {
+            (*this)(r.index_local, c.index_local) += val;
         }
     }
 }
@@ -189,10 +191,10 @@ template <typename T>
 void dmatrix<T>::add(real_type<T> beta__, const int irow_glob, const int icol_glob, T val)
 {
     auto r = spl_row_.location(irow_glob);
-    if (blacs_grid_->rank_row() == r.rank) {
+    if (blacs_grid_->rank_row() == r.ib) {
         auto c = spl_col_.location(icol_glob);
-        if (blacs_grid_->rank_col() == c.rank) {
-            (*this)(r.local_index, c.local_index) = (*this)(r.local_index, c.local_index) * beta__ + val;
+        if (blacs_grid_->rank_col() == c.ib) {
+            (*this)(r.index_local, c.index_local) = (*this)(r.index_local, c.index_local) * beta__ + val;
         }
     }
 }
@@ -202,11 +204,11 @@ void dmatrix<T>::make_real_diag(int n__)
 {
     for (int i = 0; i < n__; i++) {
         auto r = spl_row_.location(i);
-        if (blacs_grid_->rank_row() == r.rank) {
+        if (blacs_grid_->rank_row() == r.ib) {
             auto c = spl_col_.location(i);
-            if (blacs_grid_->rank_col() == c.rank) {
-                T v                                   = (*this)(r.local_index, c.local_index);
-                (*this)(r.local_index, c.local_index) = std::real(v);
+            if (blacs_grid_->rank_col() == c.ib) {
+                T v                                   = (*this)(r.index_local, c.index_local);
+                (*this)(r.index_local, c.index_local) = std::real(v);
             }
         }
     }
@@ -220,10 +222,10 @@ sddk::mdarray<T, 1> dmatrix<T>::get_diag(int n__)
 
     for (int i = 0; i < n__; i++) {
         auto r = spl_row_.location(i);
-        if (blacs_grid_->rank_row() == r.rank) {
+        if (blacs_grid_->rank_row() == r.ib) {
             auto c = spl_col_.location(i);
-            if (blacs_grid_->rank_col() == c.rank) {
-                d[i] = (*this)(r.local_index, c.local_index);
+            if (blacs_grid_->rank_col() == c.ib) {
+                d[i] = (*this)(r.index_local, c.index_local);
             }
         }
     }

--- a/src/linalg/dmatrix.hpp
+++ b/src/linalg/dmatrix.hpp
@@ -221,11 +221,15 @@ class dmatrix: public sddk::matrix<T>
     {
         int m0, m1, n0, n1;
         if (blacs_grid_ != nullptr) {
-            sddk::splindex_block_cyclic<> spl_r0(ir0__, blacs_grid().num_ranks_row(), blacs_grid().rank_row(), bs_row_);
-            sddk::splindex_block_cyclic<> spl_r1(ir0__ + nr__, blacs_grid().num_ranks_row(), blacs_grid().rank_row(), bs_row_);
+            sddk::splindex_block_cyclic<> spl_r0(ir0__, n_blocks(blacs_grid().num_ranks_row()),
+                    block_id(blacs_grid().rank_row()), bs_row_);
+            sddk::splindex_block_cyclic<> spl_r1(ir0__ + nr__, n_blocks(blacs_grid().num_ranks_row()),
+                    block_id(blacs_grid().rank_row()), bs_row_);
 
-            sddk::splindex_block_cyclic<> spl_c0(ic0__, blacs_grid().num_ranks_col(), blacs_grid().rank_col(), bs_col_);
-            sddk::splindex_block_cyclic<> spl_c1(ic0__ + nc__, blacs_grid().num_ranks_col(), blacs_grid().rank_col(), bs_col_);
+            sddk::splindex_block_cyclic<> spl_c0(ic0__, n_blocks(blacs_grid().num_ranks_col()),
+                    block_id(blacs_grid().rank_col()), bs_col_);
+            sddk::splindex_block_cyclic<> spl_c1(ic0__ + nc__, n_blocks(blacs_grid().num_ranks_col()),
+                    block_id(blacs_grid().rank_col()), bs_col_);
 
             m0 = spl_r0.local_size();
             m1 = spl_r1.local_size();
@@ -382,10 +386,10 @@ class dmatrix: public sddk::matrix<T>
         T cs{0};
 
         if (blacs_grid_ != nullptr) {
-            sddk::splindex_block_cyclic<> spl_row(m__, this->blacs_grid().num_ranks_row(),
-                                                       this->blacs_grid().rank_row(), this->bs_row());
-            sddk::splindex_block_cyclic<> spl_col(n__, this->blacs_grid().num_ranks_col(),
-                                                       this->blacs_grid().rank_col(), this->bs_col());
+            sddk::splindex_block_cyclic<> spl_row(m__, n_blocks(this->blacs_grid().num_ranks_row()),
+                                                       block_id(this->blacs_grid().rank_row()), this->bs_row());
+            sddk::splindex_block_cyclic<> spl_col(n__, n_blocks(this->blacs_grid().num_ranks_col()),
+                                                       block_id(this->blacs_grid().rank_col()), this->bs_col());
             for (int i = 0; i < spl_col.local_size(); i++) {
                 for (int j = 0; j < spl_row.local_size(); j++) {
                     cs += (*this)(j, i);

--- a/src/linalg/dmatrix.hpp
+++ b/src/linalg/dmatrix.hpp
@@ -68,10 +68,10 @@ class dmatrix: public sddk::matrix<T>
     BLACS_grid const* blacs_grid_{nullptr};
 
     /// Split index of matrix rows.
-    sddk::splindex<sddk::splindex_t::block_cyclic> spl_row_;
+    sddk::splindex_block_cyclic<> spl_row_;
 
     /// Split index of matrix columns.
-    sddk::splindex<sddk::splindex_t::block_cyclic> spl_col_;
+    sddk::splindex_block_cyclic<> spl_col_;
 
     /// ScaLAPACK matrix descriptor.
     ftn_int descriptor_[9];
@@ -153,13 +153,13 @@ class dmatrix: public sddk::matrix<T>
     /// Return local number of rows for a given MPI rank.
     inline int num_rows_local(int rank) const
     {
-        return spl_row_.local_size(rank);
+        return spl_row_.local_size(block_id(rank));
     }
 
     /// Return global row index in the range [0, num_rows) by the local index in the range [0, num_rows_local).
     inline int irow(int irow_loc) const
     {
-        return spl_row_[irow_loc];
+        return spl_row_.global_index(irow_loc);
     }
 
     inline int num_cols() const
@@ -175,13 +175,13 @@ class dmatrix: public sddk::matrix<T>
 
     inline int num_cols_local(int rank) const
     {
-        return spl_col_.local_size(rank);
+        return spl_col_.local_size(block_id(rank));
     }
 
     /// Inindex of column in global matrix.
     inline int icol(int icol_loc) const
     {
-        return spl_col_[icol_loc];
+        return spl_col_.global_index(icol_loc);
     }
 
     inline int const* descriptor() const
@@ -221,11 +221,11 @@ class dmatrix: public sddk::matrix<T>
     {
         int m0, m1, n0, n1;
         if (blacs_grid_ != nullptr) {
-            sddk::splindex<sddk::splindex_t::block_cyclic> spl_r0(ir0__, blacs_grid().num_ranks_row(), blacs_grid().rank_row(), bs_row_);
-            sddk::splindex<sddk::splindex_t::block_cyclic> spl_r1(ir0__ + nr__, blacs_grid().num_ranks_row(), blacs_grid().rank_row(), bs_row_);
+            sddk::splindex_block_cyclic<> spl_r0(ir0__, blacs_grid().num_ranks_row(), blacs_grid().rank_row(), bs_row_);
+            sddk::splindex_block_cyclic<> spl_r1(ir0__ + nr__, blacs_grid().num_ranks_row(), blacs_grid().rank_row(), bs_row_);
 
-            sddk::splindex<sddk::splindex_t::block_cyclic> spl_c0(ic0__, blacs_grid().num_ranks_col(), blacs_grid().rank_col(), bs_col_);
-            sddk::splindex<sddk::splindex_t::block_cyclic> spl_c1(ic0__ + nc__, blacs_grid().num_ranks_col(), blacs_grid().rank_col(), bs_col_);
+            sddk::splindex_block_cyclic<> spl_c0(ic0__, blacs_grid().num_ranks_col(), blacs_grid().rank_col(), bs_col_);
+            sddk::splindex_block_cyclic<> spl_c1(ic0__ + nc__, blacs_grid().num_ranks_col(), blacs_grid().rank_col(), bs_col_);
 
             m0 = spl_r0.local_size();
             m1 = spl_r1.local_size();
@@ -382,9 +382,9 @@ class dmatrix: public sddk::matrix<T>
         T cs{0};
 
         if (blacs_grid_ != nullptr) {
-            sddk::splindex<sddk::splindex_t::block_cyclic> spl_row(m__, this->blacs_grid().num_ranks_row(),
+            sddk::splindex_block_cyclic<> spl_row(m__, this->blacs_grid().num_ranks_row(),
                                                        this->blacs_grid().rank_row(), this->bs_row());
-            sddk::splindex<sddk::splindex_t::block_cyclic> spl_col(n__, this->blacs_grid().num_ranks_col(),
+            sddk::splindex_block_cyclic<> spl_col(n__, this->blacs_grid().num_ranks_col(),
                                                        this->blacs_grid().rank_col(), this->bs_col());
             for (int i = 0; i < spl_col.local_size(); i++) {
                 for (int j = 0; j < spl_row.local_size(); j++) {

--- a/src/mixer/mixer_functions.cpp
+++ b/src/mixer/mixer_functions.cpp
@@ -73,8 +73,8 @@ FunctionProperties<Periodic_function<double>> periodic_function_property()
                 y.rg().value(i) = xi * -s + yi * c;
             }
             if (x.ctx().full_potential()) {
-                for (int ialoc = 0; ialoc < x.ctx().unit_cell().spl_num_atoms().local_size(); ialoc++) {
-                    int ia = x.ctx().unit_cell().spl_num_atoms(ialoc);
+                for (auto it : x.ctx().unit_cell().spl_num_atoms()) {
+                    int ia = it.i;
                     auto& x_f_mt = x.mt()[ia];
                     auto& y_f_mt = y.mt()[ia];
                     #pragma omp for schedule(static) nowait
@@ -218,9 +218,8 @@ FunctionProperties<PAW_density<double>> paw_density_function_property()
 
     auto scale_func = [](double alpha, PAW_density<double>& x) -> void
     {
-        for (int i = 0; i < x.unit_cell().spl_num_paw_atoms().local_size(); i++) {
-            int ipaw = x.unit_cell().spl_num_paw_atoms(i);
-            int ia = x.unit_cell().paw_atom_index(ipaw);
+        for (auto it : x.unit_cell().spl_num_paw_atoms()) {
+            int ia = x.unit_cell().paw_atom_index(it.i);
             for (int j = 0; j < x.unit_cell().parameters().num_mag_dims() + 1; j++) {
                 x.ae_density(j, ia) *= alpha;
                 x.ps_density(j, ia) *= alpha;
@@ -230,9 +229,8 @@ FunctionProperties<PAW_density<double>> paw_density_function_property()
 
     auto copy_function = [](PAW_density<double> const& x, PAW_density<double>& y) -> void
     {
-        for (int i = 0; i < x.unit_cell().spl_num_paw_atoms().local_size(); i++) {
-            int ipaw = x.unit_cell().spl_num_paw_atoms(i);
-            int ia = x.unit_cell().paw_atom_index(ipaw);
+        for (auto it : x.unit_cell().spl_num_paw_atoms()) {
+            int ia = x.unit_cell().paw_atom_index(it.i);
             for (int j = 0; j < x.unit_cell().parameters().num_mag_dims() + 1; j++) {
                 sddk::copy(x.ae_density(j, ia), y.ae_density(j, ia));
                 sddk::copy(x.ps_density(j, ia), y.ps_density(j, ia));
@@ -242,9 +240,8 @@ FunctionProperties<PAW_density<double>> paw_density_function_property()
 
     auto axpy_function = [](double alpha, PAW_density<double> const& x, PAW_density<double>& y) -> void
     {
-        for (int i = 0; i < x.unit_cell().spl_num_paw_atoms().local_size(); i++) {
-            int ipaw = x.unit_cell().spl_num_paw_atoms(i);
-            int ia = x.unit_cell().paw_atom_index(ipaw);
+        for (auto it : x.unit_cell().spl_num_paw_atoms()) {
+            int ia = x.unit_cell().paw_atom_index(it.i);
             for (int j = 0; j < x.unit_cell().parameters().num_mag_dims() + 1; j++) {
                 y.ae_density(j, ia) = x.ae_density(j, ia) * alpha + y.ae_density(j, ia);
                 y.ps_density(j, ia) = x.ps_density(j, ia) * alpha + y.ps_density(j, ia);
@@ -254,9 +251,8 @@ FunctionProperties<PAW_density<double>> paw_density_function_property()
 
     auto rotate_function = [](double c, double s, PAW_density<double>& x, PAW_density<double>& y) -> void
     {
-        for (int i = 0; i < x.unit_cell().spl_num_paw_atoms().local_size(); i++) {
-            int ipaw = x.unit_cell().spl_num_paw_atoms(i);
-            int ia = x.unit_cell().paw_atom_index(ipaw);
+        for (auto it : x.unit_cell().spl_num_paw_atoms()) {
+            int ia = x.unit_cell().paw_atom_index(it.i);
             for (int j = 0; j < x.unit_cell().parameters().num_mag_dims() + 1; j++) {
                 x.ae_density(j, ia) = x.ae_density(j, ia) * c + s * y.ae_density(j, ia);
                 y.ae_density(j, ia) = y.ae_density(j, ia) * c - s * x.ae_density(j, ia);

--- a/src/nlcglib/inverse_overlap.hpp
+++ b/src/nlcglib/inverse_overlap.hpp
@@ -296,7 +296,7 @@ S_k<numeric_t>::apply(sddk::mdarray<numeric_t, 2>& Y, sddk::mdarray<numeric_t, 2
         R.allocate(sddk::memory_t::device);
     }
 
-    q_op_.rmatmul(R, bphi, this->ispn_, pm, 1, 0);
+    q_op_.rmatmul(R, bphi, this->ispn_, pm, 1.0, 0.0);
 
     sddk::auto_copy(Y, X, pu);
 

--- a/src/nlcglib/overlap.hpp
+++ b/src/nlcglib/overlap.hpp
@@ -60,12 +60,10 @@ template <class op_t>
 Overlap_operators<op_t>::Overlap_operators(const K_point_set& kset, Simulation_context& ctx,
                                            const Q_operator<double>& q_op)
 {
-    int nk = kset.spl_num_kpoints().local_size();
-    for (int ik_loc = 0; ik_loc < nk; ++ik_loc) {
-        int ik   = kset.spl_num_kpoints(ik_loc);
-        auto& kp = *kset.get<double>(ik);
+    for (auto it : kset.spl_num_kpoints()) {
+        auto& kp = *kset.get<double>(it.i);
         for (int ispn = 0; ispn < ctx.num_spins(); ++ispn) {
-            key_t key{ik, ispn};
+            key_t key{it.i.get(), ispn};
             data_[key] = std::make_shared<op_t>(ctx, q_op, kp.beta_projectors(), ispn);
         }
     }

--- a/src/nlcglib/ultrasoft_precond.hpp
+++ b/src/nlcglib/ultrasoft_precond.hpp
@@ -59,12 +59,10 @@ class UltrasoftPrecond : public nlcglib::UltrasoftPrecondBase
 inline UltrasoftPrecond::UltrasoftPrecond(K_point_set const& kset, Simulation_context& ctx,
                                           Q_operator<double> const& q_op)
 {
-    int nk = kset.spl_num_kpoints().local_size();
-    for (int ik_loc = 0; ik_loc < nk; ++ik_loc) {
-        int ik   = kset.spl_num_kpoints(ik_loc);
-        auto& kp = *kset.get<double>(ik);
+    for (auto it : kset.spl_num_kpoints()) {
+        auto& kp = *kset.get<double>(it.i);
         for (int ispn = 0; ispn < ctx.num_spins(); ++ispn) {
-            key_t key{ik, ispn};
+            key_t key{it.i.get(), ispn};
             data_[key] = std::make_shared<op_t>(ctx, q_op, ispn, kp.beta_projectors(), kp.gkvec());
         }
     }

--- a/src/potential/poisson.cpp
+++ b/src/potential/poisson.cpp
@@ -247,27 +247,26 @@ void Potential::poisson(Periodic_function<double> const& rho)
             }
         }
 
-        for (int ialoc = 0; ialoc < unit_cell_.spl_num_atoms().local_size(); ialoc++) {
-            int ia = unit_cell_.spl_num_atoms(ialoc);
-            int nmtp = unit_cell_.atom(ia).num_mt_points();
+        for (auto it : unit_cell_.spl_num_atoms()) {
+            int nmtp = unit_cell_.atom(it.i).num_mt_points();
 
             std::vector<double> vlm(ctx_.lmmax_pot());
-            SHT::convert(ctx_.lmax_pot(), &vmtlm(0, ia), &vlm[0]);
+            SHT::convert(ctx_.lmax_pot(), &vmtlm(0, it.i), &vlm[0]);
 
             #pragma omp parallel for default(shared)
             for (int lm = 0; lm < ctx_.lmmax_pot(); lm++) {
                 int l = l_by_lm_[lm];
 
                 for (int ir = 0; ir < nmtp; ir++) {
-                    hartree_potential_->mt()[ia](lm, ir) += vlm[lm] * rRl(ir, l, unit_cell_.atom(ia).type_id());
+                    hartree_potential_->mt()[it.i](lm, ir) += vlm[lm] * rRl(ir, l, unit_cell_.atom(it.i).type_id());
                 }
             }
             /* save electronic part of the potential at the point of origin */
 #ifdef __VHA_AUX
-            vh_el_(ia) = y00 * hartree_potential_->mt()[ia](0, 0) +
-                unit_cell_.atom(ia).zn() / unit_cell_.atom(ia).radial_grid(0);
+            vh_el_(it.i) = y00 * hartree_potential_->mt()[it.i](0, 0) +
+                unit_cell_.atom(it.i).zn() / unit_cell_.atom(it.i).radial_grid(0);
 #else
-            vh_el_(ia) = y00 * hartree_potential_->mt()[ia](0, 0);
+            vh_el_(it.i) = y00 * hartree_potential_->mt()[it.i](0, 0);
 #endif
         }
         ctx_.comm().allgather(vh_el_.at(sddk::memory_t::host), unit_cell_.spl_num_atoms().local_size(),
@@ -291,14 +290,13 @@ void Potential::poisson(Periodic_function<double> const& rho)
     /* add nucleus potential and contribution to Hartree energy */
     if (ctx_.full_potential()) {
         double evha_nuc{0};
-        for (int ialoc = 0; ialoc < unit_cell_.spl_num_atoms().local_size(); ialoc++) {
-            int ia = unit_cell_.spl_num_atoms(ialoc);
-            auto& atom = unit_cell_.atom(ia);
+        for (auto it : unit_cell_.spl_num_atoms()) {
+            auto& atom = unit_cell_.atom(it.i);
             Spline<double> srho(atom.radial_grid());
             for (int ir = 0; ir < atom.num_mt_points(); ir++) {
                 double r = atom.radial_grid(ir);
-                hartree_potential_->mt()[ia](0, ir) -= atom.zn() / r / y00;
-                srho(ir) = rho.mt()[ia](0, ir) * r;
+                hartree_potential_->mt()[it.i](0, ir) -= atom.zn() / r / y00;
+                srho(ir) = rho.mt()[it.i](0, ir) * r;
             }
             evha_nuc -= atom.zn() * srho.interpolate().integrate(0) / y00;
         }

--- a/src/potential/potential.hpp
+++ b/src/potential/potential.hpp
@@ -165,8 +165,8 @@ class Potential : public Field4D
         sddk::mdarray<std::complex<double>, 2> qmt(ctx_.lmmax_rho(), unit_cell_.num_atoms());
         qmt.zero();
 
-        for (int ialoc = 0; ialoc < unit_cell_.spl_num_atoms().local_size(); ialoc++) {
-            auto ia = unit_cell_.spl_num_atoms(atom_index_t::local(ialoc));
+        for (auto it : unit_cell_.spl_num_atoms()) {
+            auto ia = it.i;
 
             auto qmt_re = poisson_vmt<false>(unit_cell_.atom(ia), rho__.mt()[ia],
                 const_cast<Spheric_function<function_domain_t::spectral, double>&>(hartree_potential_->mt()[ia]));
@@ -736,7 +736,7 @@ class Potential : public Field4D
 
     auto const& effective_potential_mt(atom_index_t::local ialoc) const
     {
-        auto ia = unit_cell_.spl_num_atoms(ialoc);
+        auto ia = unit_cell_.spl_num_atoms().global_index(ialoc);
         return this->scalar().mt()[ia];
     }
 
@@ -757,7 +757,7 @@ class Potential : public Field4D
 
     auto const& hartree_potential_mt(atom_index_t::local ialoc) const
     {
-        auto ia = unit_cell_.spl_num_atoms(ialoc);
+        auto ia = unit_cell_.spl_num_atoms().global_index(ialoc);
         return hartree_potential_->mt()[ia];
     }
 

--- a/src/potential/xc.cpp
+++ b/src/potential/xc.cpp
@@ -154,7 +154,7 @@ void Potential::xc_rg_nonmagnetic(Density const& density__)
             #pragma omp parallel
             {
                 /* split local size between threads */
-                sddk::splindex<sddk::splindex_t::block> spl_t(num_points, omp_get_num_threads(), omp_get_thread_num());
+                sddk::splindex_block <>spl_t(num_points, n_blocks(omp_get_num_threads()), block_id(omp_get_thread_num()));
                 /* if this is an LDA functional */
                 if (ixc.is_lda()) {
                     ixc.get_lda(spl_t.local_size(), &rho.value(spl_t.global_offset()),
@@ -351,7 +351,7 @@ void Potential::xc_rg_magnetic(Density const& density__)
             #pragma omp parallel
             {
                 /* split local size between threads */
-                sddk::splindex<sddk::splindex_t::block> spl_t(num_points, omp_get_num_threads(), omp_get_thread_num());
+                sddk::splindex_block<> spl_t(num_points, n_blocks(omp_get_num_threads()), block_id(omp_get_thread_num()));
                 /* if this is an LDA functional */
                 if (ixc.is_lda()) {
                     ixc.get_lda(spl_t.local_size(), &rho_up.value(spl_t.global_offset()),

--- a/src/radial/radial_integrals.cpp
+++ b/src/radial/radial_integrals.cpp
@@ -96,8 +96,8 @@ void Radial_integrals_aug<jl_deriv>::generate()
         }
 
         #pragma omp parallel for
-        for (int iq_loc = 0; iq_loc < spl_q_.local_size(); iq_loc++) {
-            int iq = spl_q_[iq_loc];
+        for (auto it : spl_q_) {
+            int iq = it.i;
 
             Spherical_Bessel_functions jl(2 * lmax_beta, atom_type.radial_grid(), grid_q_[iq]);
 
@@ -154,8 +154,8 @@ void Radial_integrals_rho_pseudo::generate()
         Spline<double> rho(atom_type.radial_grid(), atom_type.ps_total_charge_density());
 
         #pragma omp parallel for
-        for (int iq_loc = 0; iq_loc < spl_q_.local_size(); iq_loc++) {
-            int iq = spl_q_[iq_loc];
+        for (auto it : spl_q_) {
+            int iq = it.i;
             Spherical_Bessel_functions jl(0, atom_type.radial_grid(), grid_q_[iq]);
 
             values_(iat)(iq) = sirius::inner(jl[0], rho, 0, atom_type.num_mt_points()) / fourpi;
@@ -182,8 +182,8 @@ void Radial_integrals_rho_core_pseudo<jl_deriv>::generate()
         Spline<double> ps_core(atom_type.radial_grid(), atom_type.ps_core_charge_density());
 
         #pragma omp parallel for
-        for (int iq_loc = 0; iq_loc < spl_q_.local_size(); iq_loc++) {
-            int iq = spl_q_[iq_loc];
+        for (auto it : spl_q_) {
+            int iq = it.i;
             Spherical_Bessel_functions jl(0, atom_type.radial_grid(), grid_q_[iq]);
 
             if (jl_deriv) {
@@ -216,8 +216,8 @@ void Radial_integrals_beta<jl_deriv>::generate()
         }
 
         #pragma omp parallel for
-        for (int iq_loc = 0; iq_loc < spl_q_.local_size(); iq_loc++) {
-            int iq = spl_q_[iq_loc];
+        for (auto it : spl_q_) {
+            int iq = it.i;
             Spherical_Bessel_functions jl(unit_cell_.lmax(), atom_type.radial_grid(), grid_q_[iq]);
             for (int idxrf = 0; idxrf < nrb; idxrf++) {
                 int l  = atom_type.indexr(idxrf).am.l();
@@ -313,8 +313,8 @@ void Radial_integrals_vloc<jl_deriv>::generate()
         auto rg = atom_type.radial_grid().segment(np);
 
         #pragma omp parallel for
-        for (int iq_loc = 0; iq_loc < spl_q_.local_size(); iq_loc++) {
-            int iq = spl_q_[iq_loc];
+        for (auto it : spl_q_) {
+            int iq = it.i;
             Spline<double> s(rg);
             double g = grid_q_[iq];
 

--- a/src/radial/radial_integrals.hpp
+++ b/src/radial/radial_integrals.hpp
@@ -43,7 +43,7 @@ class Radial_integrals_base
     Radial_grid<double> grid_q_;
 
     /// Split index of q-points.
-    sddk::splindex<sddk::splindex_t::block> spl_q_;
+    sddk::splindex_block<> spl_q_;
 
     /// Array with integrals.
     sddk::mdarray<Spline<double>, N> values_;
@@ -64,8 +64,8 @@ class Radial_integrals_base
         qmax_ = qmax__ + std::max(10.0, qmax__ * 0.1);
 
         grid_q_ = Radial_grid_lin<double>(static_cast<int>(np__ * qmax_), 0, qmax_);
-        spl_q_  = sddk::splindex<sddk::splindex_t::block>(grid_q_.num_points(), unit_cell_.comm().size(),
-                                                          unit_cell_.comm().rank());
+        spl_q_  = sddk::splindex_block<>(grid_q_.num_points(), n_blocks(unit_cell_.comm().size()),
+                block_id(unit_cell_.comm().rank()));
     }
 
     /// Get starting index iq and delta dq for the q-point on the linear grid.
@@ -247,17 +247,17 @@ class Radial_integrals_rho_pseudo : public Radial_integrals_base<1>
     }
 
     /// Compute all values of the raial integrals.
-    inline sddk::mdarray<double, 2> values(std::vector<double>& q__, mpi::Communicator const& comm__) const
+    inline auto values(std::vector<double>& q__, mpi::Communicator const& comm__) const
     {
         int nq = static_cast<int>(q__.size());
-        sddk::splindex<sddk::splindex_t::block> splq(nq, comm__.size(), comm__.rank());
+        sddk::splindex_block<> splq(nq, n_blocks(comm__.size()), block_id(comm__.rank()));
         sddk::mdarray<double, 2> result(nq, unit_cell_.num_atom_types());
         result.zero();
         for (int iat = 0; iat < unit_cell_.num_atom_types(); iat++) {
             if (!unit_cell_.atom_type(iat).ps_total_charge_density().empty()) {
                 #pragma omp parallel for
                 for (int iqloc = 0; iqloc < splq.local_size(); iqloc++) {
-                    int iq = splq[iqloc];
+                    auto iq = splq.global_index(iqloc);
                     if (ri_callback_) {
                         ri_callback_(iat + 1, 1, &q__[iq], &result(iq, iat));
                     } else {
@@ -291,17 +291,17 @@ class Radial_integrals_rho_core_pseudo : public Radial_integrals_base<1>
     }
 
     /// Compute all values of the raial integrals.
-    inline sddk::mdarray<double, 2> values(std::vector<double>& q__, mpi::Communicator const& comm__) const
+    inline auto values(std::vector<double>& q__, mpi::Communicator const& comm__) const
     {
         int nq = static_cast<int>(q__.size());
-        sddk::splindex<sddk::splindex_t::block> splq(nq, comm__.size(), comm__.rank());
+        sddk::splindex_block<> splq(nq, n_blocks(comm__.size()), block_id(comm__.rank()));
         sddk::mdarray<double, 2> result(nq, unit_cell_.num_atom_types());
         result.zero();
         for (int iat = 0; iat < unit_cell_.num_atom_types(); iat++) {
             if (!unit_cell_.atom_type(iat).ps_core_charge_density().empty()) {
                 #pragma omp parallel for
                 for (int iqloc = 0; iqloc < splq.local_size(); iqloc++) {
-                    int iq = splq[iqloc];
+                    auto iq = splq.global_index(iqloc);
                     if (ri_callback_) {
                         ri_callback_(iat + 1, 1, &q__[iq], &result(iq, iat));
                     } else {
@@ -402,17 +402,17 @@ class Radial_integrals_vloc : public Radial_integrals_base<1>
     }
 
     /// Compute all values of the raial integrals.
-    inline sddk::mdarray<double, 2> values(std::vector<double>& q__, mpi::Communicator const& comm__) const
+    inline auto values(std::vector<double>& q__, mpi::Communicator const& comm__) const
     {
         int nq = static_cast<int>(q__.size());
-        sddk::splindex<sddk::splindex_t::block> splq(nq, comm__.size(), comm__.rank());
+        sddk::splindex_block<> splq(nq, n_blocks(comm__.size()), block_id(comm__.rank()));
         sddk::mdarray<double, 2> result(nq, unit_cell_.num_atom_types());
         result.zero();
         for (int iat = 0; iat < unit_cell_.num_atom_types(); iat++) {
             if (!unit_cell_.atom_type(iat).local_potential().empty()) {
                 #pragma omp parallel for
                 for (int iqloc = 0; iqloc < splq.local_size(); iqloc++) {
-                    int iq = splq[iqloc];
+                    auto iq = splq.global_index(iqloc);
                     if (ri_callback_) {
                         ri_callback_(iat + 1, 1, &q__[iq], &result(iq, iat));
                     } else {

--- a/src/strong_type.hpp
+++ b/src/strong_type.hpp
@@ -1,7 +1,7 @@
 #ifndef __STRONG_TYPE_HPP__
 #define __STRONG_TYPE_HPP__
 
-namespace sirius {
+//namespace sirius {
 
 template <typename T, typename Tag>
 class strong_type
@@ -52,6 +52,6 @@ class strong_type
     }
 };
 
-}
+//}
 
 #endif

--- a/src/symmetry/symmetrize.hpp
+++ b/src/symmetry/symmetrize.hpp
@@ -356,9 +356,10 @@ symmetrize(Crystal_symmetry const& sym__, fft::Gvec_shells const& gvec_shells__,
     }
 }
 
+template <typename Index_t>
 inline void
 symmetrize(Crystal_symmetry const& sym__, mpi::Communicator const& comm__, int num_mag_dims__,
-        std::vector<Spheric_function_set<double>*> frlm__)
+        std::vector<Spheric_function_set<double, Index_t>*> frlm__)
 {
     PROFILE("sirius::symmetrize_function|flm");
 
@@ -373,7 +374,7 @@ symmetrize(Crystal_symmetry const& sym__, mpi::Communicator const& comm__, int n
     int lmax = utils::lmax(lmmax);
 
     /* split atoms between MPI ranks */
-    sddk::splindex<sddk::splindex_t::block> spl_atoms(frlm.atoms().size(), comm__.size(), comm__.rank());
+    sddk::splindex_block<Index_t> spl_atoms(frlm.atoms().size(), n_blocks(comm__.size()), block_id(comm__.rank()));
 
     /* space for real Rlm rotation matrix */
     sddk::mdarray<double, 2> rotm(lmmax, lmmax);

--- a/src/symmetry/symmetrize.hpp
+++ b/src/symmetry/symmetrize.hpp
@@ -395,9 +395,9 @@ symmetrize(Crystal_symmetry const& sym__, mpi::Communicator const& comm__, int n
         /* compute Rlm rotation matrix */
         sht::rotation_matrix(lmax, sym__[i].spg_op.euler_angles, sym__[i].spg_op.proper, rotm);
 
-        for (int ialoc = 0; ialoc < spl_atoms.local_size(); ialoc++) {
+        for (auto it : spl_atoms) {
             /* get global index of the atom */
-            int ia = frlm.atoms()[spl_atoms[ialoc]];
+            int ia = it.i;
             int lmmax_ia = frlm[ia].angular_domain_size();
             int nrmax_ia = frlm.unit_cell().atom(ia).num_mt_points();
             int ja = sym__[i].spg_op.inv_sym_atom[ia];
@@ -411,14 +411,14 @@ symmetrize(Crystal_symmetry const& sym__, mpi::Communicator const& comm__, int n
             /* always symmetrize the scalar component */
             for (int ir = 0; ir < nrmax_ia; ir++) {
                 for (int lm = 0; lm < lmmax_ia; lm++) {
-                    fsym_loc(lm, ir, 0, ialoc) += ftmp(lm, ir, 0);
+                    fsym_loc(lm, ir, 0, it.li) += ftmp(lm, ir, 0);
                 }
             }
             /* apply S part to [0, 0, z] collinear vector */
             if (num_mag_dims__ == 1) {
                 for (int ir = 0; ir < nrmax_ia; ir++) {
                     for (int lm = 0; lm < lmmax_ia; lm++) {
-                        fsym_loc(lm, ir, 1, ialoc) += ftmp(lm, ir, 1) * S(2, 2);
+                        fsym_loc(lm, ir, 1, it.li) += ftmp(lm, ir, 1) * S(2, 2);
                     }
                 }
             }
@@ -428,7 +428,7 @@ symmetrize(Crystal_symmetry const& sym__, mpi::Communicator const& comm__, int n
                     for (int j : {0, 1, 2}) {
                         for (int ir = 0; ir < nrmax_ia; ir++) {
                             for (int lm = 0; lm < lmmax_ia; lm++) {
-                                fsym_loc(lm, ir, 1 + k, ialoc) += ftmp(lm, ir, 1 + j) * S(k, j);
+                                fsym_loc(lm, ir, 1 + k, it.li) += ftmp(lm, ir, 1 + j) * S(k, j);
                             }
                         }
                     }

--- a/src/traits.hpp
+++ b/src/traits.hpp
@@ -1,5 +1,5 @@
-#ifndef TRAITS_H
-#define TRAITS_H
+#ifndef __TRAITS_HPP__
+#define __TRAITS_HPP__
 
 namespace sirius {
 
@@ -14,4 +14,4 @@ using identity_t = typename identity<X>::type;
 
 } // namespace sirius
 
-#endif /* TRAITS_H */
+#endif /* __TRAITS_HPP__ */

--- a/src/typedefs.hpp
+++ b/src/typedefs.hpp
@@ -26,7 +26,6 @@
 #define __TYPEDEFS_HPP__
 
 #include <cstdlib>
-//#include <assert.h>
 #include <complex>
 #include <cstdint>
 #include <vector>

--- a/src/unit_cell/atom.hpp
+++ b/src/unit_cell/atom.hpp
@@ -151,7 +151,7 @@ class Atom
             RTE_THROW("not yet mpi parallel");
         }
 
-        sddk::splindex<sddk::splindex_t::block> spl_lm(lmmax, comm__.size(), comm__.rank());
+        sddk::splindex_block<> spl_lm(lmmax, n_blocks(comm__.size()), block_id(comm__.rank()));
 
         auto l_by_lm = utils::l_by_lm(lmax_pot_);
 

--- a/src/unit_cell/basis_functions_index.hpp
+++ b/src/unit_cell/basis_functions_index.hpp
@@ -72,9 +72,6 @@ class basis_functions_index
 
     sddk::mdarray<int, 2> index_by_lm_order_;
 
-    /// Maximum l of the radial basis functions.
-    int lmax_{-1};
-
     int offset_lo_{-1};
 
     std::vector<int> offset_;

--- a/src/unit_cell/unit_cell.cpp
+++ b/src/unit_cell/unit_cell.cpp
@@ -958,6 +958,8 @@ Unit_cell::init_paw()
     }
 
     spl_num_paw_atoms_ = sddk::splindex<sddk::splindex_t::block>(num_paw_atoms(), comm_.size(), comm_.rank());
+    spl_num_paw_atoms1_ = sirius::experimental::splindex_block<sirius::experimental::paw_atom_index_t>(num_paw_atoms(),
+            sirius::experimental::n_blocks(comm_.size()), sirius::experimental::block_id(comm_.rank()));
 }
 
 std::pair<int, std::vector<int>>

--- a/src/unit_cell/unit_cell.cpp
+++ b/src/unit_cell/unit_cell.cpp
@@ -531,13 +531,12 @@ Unit_cell::generate_radial_functions(std::ostream& out__)
 {
     PROFILE("sirius::Unit_cell::generate_radial_functions");
 
-    for (int icloc = 0; icloc < (int)spl_num_atom_symmetry_classes().local_size(); icloc++) {
-        int ic = spl_num_atom_symmetry_classes(icloc);
-        atom_symmetry_class(ic).generate_radial_functions(parameters_.valence_relativity());
+    for (auto it : spl_num_atom_symmetry_classes()) {
+        atom_symmetry_class(it.i).generate_radial_functions(parameters_.valence_relativity());
     }
 
     for (int ic = 0; ic < num_atom_symmetry_classes(); ic++) {
-        int rank = spl_num_atom_symmetry_classes().local_rank(ic);
+        int rank = spl_num_atom_symmetry_classes().location(typename atom_symmetry_class_index_t::global(ic)).ib;
         atom_symmetry_class(ic).sync_radial_functions(comm_, rank);
     }
 
@@ -547,9 +546,8 @@ Unit_cell::generate_radial_functions(std::ostream& out__)
             pout << std::endl << "Linearization energies" << std::endl;
         }
 
-        for (int icloc = 0; icloc < (int)spl_num_atom_symmetry_classes().local_size(); icloc++) {
-            int ic = spl_num_atom_symmetry_classes(icloc);
-            atom_symmetry_class(ic).write_enu(pout);
+        for (auto it : spl_num_atom_symmetry_classes()) {
+            atom_symmetry_class(it.i).write_enu(pout);
         }
         RTE_OUT(out__) << pout.flush(0);
     }
@@ -566,13 +564,12 @@ Unit_cell::generate_radial_integrals()
     PROFILE("sirius::Unit_cell::generate_radial_integrals");
 
     try {
-        for (int icloc = 0; icloc < spl_num_atom_symmetry_classes().local_size(); icloc++) {
-            int ic = spl_num_atom_symmetry_classes(icloc);
-            atom_symmetry_class(ic).generate_radial_integrals(parameters_.valence_relativity());
+        for (auto it : spl_num_atom_symmetry_classes()) {
+            atom_symmetry_class(it.i).generate_radial_integrals(parameters_.valence_relativity());
         }
 
         for (int ic = 0; ic < num_atom_symmetry_classes(); ic++) {
-            int rank = spl_num_atom_symmetry_classes().local_rank(ic);
+            int rank = spl_num_atom_symmetry_classes().location(typename atom_symmetry_class_index_t::global(ic)).ib;
             atom_symmetry_class(ic).sync_radial_integrals(comm_, rank);
         }
     } catch(std::exception const& e) {
@@ -582,13 +579,12 @@ Unit_cell::generate_radial_integrals()
     }
 
     try {
-        for (int ialoc = 0; ialoc < spl_num_atoms_.local_size(); ialoc++) {
-            int ia = spl_num_atoms_[ialoc];
-            atom(ia).generate_radial_integrals(parameters_.processing_unit(), mpi::Communicator::self());
+        for (auto it : spl_num_atoms_) {
+            atom(it.i).generate_radial_integrals(parameters_.processing_unit(), mpi::Communicator::self());
         }
 
         for (int ia = 0; ia < num_atoms(); ia++) {
-            int rank = spl_num_atoms().local_rank(ia);
+            int rank = spl_num_atoms().location(typename atom_index_t::global(ia)).ib;
             atom(ia).sync_radial_integrals(comm_, rank);
         }
     } catch(std::exception const& e) {
@@ -665,7 +661,7 @@ Unit_cell::initialize()
     PROFILE("sirius::Unit_cell::initialize");
 
     /* split number of atom between all MPI ranks */
-    spl_num_atoms_ = sddk::splindex<sddk::splindex_t::block>(num_atoms(), comm_.size(), comm_.rank());
+    spl_num_atoms_ = sddk::splindex_block<atom_index_t>(num_atoms(), n_blocks(comm_.size()), block_id(comm_.rank()));
 
     /* initialize atom types */
     for (int iat = 0; iat < num_atom_types(); iat++) {
@@ -873,8 +869,8 @@ Unit_cell::update()
 
     get_symmetry();
 
-    spl_num_atom_symmetry_classes_ = sddk::splindex<sddk::splindex_t::block>(num_atom_symmetry_classes(),
-            comm_.size(), comm_.rank());
+    spl_num_atom_symmetry_classes_ = sddk::splindex_block<atom_symmetry_class_index_t>(num_atom_symmetry_classes(),
+            n_blocks(comm_.size()), block_id(comm_.rank()));
 
     volume_mt_ = 0.0;
     if (parameters_.full_potential()) {
@@ -957,9 +953,8 @@ Unit_cell::init_paw()
         }
     }
 
-    spl_num_paw_atoms_ = sddk::splindex<sddk::splindex_t::block>(num_paw_atoms(), comm_.size(), comm_.rank());
-    spl_num_paw_atoms1_ = sirius::experimental::splindex_block<sirius::experimental::paw_atom_index_t>(num_paw_atoms(),
-            sirius::experimental::n_blocks(comm_.size()), sirius::experimental::block_id(comm_.rank()));
+    spl_num_paw_atoms_ = sddk::splindex_block<paw_atom_index_t>(num_paw_atoms(), n_blocks(comm_.size()),
+            block_id(comm_.rank()));
 }
 
 std::pair<int, std::vector<int>>

--- a/src/unit_cell/unit_cell.hpp
+++ b/src/unit_cell/unit_cell.hpp
@@ -513,20 +513,10 @@ class Unit_cell
         return spl_num_atoms_;
     }
 
-    //inline auto spl_num_atoms(atom_index_t::local i) const
-    //{
-    //    return spl_num_atoms_.global_index(i);
-    //}
-
     inline auto const& spl_num_atom_symmetry_classes() const
     {
         return spl_num_atom_symmetry_classes_;
     }
-
-    //inline auto spl_num_atom_symmetry_classes(atom_symmetry_class_index_t::local i) const
-    //{
-    //    return spl_num_atom_symmetry_classes_.global_index(i);
-    //}
 
     inline double volume_mt() const
     {

--- a/src/unit_cell/unit_cell.hpp
+++ b/src/unit_cell/unit_cell.hpp
@@ -58,16 +58,16 @@ class Unit_cell
     std::vector<std::shared_ptr<Atom>> atoms_;
 
     /// Split index of atoms.
-    sddk::splindex<sddk::splindex_t::block> spl_num_atoms_;
+    sddk::splindex_block<atom_index_t> spl_num_atoms_;
 
     /// Global index of atom by index of PAW atom.
     std::vector<int> paw_atom_index_;
 
     /// Split index of PAW atoms.
-    sddk::splindex<sddk::splindex_t::block> spl_num_paw_atoms_;
+    sddk::splindex_block<paw_atom_index_t> spl_num_paw_atoms_;
 
     /// Split index of atom symmetry classes.
-    sddk::splindex<sddk::splindex_t::block> spl_num_atom_symmetry_classes_;
+    sddk::splindex_block<atom_symmetry_class_index_t> spl_num_atom_symmetry_classes_;
 
     /// Bravais lattice vectors in column order.
     /** The following convention is used to transform fractional coordinates to Cartesian:
@@ -174,13 +174,13 @@ class Unit_cell
         return spl_num_paw_atoms_;
     }
 
-    inline int spl_num_paw_atoms(int idx__) const
+    inline auto spl_num_paw_atoms(paw_atom_index_t::local idx__) const
     {
-        return spl_num_paw_atoms_[idx__];
+        return spl_num_paw_atoms_.global_index(idx__);
     }
 
     /// Return global index of atom by the index in the list of PAW atoms.
-    inline int paw_atom_index(int ipaw__) const
+    inline int paw_atom_index(paw_atom_index_t::global ipaw__) const
     {
         return paw_atom_index_[ipaw__];
     }
@@ -513,9 +513,9 @@ class Unit_cell
         return spl_num_atoms_;
     }
 
-    inline auto spl_num_atoms(int i) const
+    inline auto spl_num_atoms(atom_index_t::local i) const
     {
-        return static_cast<int>(spl_num_atoms_[i]);
+        return spl_num_atoms_.global_index(i);
     }
 
     inline auto const& spl_num_atom_symmetry_classes() const
@@ -523,9 +523,9 @@ class Unit_cell
         return spl_num_atom_symmetry_classes_;
     }
 
-    inline auto spl_num_atom_symmetry_classes(int i) const
+    inline auto spl_num_atom_symmetry_classes(atom_symmetry_class_index_t::local i) const
     {
-        return static_cast<int>(spl_num_atom_symmetry_classes_[i]);
+        return spl_num_atom_symmetry_classes_.global_index(i);
     }
 
     inline double volume_mt() const

--- a/src/unit_cell/unit_cell.hpp
+++ b/src/unit_cell/unit_cell.hpp
@@ -513,20 +513,20 @@ class Unit_cell
         return spl_num_atoms_;
     }
 
-    inline auto spl_num_atoms(atom_index_t::local i) const
-    {
-        return spl_num_atoms_.global_index(i);
-    }
+    //inline auto spl_num_atoms(atom_index_t::local i) const
+    //{
+    //    return spl_num_atoms_.global_index(i);
+    //}
 
     inline auto const& spl_num_atom_symmetry_classes() const
     {
         return spl_num_atom_symmetry_classes_;
     }
 
-    inline auto spl_num_atom_symmetry_classes(atom_symmetry_class_index_t::local i) const
-    {
-        return spl_num_atom_symmetry_classes_.global_index(i);
-    }
+    //inline auto spl_num_atom_symmetry_classes(atom_symmetry_class_index_t::local i) const
+    //{
+    //    return spl_num_atom_symmetry_classes_.global_index(i);
+    //}
 
     inline double volume_mt() const
     {


### PR DESCRIPTION
Split index class is simplified. It is now teamplated over the index type which allows to distingush between different indices. Iterator is introduced:
```
for (auto it : spl_index) {
  std::cout << "local index : " << it.li << ", global index : " << li.i << std::endl;
}
```
Iterator has two fields: `i` for global index and `li` for local index.