### PR TITLE
[enhancement] Simplify Simulation_context class.

### DIFF
--- a/apps/tests/test_sym.cpp
+++ b/apps/tests/test_sym.cpp
@@ -58,7 +58,7 @@ void test_sym(cmd_args const& args__)
     for (int ik = 0; ik < kset_sym.num_kpoints(); ik++) {
         auto kp = kset_sym.get<double>(ik);
         phi_sym.emplace_back(kp->gkvec_sptr(), wf::num_mag_dims(0), wf::num_bands(nawf.first), sddk::memory_t::host);
-        kp->generate_atomic_wave_functions(atoms, idxb, ctx.ps_atomic_wf_ri(), phi_sym.back());
+        kp->generate_atomic_wave_functions(atoms, idxb, *ctx.ri().ps_atomic_wf_, phi_sym.back());
     }
 
     std::vector<wf::Wave_functions<double>> phi_nosym;
@@ -66,7 +66,7 @@ void test_sym(cmd_args const& args__)
     for (int ik = 0; ik < kset_nosym.num_kpoints(); ik++) {
         auto kp = kset_nosym.get<double>(ik);
         phi_nosym.emplace_back(kp->gkvec_sptr(), wf::num_mag_dims(0), wf::num_bands(nawf.first), sddk::memory_t::host);
-        kp->generate_atomic_wave_functions(atoms, idxb, ctx.ps_atomic_wf_ri(), phi_nosym.back());
+        kp->generate_atomic_wave_functions(atoms, idxb, *ctx.ri().ps_atomic_wf_, phi_nosym.back());
     }
 
     auto& sym = ctx.unit_cell().symmetry();

--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -5417,31 +5417,31 @@ sirius_set_callback_function(void* const* handler__, char const* label__, void (
             std::transform(label.begin(), label.end(), label.begin(), ::tolower);
             auto& sim_ctx = get_sim_ctx(handler__);
             if (label == "beta_ri") {
-                sim_ctx.beta_ri_callback(reinterpret_cast<void (*)(int, double, double*, int)>(fptr__));
+                sim_ctx.cb().beta_ri_ = reinterpret_cast<void (*)(int, double, double*, int)>(fptr__);
             } else if (label == "beta_ri_djl") {
-                sim_ctx.beta_ri_djl_callback(reinterpret_cast<void (*)(int, double, double*, int)>(fptr__));
+                sim_ctx.cb().beta_ri_djl_ = reinterpret_cast<void (*)(int, double, double*, int)>(fptr__);
             } else if (label == "aug_ri") {
-                sim_ctx.aug_ri_callback(reinterpret_cast<void (*)(int, double, double*, int, int)>(fptr__));
+                sim_ctx.cb().aug_ri_ = reinterpret_cast<void (*)(int, double, double*, int, int)>(fptr__);
             } else if (label == "aug_ri_djl") {
-                sim_ctx.aug_ri_djl_callback(reinterpret_cast<void (*)(int, double, double*, int, int)>(fptr__));
+                sim_ctx.cb().aug_ri_djl_ = reinterpret_cast<void (*)(int, double, double*, int, int)>(fptr__);
             } else if (label == "vloc_ri") {
-                sim_ctx.vloc_ri_callback(reinterpret_cast<void (*)(int, int, double*, double*)>(fptr__));
+                sim_ctx.cb().vloc_ri_ = reinterpret_cast<void (*)(int, int, double*, double*)>(fptr__);
             } else if (label == "vloc_ri_djl") {
-                sim_ctx.vloc_ri_djl_callback(reinterpret_cast<void (*)(int, int, double*, double*)>(fptr__));
+                sim_ctx.cb().vloc_ri_djl_ = reinterpret_cast<void (*)(int, int, double*, double*)>(fptr__);
             } else if (label == "rhoc_ri") {
-                sim_ctx.rhoc_ri_callback(reinterpret_cast<void (*)(int, int, double*, double*)>(fptr__));
+                sim_ctx.cb().rhoc_ri_ = reinterpret_cast<void (*)(int, int, double*, double*)>(fptr__);
             } else if (label == "rhoc_ri_djl") {
-                sim_ctx.rhoc_ri_djl_callback(reinterpret_cast<void (*)(int, int, double*, double*)>(fptr__));
+                sim_ctx.cb().rhoc_ri_djl_ = reinterpret_cast<void (*)(int, int, double*, double*)>(fptr__);
             } else if (label == "band_occ") {
-                sim_ctx.band_occ_callback(reinterpret_cast<void (*)(void)>(fptr__));
+                sim_ctx.cb().band_occ_ = reinterpret_cast<void (*)(void)>(fptr__);
             } else if (label == "veff") {
-                sim_ctx.veff_callback(reinterpret_cast<void (*)(void)>(fptr__));
+                sim_ctx.cb().veff_ = reinterpret_cast<void (*)(void)>(fptr__);
             } else if (label == "ps_rho_ri") {
-                sim_ctx.ps_rho_ri_callback(reinterpret_cast<void (*)(int, int, double*, double*)>(fptr__));
+                sim_ctx.cb().ps_rho_ri_ = reinterpret_cast<void (*)(int, int, double*, double*)>(fptr__);
             } else if (label == "ps_atomic_wf_ri") {
-                sim_ctx.ps_atomic_wf_ri_callback(reinterpret_cast<void (*)(int, double, double*, int)>(fptr__));
+                sim_ctx.cb().ps_atomic_wf_ri_ = reinterpret_cast<void (*)(int, double, double*, int)>(fptr__);
             } else if (label == "ps_atomic_wf_ri_djl") {
-                sim_ctx.ps_atomic_wf_ri_djl_callback(reinterpret_cast<void (*)(int, double, double*, int)>(fptr__));
+                sim_ctx.cb().ps_atomic_wf_ri_djl_ = reinterpret_cast<void (*)(int, double, double*, int)>(fptr__);
             } else {
                 RTE_THROW("Wrong label of the callback function: " + label);
             }
@@ -5892,9 +5892,6 @@ void sirius_linear_solver(void* const* handler__, double const* vkq__, int const
             gkq_in_distr.counts[gvkq.comm().rank()] = num_gvec_kq_loc;
             gvkq.comm().allgather(gkq_in_distr.counts.data(), 1, gvkq.comm().rank());
             gkq_in_distr.calc_offsets();
-
-            /* offset in the incoming G-vector index */
-            int offset = gkq_in_distr.offsets[gvkq.comm().rank()];
 
             // Copy eigenvalues (factor 2 for rydberg/hartree)
             std::vector<double> eigvals_vec(eigvals__, eigvals__ + sctx.num_bands());

--- a/src/band/band.hpp
+++ b/src/band/band.hpp
@@ -240,7 +240,7 @@ inline void initialize_subspace(Hamiltonian_k<T>& Hk__, int num_ao__)
     std::vector<int> atoms(ctx.unit_cell().num_atoms());
     std::iota(atoms.begin(), atoms.end(), 0);
     Hk__.kp().generate_atomic_wave_functions(atoms, [&](int iat){return &ctx.unit_cell().atom_type(iat).indexb_wfs();},
-                                             ctx.ps_atomic_wf_ri(), phi);
+                                             *ctx.ri().ps_atomic_wf_, phi);
 
     /* generate some random noise */
     std::vector<T> tmp(4096);

--- a/src/beta_projectors/beta_projectors.hpp
+++ b/src/beta_projectors/beta_projectors.hpp
@@ -55,7 +55,7 @@ class Beta_projectors : public Beta_projectors_base<T>
 
         auto& comm = this->gkvec_.comm();
 
-        auto& beta_radial_integrals = this->ctx_.beta_ri();
+        auto& beta_radial_integrals = *this->ctx_.ri().beta_;
 
         std::vector<std::complex<double>> z(uc.lmax() + 1);
         for (int l = 0; l <= uc.lmax(); l++) {

--- a/src/beta_projectors/beta_projectors_strain_deriv.hpp
+++ b/src/beta_projectors/beta_projectors_strain_deriv.hpp
@@ -53,8 +53,8 @@ class Beta_projectors_strain_deriv : public Beta_projectors_base<T>
                     return offs;
                 });
 
-        auto& beta_ri0 = this->ctx_.beta_ri();
-        auto& beta_ri1 = this->ctx_.beta_ri_djl();
+        auto& beta_ri0 = *this->ctx_.ri().beta_;
+        auto& beta_ri1 = *this->ctx_.ri().beta_djl_;
 
         int lmax  = uc.lmax();
         int lmmax = utils::lmmax(lmax);

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -1153,52 +1153,51 @@ Simulation_context::update()
         }
 
         /* radial integrals with pw_cutoff */
-        if (!aug_ri_ || aug_ri_->qmax() < new_pw_cutoff) {
-            aug_ri_ = std::unique_ptr<Radial_integrals_aug<false>>(new Radial_integrals_aug<false>(
-                unit_cell(), new_pw_cutoff, cfg().settings().nprii_aug(), aug_ri_callback_));
+        if (!ri_.aug_ || ri_.aug_->qmax() < new_pw_cutoff) {
+            ri_.aug_ = std::make_unique<Radial_integrals_aug<false>>(unit_cell(), new_pw_cutoff,
+                    cfg().settings().nprii_aug(), cb_.aug_ri_);
         }
 
-        if (!aug_ri_djl_ || aug_ri_djl_->qmax() < new_pw_cutoff) {
-            aug_ri_djl_ = std::unique_ptr<Radial_integrals_aug<true>>(new Radial_integrals_aug<true>(
-                unit_cell(), new_pw_cutoff, cfg().settings().nprii_aug(), aug_ri_djl_callback_));
+        if (!ri_.aug_djl_ || ri_.aug_djl_->qmax() < new_pw_cutoff) {
+            ri_.aug_djl_ = std::make_unique<Radial_integrals_aug<true>>(unit_cell(), new_pw_cutoff,
+                    cfg().settings().nprii_aug(), cb_.aug_ri_djl_);
         }
 
-        if (!ps_core_ri_ || ps_core_ri_->qmax() < new_pw_cutoff) {
-            ps_core_ri_ =
-                std::unique_ptr<Radial_integrals_rho_core_pseudo<false>>(new Radial_integrals_rho_core_pseudo<false>(
-                    unit_cell(), new_pw_cutoff, cfg().settings().nprii_rho_core(), rhoc_ri_callback_));
+        if (!ri_.ps_core_ || ri_.ps_core_->qmax() < new_pw_cutoff) {
+            ri_.ps_core_ = std::make_unique<Radial_integrals_rho_core_pseudo<false>>(unit_cell(),
+                    new_pw_cutoff, cfg().settings().nprii_rho_core(), cb_.rhoc_ri_);
         }
 
-        if (!ps_core_ri_djl_ || ps_core_ri_djl_->qmax() < new_pw_cutoff) {
-            ps_core_ri_djl_ =
-                std::unique_ptr<Radial_integrals_rho_core_pseudo<true>>(new Radial_integrals_rho_core_pseudo<true>(
-                    unit_cell(), new_pw_cutoff, cfg().settings().nprii_rho_core(), rhoc_ri_djl_callback_));
+        if (!ri_.ps_core_djl_ || ri_.ps_core_djl_->qmax() < new_pw_cutoff) {
+            ri_.ps_core_djl_ =
+                std::make_unique<Radial_integrals_rho_core_pseudo<true>>(unit_cell(), new_pw_cutoff,
+                        cfg().settings().nprii_rho_core(), cb_.rhoc_ri_djl_);
         }
 
-        if (!ps_rho_ri_ || ps_rho_ri_->qmax() < new_pw_cutoff) {
-            ps_rho_ri_ = std::unique_ptr<Radial_integrals_rho_pseudo>(
-                new Radial_integrals_rho_pseudo(unit_cell(), new_pw_cutoff, 20, ps_rho_ri_callback_));
+        if (!ri_.ps_rho_ || ri_.ps_rho_->qmax() < new_pw_cutoff) {
+            ri_.ps_rho_ = std::make_unique<Radial_integrals_rho_pseudo>(unit_cell(), new_pw_cutoff, 20,
+                    cb_.ps_rho_ri_);
         }
 
-        if (!vloc_ri_ || vloc_ri_->qmax() < new_pw_cutoff) {
-            vloc_ri_ = std::unique_ptr<Radial_integrals_vloc<false>>(new Radial_integrals_vloc<false>(
-                unit_cell(), new_pw_cutoff, cfg().settings().nprii_vloc(), vloc_ri_callback_));
+        if (!ri_.vloc_ || ri_.vloc_->qmax() < new_pw_cutoff) {
+            ri_.vloc_ = std::make_unique<Radial_integrals_vloc<false>>(unit_cell(), new_pw_cutoff,
+                    cfg().settings().nprii_vloc(), cb_.vloc_ri_);
         }
 
-        if (!vloc_ri_djl_ || vloc_ri_djl_->qmax() < new_pw_cutoff) {
-            vloc_ri_djl_ = std::unique_ptr<Radial_integrals_vloc<true>>(new Radial_integrals_vloc<true>(
-                unit_cell(), new_pw_cutoff, cfg().settings().nprii_vloc(), vloc_ri_djl_callback_));
+        if (!ri_.vloc_djl_ || ri_.vloc_djl_->qmax() < new_pw_cutoff) {
+            ri_.vloc_djl_ = std::make_unique<Radial_integrals_vloc<true>>(unit_cell(), new_pw_cutoff,
+                    cfg().settings().nprii_vloc(), cb_.vloc_ri_djl_);
         }
 
         /* radial integrals with pw_cutoff */
-        if (!beta_ri_ || beta_ri_->qmax() < new_gk_cutoff) {
-            beta_ri_ = std::unique_ptr<Radial_integrals_beta<false>>(new Radial_integrals_beta<false>(
-                unit_cell(), new_gk_cutoff, cfg().settings().nprii_beta(), beta_ri_callback_));
+        if (!ri_.beta_ || ri_.beta_->qmax() < new_gk_cutoff) {
+            ri_.beta_ = std::make_unique<Radial_integrals_beta<false>>(unit_cell(), new_gk_cutoff,
+                    cfg().settings().nprii_beta(), cb_.beta_ri_);
         }
 
-        if (!beta_ri_djl_ || beta_ri_djl_->qmax() < new_gk_cutoff) {
-            beta_ri_djl_ = std::unique_ptr<Radial_integrals_beta<true>>(new Radial_integrals_beta<true>(
-                unit_cell(), new_gk_cutoff, cfg().settings().nprii_beta(), beta_ri_djl_callback_));
+        if (!ri_.beta_djl_ || ri_.beta_djl_->qmax() < new_gk_cutoff) {
+            ri_.beta_djl_ = std::make_unique<Radial_integrals_beta<true>>(unit_cell(), new_gk_cutoff,
+                    cfg().settings().nprii_beta(), cb_.beta_ri_djl_);
         }
 
         auto idxr_wf = [&](int iat) -> radial_functions_index const& {
@@ -1209,19 +1208,20 @@ Simulation_context::update()
             return unit_cell().atom_type(iat).ps_atomic_wf(i).f;
         };
 
-        if (!ps_atomic_wf_ri_ || ps_atomic_wf_ri_->qmax() < new_gk_cutoff) {
-            ps_atomic_wf_ri_ = std::unique_ptr<Radial_integrals_atomic_wf<false>>(new Radial_integrals_atomic_wf<false>(
-                unit_cell(), new_gk_cutoff, 20, idxr_wf, ps_wf, ps_atomic_wf_ri_callback_));
+        if (!ri_.ps_atomic_wf_ || ri_.ps_atomic_wf_->qmax() < new_gk_cutoff) {
+            ri_.ps_atomic_wf_ = std::make_unique<Radial_integrals_atomic_wf<false>>(unit_cell(), new_gk_cutoff, 20,
+                    idxr_wf, ps_wf, cb_.ps_atomic_wf_ri_);
         }
 
-        if (!ps_atomic_wf_ri_djl_ || ps_atomic_wf_ri_djl_->qmax() < new_gk_cutoff) {
-            ps_atomic_wf_ri_djl_ = std::unique_ptr<Radial_integrals_atomic_wf<true>>(
-                new Radial_integrals_atomic_wf<true>(unit_cell(), new_gk_cutoff, 20, idxr_wf, ps_wf, ps_atomic_wf_ri_djl_callback_));
+        if (!ri_.ps_atomic_wf_djl_ || ri_.ps_atomic_wf_djl_->qmax() < new_gk_cutoff) {
+            ri_.ps_atomic_wf_djl_ = std::make_unique<Radial_integrals_atomic_wf<true>>(unit_cell(), new_gk_cutoff,
+                    20, idxr_wf, ps_wf, cb_.ps_atomic_wf_ri_djl_);
         }
 
         for (int iat = 0; iat < unit_cell().num_atom_types(); iat++) {
             if (unit_cell().atom_type(iat).augment() && unit_cell().atom_type(iat).num_atoms() > 0) {
-                augmentation_op_[iat] = std::make_unique<Augmentation_operator>(unit_cell().atom_type(iat), gvec(), aug_ri(), aug_ri_djl());
+                augmentation_op_[iat] = std::make_unique<Augmentation_operator>(unit_cell().atom_type(iat), gvec(),
+                        *ri_.aug_, *ri_.aug_djl_);
                 augmentation_op_[iat]->generate_pw_coeffs();
             } else {
                 augmentation_op_[iat] = nullptr;

--- a/src/context/simulation_context.hpp
+++ b/src/context/simulation_context.hpp
@@ -91,6 +91,76 @@ print_memory_usage(OUT&& out__, std::string file_and_line__ = "")
 /// Utility function to generate LAPW unit step function.
 double unit_step_function_form_factors(double R__, double g__);
 
+struct callback_functions_t
+{
+    /// Callback function provided by the host code to compute radial integrals of beta projectors.
+    std::function<void(int, double, double*, int)> beta_ri_{nullptr};
+
+    std::function<void(int, double, double*, int)> beta_ri_djl_{nullptr};
+
+    /// Callback function provided by the host code to compute radial integrals of augmentation operator.
+    std::function<void(int, double, double*, int, int)> aug_ri_{nullptr};
+
+    std::function<void(int, double, double*, int, int)> aug_ri_djl_{nullptr};
+
+    std::function<void(int, int, double*, double*)> rhoc_ri_{nullptr};
+
+    std::function<void(int, int, double*, double*)> rhoc_ri_djl_{nullptr};
+
+    std::function<void(int, int, double*, double*)> ps_rho_ri_{nullptr};
+
+    std::function<void(int, double, double*, int)> ps_atomic_wf_ri_{nullptr};
+
+    std::function<void(int, double, double*, int)> ps_atomic_wf_ri_djl_{nullptr};
+
+    /// Callback function to compute radial integrals of local potential.
+    std::function<void(int, int, double*, double*)> vloc_ri_{nullptr};
+
+    std::function<void(int, int, double*, double*)> vloc_ri_djl_{nullptr};
+
+    /// Callback function to compute band occupancies.
+    std::function<void(void)> band_occ_{nullptr};
+
+    /// Callback function to compute effective potential.
+    std::function<void(void)> veff_{nullptr};
+};
+
+struct radial_integrals_t
+{
+    /// Radial integrals of beta-projectors.
+    std::unique_ptr<Radial_integrals_beta<false>> beta_;
+
+    /// Radial integrals of beta-projectors with derivatives of spherical Bessel functions.
+    std::unique_ptr<Radial_integrals_beta<true>> beta_djl_;
+
+    /// Radial integrals of augmentation operator.
+    std::unique_ptr<Radial_integrals_aug<false>> aug_;
+
+    /// Radial integrals of augmentation operator with derivatives of spherical Bessel functions.
+    std::unique_ptr<Radial_integrals_aug<true>> aug_djl_;
+
+    /// Radial integrals of atomic wave-functions.
+    std::unique_ptr<Radial_integrals_atomic_wf<false>> ps_atomic_wf_;
+
+    /// Radial integrals of atomic wave-functions with derivatives of spherical Bessel functions.
+    std::unique_ptr<Radial_integrals_atomic_wf<true>> ps_atomic_wf_djl_;
+
+    /// Radial integrals of pseudo-core charge density.
+    std::unique_ptr<Radial_integrals_rho_core_pseudo<false>> ps_core_;
+
+    /// Radial integrals of pseudo-core charge density with derivatives of spherical Bessel functions.
+    std::unique_ptr<Radial_integrals_rho_core_pseudo<true>> ps_core_djl_;
+
+    /// Radial integrals of total pseudo-charge density.
+    std::unique_ptr<Radial_integrals_rho_pseudo> ps_rho_;
+
+    /// Radial integrals of the local part of pseudopotential.
+    std::unique_ptr<Radial_integrals_vloc<false>> vloc_;
+
+    /// Radial integrals of the local part of pseudopotential with derivatives of spherical Bessel functions.
+    std::unique_ptr<Radial_integrals_vloc<true>> vloc_djl_;
+};
+
 /// Simulation context is a set of parameters and objects describing a single simulation.
 /** The order of initialization of the simulation context is the following: first, the default parameter
     values are set in the constructor, then (optionally) import() method is called and the parameters are
@@ -179,61 +249,6 @@ class Simulation_context : public Simulation_parameters
     /// Initial lattice vectors.
     r3::matrix<double> lattice_vectors0_;
 
-    /// Radial integrals of beta-projectors.
-    std::unique_ptr<Radial_integrals_beta<false>> beta_ri_;
-
-    /// Callback function provided by the host code to compute radial integrals of beta projectors.
-    std::function<void(int, double, double*, int)> beta_ri_callback_{nullptr};
-
-    /// Radial integrals of beta-projectors with derivatives of spherical Bessel functions.
-    std::unique_ptr<Radial_integrals_beta<true>> beta_ri_djl_;
-
-    std::function<void(int, double, double*, int)> beta_ri_djl_callback_{nullptr};
-
-    /// Radial integrals of augmentation operator.
-    std::unique_ptr<Radial_integrals_aug<false>> aug_ri_;
-
-    /// Callback function provided by the host code to compute radial integrals of augmentation operator.
-    std::function<void(int, double, double*, int, int)> aug_ri_callback_{nullptr};
-
-    /// Radial integrals of augmentation operator with derivatives of spherical Bessel functions.
-    std::unique_ptr<Radial_integrals_aug<true>> aug_ri_djl_;
-
-    std::function<void(int, double, double*, int, int)> aug_ri_djl_callback_{nullptr};
-
-    /// Radial integrals of atomic wave-functions.
-    std::unique_ptr<Radial_integrals_atomic_wf<false>> ps_atomic_wf_ri_;
-
-    /// Radial integrals of atomic wave-functions with derivatives of spherical Bessel functions.
-    std::unique_ptr<Radial_integrals_atomic_wf<true>> ps_atomic_wf_ri_djl_;
-
-    /// Radial integrals of pseudo-core charge density.
-    std::unique_ptr<Radial_integrals_rho_core_pseudo<false>> ps_core_ri_;
-
-    /// Radial integrals of pseudo-core charge density with derivatives of spherical Bessel functions.
-    std::unique_ptr<Radial_integrals_rho_core_pseudo<true>> ps_core_ri_djl_;
-
-    std::function<void(int, int, double*, double*)> rhoc_ri_callback_{nullptr};
-    std::function<void(int, int, double*, double*)> rhoc_ri_djl_callback_{nullptr};
-
-    std::function<void(int, int, double*, double*)> ps_rho_ri_callback_{nullptr};
-    std::function<void(int, double, double*, int)> ps_atomic_wf_ri_callback_{nullptr};
-    std::function<void(int, double, double*, int)> ps_atomic_wf_ri_djl_callback_{nullptr};
-
-    /// Radial integrals of total pseudo-charge density.
-    std::unique_ptr<Radial_integrals_rho_pseudo> ps_rho_ri_;
-
-    /// Radial integrals of the local part of pseudopotential.
-    std::unique_ptr<Radial_integrals_vloc<false>> vloc_ri_;
-
-    /// Callback function to compute radial integrals of local potential.
-    std::function<void(int, int, double*, double*)> vloc_ri_callback_{nullptr};
-
-    /// Radial integrals of the local part of pseudopotential with derivatives of spherical Bessel functions.
-    std::unique_ptr<Radial_integrals_vloc<true>> vloc_ri_djl_;
-
-    std::function<void(int, int, double*, double*)> vloc_ri_djl_callback_{nullptr};
-
     /// List of real-space point indices for each of the atoms.
     std::vector<std::vector<std::pair<int, double>>> atoms_to_grid_idx_;
 
@@ -256,12 +271,6 @@ class Simulation_context : public Simulation_parameters
     /// Type of host memory (pagable or page-locked) for the arrays that participate in host-to-device memory copy.
     sddk::memory_t host_memory_t_{sddk::memory_t::none};
 
-    /// Callback function to compute band occupancies.
-    std::function<void(void)> band_occ_callback_{nullptr};
-
-    /// Callback function to compute effective potential.
-    std::function<void(void)> veff_callback_{nullptr};
-
     /// Spla context.
     std::shared_ptr<::spla::Context> spla_ctx_{new ::spla::Context{SPLA_PU_HOST}};
 
@@ -270,6 +279,10 @@ class Simulation_context : public Simulation_parameters
 
     /// External pointers to periodic functions.
     std::map<std::string, periodic_function_ptr_t<double>> pf_ext_ptr;
+
+    callback_functions_t cb_;
+
+    radial_integrals_t ri_;
 
     mutable double evp_work_count_{0};
     mutable int num_loc_op_applied_{0};
@@ -650,61 +663,6 @@ class Simulation_context : public Simulation_parameters
     sddk::mdarray<std::complex<double>, 2> sum_fg_fl_yg(int lmax__, std::complex<double> const* fpw__, sddk::mdarray<double, 3>& fl__,
                                             sddk::matrix<std::complex<double>>& gvec_ylm__);
 
-    inline auto const& beta_ri() const
-    {
-        return *beta_ri_;
-    }
-
-    inline auto const& beta_ri_djl() const
-    {
-        return *beta_ri_djl_;
-    }
-
-    inline auto const& aug_ri() const
-    {
-        return *aug_ri_;
-    }
-
-    inline auto const& aug_ri_djl() const
-    {
-        return *aug_ri_djl_;
-    }
-
-    inline auto const& ps_atomic_wf_ri() const
-    {
-        return *ps_atomic_wf_ri_;
-    }
-
-    inline auto const& ps_atomic_wf_ri_djl() const
-    {
-        return *ps_atomic_wf_ri_djl_;
-    }
-
-    inline auto const& ps_core_ri() const
-    {
-        return *ps_core_ri_;
-    }
-
-    inline auto const& ps_core_ri_djl() const
-    {
-        return *ps_core_ri_djl_;
-    }
-
-    inline auto const& ps_rho_ri() const
-    {
-        return *ps_rho_ri_;
-    }
-
-    inline auto const& vloc_ri() const
-    {
-        return *vloc_ri_;
-    }
-
-    inline auto const& vloc_ri_djl() const
-    {
-        return *vloc_ri_djl_;
-    }
-
     /// Find the lambda parameter used in the Ewald summation.
     /** Lambda parameter scales the erfc function argument:
      *  \f[
@@ -821,83 +779,34 @@ class Simulation_context : public Simulation_parameters
         return num_itsol_steps_;
     }
 
-    /// Set the callback function.
-    inline void beta_ri_callback(void (*fptr__)(int, double, double*, int))
+    inline auto& cb()
     {
-        beta_ri_callback_ = fptr__;
+        return cb_;
     }
 
-    inline void beta_ri_djl_callback(void (*fptr__)(int, double, double*, int))
+    inline auto const& cb() const
     {
-        beta_ri_djl_callback_ = fptr__;
+        return cb_;
     }
 
-    /// Set the callback function.
-    inline void aug_ri_callback(void (*fptr__)(int, double, double*, int, int))
+    inline auto& ri()
     {
-        aug_ri_callback_ = fptr__;
+        return ri_;
     }
 
-    /// Set the callback function.
-    inline void aug_ri_djl_callback(void (*fptr__)(int, double, double*, int, int))
+    inline auto const& ri() const
     {
-        aug_ri_djl_callback_ = fptr__;
-    }
-
-    inline void vloc_ri_callback(void (*fptr__)(int, int, double*, double*))
-    {
-        vloc_ri_callback_ = fptr__;
-    }
-
-    inline void ps_rho_ri_callback(void (*fptr__)(int, int, double*, double*))
-    {
-        ps_rho_ri_callback_ = fptr__;
-    }
-
-    inline void vloc_ri_djl_callback(void (*fptr__)(int, int, double*, double*))
-    {
-        vloc_ri_djl_callback_ = fptr__;
-    }
-
-    inline void rhoc_ri_callback(void (*fptr__)(int, int, double*, double*))
-    {
-        rhoc_ri_callback_ = fptr__;
-    }
-
-    inline void rhoc_ri_djl_callback(void (*fptr__)(int, int, double*, double*))
-    {
-        rhoc_ri_djl_callback_ = fptr__;
-    }
-
-    inline void ps_atomic_wf_ri_callback(void (*fptr__)(int, double, double*, int))
-    {
-        ps_atomic_wf_ri_callback_ = fptr__;
-    }
-
-    inline void ps_atomic_wf_ri_djl_callback(void (*fptr__)(int, double, double*, int))
-    {
-        ps_atomic_wf_ri_djl_callback_ = fptr__;
-    }
-
-    /// Set callback function to compute band occupations
-    inline void band_occ_callback(void (*fptr__)(void))
-    {
-        band_occ_callback_ = fptr__;
+        return ri_;
     }
 
     inline std::function<void(void)> band_occ_callback() const
     {
-        return band_occ_callback_;
-    }
-
-    inline void veff_callback(void (*fptr__)(void))
-    {
-        veff_callback_ = fptr__;
+        return cb_.band_occ_;
     }
 
     inline std::function<void(void)> veff_callback() const
     {
-        return veff_callback_;
+        return cb_.veff_;
     }
 
     /// Export parameters of simulation context as a JSON dictionary.

--- a/src/context/simulation_context.hpp
+++ b/src/context/simulation_context.hpp
@@ -91,31 +91,44 @@ print_memory_usage(OUT&& out__, std::string file_and_line__ = "")
 /// Utility function to generate LAPW unit step function.
 double unit_step_function_form_factors(double R__, double g__);
 
+/// Store all callback functions in one place.
 struct callback_functions_t
 {
     /// Callback function provided by the host code to compute radial integrals of beta projectors.
     std::function<void(int, double, double*, int)> beta_ri_{nullptr};
 
+    /// Callback function provided by the host code to compute radial integrals of beta projectors with
+    /// derivatives of spherical Bessel functions.
     std::function<void(int, double, double*, int)> beta_ri_djl_{nullptr};
 
     /// Callback function provided by the host code to compute radial integrals of augmentation operator.
     std::function<void(int, double, double*, int, int)> aug_ri_{nullptr};
 
+    /// Callback function provided by the host code to compute radial integrals of augmentation operator with
+    /// derivatives of spherical Bessel functions.
     std::function<void(int, double, double*, int, int)> aug_ri_djl_{nullptr};
 
+    /// Callback function provided by the host code to compute radial integrals of pseudo core charge density.
     std::function<void(int, int, double*, double*)> rhoc_ri_{nullptr};
 
+    /// Callback function provided by the host code to compute radial integrals of pseudo core charge density with
+    /// derivatives of spherical Bessel functions.
     std::function<void(int, int, double*, double*)> rhoc_ri_djl_{nullptr};
 
+    /// Callback function provided by the host code to compute radial integrals of pseudo charge density.
     std::function<void(int, int, double*, double*)> ps_rho_ri_{nullptr};
 
+    /// Callback function provided by the host code to compute radial integrals of pseudo atomic wave-functions.
     std::function<void(int, double, double*, int)> ps_atomic_wf_ri_{nullptr};
 
+    /// Callback function provided by the host code to compute radial integrals of pseudo atomic wave-functions with
+    /// derivatives of spherical Bessel functions.
     std::function<void(int, double, double*, int)> ps_atomic_wf_ri_djl_{nullptr};
 
     /// Callback function to compute radial integrals of local potential.
     std::function<void(int, int, double*, double*)> vloc_ri_{nullptr};
 
+    /// Callback function to compute radial integrals of local potential with derivatives of spherical Bessel functions.
     std::function<void(int, int, double*, double*)> vloc_ri_djl_{nullptr};
 
     /// Callback function to compute band occupancies.
@@ -125,6 +138,7 @@ struct callback_functions_t
     std::function<void(void)> veff_{nullptr};
 };
 
+/// Store all radial integrals in one place.
 struct radial_integrals_t
 {
     /// Radial integrals of beta-projectors.
@@ -271,7 +285,7 @@ class Simulation_context : public Simulation_parameters
     /// Type of host memory (pagable or page-locked) for the arrays that participate in host-to-device memory copy.
     sddk::memory_t host_memory_t_{sddk::memory_t::none};
 
-    /// Spla context.
+    /// SPLA library context.
     std::shared_ptr<::spla::Context> spla_ctx_{new ::spla::Context{SPLA_PU_HOST}};
 
     std::ostream* output_stream_{nullptr};
@@ -280,8 +294,10 @@ class Simulation_context : public Simulation_parameters
     /// External pointers to periodic functions.
     std::map<std::string, periodic_function_ptr_t<double>> pf_ext_ptr;
 
+    /// Stores all callback functions.
     callback_functions_t cb_;
 
+    /// Stores all radial integrals.
     radial_integrals_t ri_;
 
     mutable double evp_work_count_{0};

--- a/src/density/density.cpp
+++ b/src/density/density.cpp
@@ -173,7 +173,7 @@ Density::initial_density_pseudo()
     auto q = ctx_.gvec().shells_len();
     /* get form-factors for all G shells */
     // TODO: MPI parallelise over G-shells
-    auto ff = ctx_.ps_rho_ri().values(q, ctx_.comm());
+    auto ff = ctx_.ri().ps_rho_->values(q, ctx_.comm());
     /* make Vloc(G) */
     auto v = ctx_.make_periodic_function<sddk::index_domain_t::local>(ff);
 

--- a/src/density/density.hpp
+++ b/src/density/density.hpp
@@ -327,7 +327,7 @@ class Density : public Field4D
         /* get lenghts of all G shells */
         auto q = ctx_.gvec().shells_len();
         /* get form-factors for all G shells */
-        auto ff = ctx_.ps_core_ri().values(q, ctx_.comm());
+        auto ff = ctx_.ri().ps_core_->values(q, ctx_.comm());
         /* make rho_core(G) */
         auto v = ctx_.make_periodic_function<sddk::index_domain_t::local>(ff);
 

--- a/src/geometry/force.cpp
+++ b/src/geometry/force.cpp
@@ -515,7 +515,7 @@ Force::calc_forces_scf_corr()
 
     auto q = ctx_.gvec().shells_len();
     /* get form-factors for all G shells */
-    auto ff = ctx_.ps_rho_ri().values(q, ctx_.comm());
+    auto ff = ctx_.ri().ps_rho_->values(q, ctx_.comm());
 
     forces_scf_corr_ = sddk::mdarray<double, 2>(3, ctx_.unit_cell().num_atoms());
     forces_scf_corr_.zero();
@@ -571,7 +571,7 @@ Force::calc_forces_core()
 
     auto q = ctx_.gvec().shells_len();
     /* get form-factors for all G shells */
-    auto ff = ctx_.ps_core_ri().values(q, ctx_.comm());
+    auto ff = ctx_.ri().ps_core_->values(q, ctx_.comm());
 
     forces_core_ = sddk::mdarray<double, 2>(3, ctx_.unit_cell().num_atoms());
     forces_core_.zero();
@@ -695,7 +695,7 @@ Force::calc_forces_vloc()
 
     auto q = ctx_.gvec().shells_len();
     /* get form-factors for all G shells */
-    auto ff = ctx_.vloc_ri().values(q, ctx_.comm());
+    auto ff = ctx_.ri().vloc_->values(q, ctx_.comm());
 
     forces_vloc_ = sddk::mdarray<double, 2>(3, ctx_.unit_cell().num_atoms());
     forces_vloc_.zero();

--- a/src/geometry/stress.cpp
+++ b/src/geometry/stress.cpp
@@ -239,7 +239,7 @@ Stress::calc_stress_core()
     potential_.xc_potential().rg().fft_transform(-1);
 
     auto q     = ctx_.gvec().shells_len();
-    auto ff    = ctx_.ps_core_ri_djl().values(q, ctx_.comm());
+    auto ff    = ctx_.ri().ps_core_djl_->values(q, ctx_.comm());
     auto drhoc = ctx_.make_periodic_function<sddk::index_domain_t::local>(ff);
 
     double sdiag{0};
@@ -407,7 +407,8 @@ Stress::calc_stress_us()
             continue;
         }
 
-        Augmentation_operator q_deriv(ctx_.unit_cell().atom_type(iat), ctx_.gvec(), ctx_.aug_ri(), ctx_.aug_ri_djl());
+        Augmentation_operator q_deriv(ctx_.unit_cell().atom_type(iat), ctx_.gvec(), *ctx_.ri().aug_,
+                *ctx_.ri().aug_djl_);
 
         auto nbf = atom_type.mt_basis_size();
 
@@ -733,8 +734,8 @@ Stress::calc_stress_vloc()
     stress_vloc_.zero();
 
     auto q          = ctx_.gvec().shells_len();
-    auto ri_vloc    = ctx_.vloc_ri().values(q, ctx_.comm());
-    auto ri_vloc_dg = ctx_.vloc_ri_djl().values(q, ctx_.comm());
+    auto ri_vloc    = ctx_.ri().vloc_->values(q, ctx_.comm());
+    auto ri_vloc_dg = ctx_.ri().vloc_djl_->values(q, ctx_.comm());
 
     auto v  = ctx_.make_periodic_function<sddk::index_domain_t::local>(ri_vloc);
     auto dv = ctx_.make_periodic_function<sddk::index_domain_t::local>(ri_vloc_dg);

--- a/src/geometry/wavefunction_strain_deriv.hpp
+++ b/src/geometry/wavefunction_strain_deriv.hpp
@@ -21,12 +21,12 @@ wavefunctions_strain_deriv(Simulation_context const& ctx__, K_point<double>& kp_
 
         std::vector<sddk::mdarray<double, 1>> ri_values(ctx__.unit_cell().num_atom_types());
         for (int iat = 0; iat < ctx__.unit_cell().num_atom_types(); iat++) {
-            ri_values[iat] = ctx__.ps_atomic_wf_ri().values(iat, gvs[0]);
+            ri_values[iat] = ctx__.ri().ps_atomic_wf_->values(iat, gvs[0]);
         }
 
         std::vector<sddk::mdarray<double, 1>> ridjl_values(ctx__.unit_cell().num_atom_types());
         for (int iat = 0; iat < ctx__.unit_cell().num_atom_types(); iat++) {
-            ridjl_values[iat] = ctx__.ps_atomic_wf_ri_djl().values(iat, gvs[0]);
+            ridjl_values[iat] = ctx__.ri().ps_atomic_wf_djl_->values(iat, gvs[0]);
         }
 
         const double p = (mu__ == nu__) ? 0.5 : 0.0;

--- a/src/k_point/k_point.cpp
+++ b/src/k_point/k_point.cpp
@@ -205,7 +205,7 @@ K_point<T>::generate_hubbard_orbitals()
     std::iota(atoms.begin(), atoms.end(), 0);
 
     this->generate_atomic_wave_functions(atoms, [&](int iat){ return &ctx_.unit_cell().atom_type(iat).indexb_wfs(); },
-                ctx_.ps_atomic_wf_ri(), *atomic_wave_functions_);
+                *ctx_.ri().ps_atomic_wf_, *atomic_wave_functions_);
 
     auto pcs = env::print_checksum();
     if (pcs) {

--- a/src/potential/potential.hpp
+++ b/src/potential/potential.hpp
@@ -253,7 +253,7 @@ class Potential : public Field4D
         /* get lenghts of all G shells */
         auto q = ctx_.gvec().shells_len();
         /* get form-factors for all G shells */
-        auto ff = ctx_.vloc_ri().values(q, ctx_.comm());
+        auto ff = ctx_.ri().vloc_->values(q, ctx_.comm());
         /* make Vloc(G) */
         auto v = ctx_.make_periodic_function<sddk::index_domain_t::local>(ff);
 


### PR DESCRIPTION
Collect all radial integrals and all callback functions in standalone data-structures. Rationale: they are internal objects that do not need to be properly "interfaced". This simplifies the amount of methods and members of Simulation_context class.