### PR TITLE
[enhancement] re-introduce check_wave_functions() function

### DIFF
--- a/src/SDDK/wave_functions.hpp
+++ b/src/SDDK/wave_functions.hpp
@@ -753,6 +753,11 @@ class Wave_functions : public Wave_functions_mt<T>
         return *gkvec_;
     }
 
+    auto gkvec_sptr() const
+    {
+        return gkvec_;
+    }
+
     inline auto checksum_pw(sddk::memory_t mem__, spin_index s__, band_range b__) const
     {
         std::complex<T> cs{0};

--- a/src/band/band.cpp
+++ b/src/band/band.cpp
@@ -75,59 +75,6 @@ Band::initialize_subspace(K_point_set& kset__, Hamiltonian0<T>& H0__) const
     }
 }
 
-
-///// Check wave-functions for orthonormalization.
-//template <typename T>
-//void Band::check_wave_functions(Hamiltonian_k<real_type<T>>& Hk__) const
-//{
-//    auto& kp = Hk__.kp();
-//    kp.message(1, __function_name__, "%s", "checking wave-functions\n");
-//
-//    if (!ctx_.full_potential()) {
-//
-//        sddk::dmatrix<T> ovlp(ctx_.num_bands(), ctx_.num_bands(), ctx_.blacs_grid(), ctx_.cyclic_block_size(), ctx_.cyclic_block_size());
-//
-//        const bool nc_mag = (ctx_.num_mag_dims() == 3);
-//        const int num_sc = nc_mag ? 2 : 1;
-//
-//        auto& psi = kp.spinor_wave_functions();
-//        sddk::Wave_functions<real_type<T>> spsi(kp.gkvec_partition(), ctx_.num_bands(), ctx_.preferred_memory_t(), num_sc);
-//
-//        if (is_device_memory(ctx_.preferred_memory_t())) {
-//            auto& mpd = ctx_.mem_pool(sddk::memory_t::device);
-//            for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
-//                psi.pw_coeffs(ispn).allocate(mpd);
-//                psi.pw_coeffs(ispn).copy_to(sddk::memory_t::device, 0, ctx_.num_bands());
-//            }
-//            for (int i = 0; i < num_sc; i++) {
-//                spsi.pw_coeffs(i).allocate(mpd);
-//            }
-//            ovlp.allocate(sddk::memory_t::device);
-//        }
-//
-//        /* compute residuals */
-//        for (int ispin_step = 0; ispin_step < ctx_.num_spinors(); ispin_step++) {
-//            auto sr = sddk::spin_range(nc_mag ? 2 : ispin_step);
-//            /* apply Hamiltonian and S operators to the wave-functions */
-//            Hk__.template apply_h_s<T>(sr, 0, ctx_.num_bands(), psi, nullptr, &spsi);
-//            inner(ctx_.spla_context(), sr, psi, 0, ctx_.num_bands(), spsi, 0, ctx_.num_bands(), ovlp, 0, 0);
-//
-//            double diff = check_identity(ovlp, ctx_.num_bands());
-//
-//            if (diff > 1e-12) {
-//                kp.message(1, __function_name__, "overlap matrix is not identity, maximum error : %20.12f\n", diff);
-//            } else {
-//                kp.message(1, __function_name__, "%s", "OK! Wave functions are orthonormal.\n");
-//            }
-//        }
-//        if (is_device_memory(ctx_.preferred_memory_t())) {
-//            for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
-//                psi.pw_coeffs(ispn).deallocate(sddk::memory_t::device);
-//            }
-//        }
-//    }
-//}
-
 template
 void
 Band::initialize_subspace<double>(K_point_set& kset__, Hamiltonian0<double>& H0__) const;

--- a/src/band/band.hpp
+++ b/src/band/band.hpp
@@ -172,14 +172,6 @@ class Band // TODO: Band class is lightweight and in principle can be converted 
     template <typename T>
     void solve_full_potential(Hamiltonian_k<T>& Hk__, double itsol_tol__) const;
 
-    /// Check the residuals of wave-functions.
-    template <typename T>
-    void check_residuals(Hamiltonian_k<real_type<T>>& Hk__) const;
-
-    /// Check wave-functions for orthonormalization.
-    template <typename T>
-    void check_wave_functions(Hamiltonian_k<real_type<T>>& Hk__) const;
-
     /// Solve \f$ \hat H \psi = E \psi \f$ and find eigen-states of the Hamiltonian.
     template <typename T, typename F>
     void solve(K_point_set& kset__, Hamiltonian0<T>& H0__, double itsol_tol__) const;
@@ -441,16 +433,7 @@ inline void initialize_subspace(Hamiltonian_k<T>& Hk__, int num_ao__)
             }
         }
     }
-
-    ///* check residuals */
-    //if (ctx_.cfg().control().verification() >= 2) {
-    //    check_residuals<T>(Hk__);
-    //    check_wave_functions<T>(Hk__);
-    //}
-
-    //ctx_.print_memory_usage(__FILE__, __LINE__);
 }
-
 
 }
 

--- a/src/band/check_wave_functions.hpp
+++ b/src/band/check_wave_functions.hpp
@@ -1,0 +1,70 @@
+// Copyright (c) 2013-2023 Anton Kozhevnikov, Thomas Schulthess
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+// the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the
+//    following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+//    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+// WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+// PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+// OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/** \file check_wave_functions.hpp
+ *
+ *  \brief Check orthogonality of wave-functions and their residuals.
+ */
+
+#ifndef __CHECK_WAVE_FUNCTIONS_HPP__
+#define __CHECK_WAVE_FUNCTIONS_HPP__
+
+namespace sirius {
+
+template <typename T, typename F>
+void check_wave_functions(Hamiltonian_k<real_type<T>>& Hk__, wf::Wave_functions<T>& psi__, wf::spin_range sr__,
+        wf::band_range br__, double* eval__)
+{
+    wf::Wave_functions<T> hpsi(psi__.gkvec_sptr(), psi__.num_md(), wf::num_bands(br__.size()), sddk::memory_t::host);
+    wf::Wave_functions<T> spsi(psi__.gkvec_sptr(), psi__.num_md(), wf::num_bands(br__.size()), sddk::memory_t::host);
+
+    la::dmatrix<F> ovlp(br__.size(), br__.size());
+
+    /* apply Hamiltonian and S operators to the wave-functions */
+    Hk__.template apply_h_s<F>(sr__, br__, psi__, &hpsi, &spsi);
+
+    wf::inner(Hk__.H0().ctx().spla_context(), sddk::memory_t::host, sr__, psi__, br__, spsi, br__, ovlp, 0, 0);
+
+    auto diff = check_identity(ovlp, br__.size());
+    if (diff > 1e-12) {
+        std::cout << "[check_wave_functions] Error! Wave-functions are not orthonormal, difference : " << diff << std::endl;
+    } else {
+        std::cout << "[check_wave_functions] Ok! Wave-functions are orthonormal" << std::endl;
+    }
+
+    for (int ib = 0; ib < br__.size(); ib++) {
+        double l2norm{0};
+        for (int s = sr__.begin(); s != sr__.end(); s++) {
+            for (int ig = 0; ig < psi__.gkvec().count(); ig++) {
+                /* H|psi> - e S|psi> */
+                auto z = hpsi.pw_coeffs(ig, wf::spin_index(s), wf::band_index(ib)) -
+                    spsi.pw_coeffs(ig, wf::spin_index(s), wf::band_index(ib)) * static_cast<real_type<T>>(eval__[ib]);
+                l2norm += std::real(z * std::conj(z));
+            }
+            psi__.gkvec().comm().allreduce(&l2norm, 1);
+            l2norm = std::sqrt(l2norm);
+            std::cout << "[check_wave_functions] band : " << ib << ", residual l2norm : " << l2norm << std::endl;
+        }
+    }
+}
+
+}
+
+#endif
+

--- a/src/band/solve.cpp
+++ b/src/band/solve.cpp
@@ -23,6 +23,7 @@
  */
 #include "band.hpp"
 #include "davidson.hpp"
+#include "check_wave_functions.hpp"
 
 namespace sirius {
 
@@ -115,11 +116,20 @@ Band::solve_pseudo_potential(Hamiltonian_k<T>& Hk__, double itsol_tol__, double 
         RTE_THROW("unknown iterative solver type");
     }
 
-    ///* check residuals */
-    //if (ctx_.cfg().control().verification() >= 2) {
-    //    check_residuals<T>(Hk__);
-    //    check_wave_functions<T>(Hk__);
-    //}
+    /* check wave-functions */
+    if (ctx_.cfg().control().verification() >= 2) {
+        if (ctx_.num_mag_dims() == 3) {
+            auto eval = Hk__.kp().band_energies(0);
+            check_wave_functions<T, F>(Hk__, Hk__.kp().spinor_wave_functions(), wf::spin_range(0, 2),
+                    wf::band_range(0, ctx_.num_bands()), eval.data());
+        } else {
+            for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
+                auto eval = Hk__.kp().band_energies(ispn);
+                check_wave_functions<T, F>(Hk__, Hk__.kp().spinor_wave_functions(), wf::spin_range(ispn),
+                        wf::band_range(0, ctx_.num_bands()), eval.data());
+            }
+        }
+    }
 
     print_memory_usage(ctx_.out(), FILE_LINE);
 

--- a/src/hamiltonian/hamiltonian.hpp
+++ b/src/hamiltonian/hamiltonian.hpp
@@ -174,6 +174,7 @@ template <typename T>
 class Hamiltonian_k
 {
   private:
+    /// K-point independent part of Hamiltonian.
     Hamiltonian0<T>& H0_;
     K_point<T>& kp_;
     /// Hubbard correction.
@@ -344,17 +345,14 @@ class Hamiltonian_k
      *
      *  \param [in]  apw_only   True if only APW-APW block of H and O are applied.
      *  \param [in]  phi_is_lo  True if input wave-functions are pure local orbitals.
-     *  \param [in]  N          Starting index of wave-functions.
-     *  \param [in]  n          Number of wave-functions to which H and S are applied.
+     *  \param [in]  b          Range of bands.
      *  \param [in]  phi        Input wave-functions.
      *  \param [out] hphi       Result of Hamiltonian, applied to wave-functions.
      *  \param [out] ophi       Result of overlap operator, applied to wave-functions.
      */
-    //void apply_fv_h_o(bool apw_only__, bool phi_is_lo__, int N__, int n__, sddk::Wave_functions<T>& phi__,
-    //                  sddk::Wave_functions<T>* hphi__, sddk::Wave_functions<T>* ophi__);
-
     void apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range b__, wf::Wave_functions<T>& phi__,
                       wf::Wave_functions<T>* hphi__, wf::Wave_functions<T>* ophi__);
+
     /// Setup the Hamiltonian and overlap matrices in APW+lo basis
     /** The Hamiltonian matrix has the following expression:
      *  \f[
@@ -436,21 +434,15 @@ class Hamiltonian_k
                            sddk::mdarray<std::complex<T>, 2>& o) const;
 
     /// Apply pseudopotential H and S operators to the wavefunctions.
-    /** \param [in]  spins Spin index range
-     *  \param [in]  N     Starting index of wave-functions.
-     *  \param [in]  n     Number of wave-functions to which H and S are applied.
+    /** \tparam F    Type of the subspace matrix.
+     *  \param [in]  spins Range of spins.
+     *  \param [in]  br    Range of bands.
      *  \param [in]  phi   Input wave-functions [storage: CPU && GPU].
      *  \param [out] hphi  Result of Hamiltonian, applied to wave-functions [storage: CPU || GPU].
      *  \param [out] sphi  Result of S-operator, applied to wave-functions [storage: CPU || GPU].
      *
      *  In non-collinear case (spins in [0,1]) the Hamiltonian and S operator are applied to both components of spinor
      *  wave-functions. Otherwise they are applied to a single component.
-     */
-    //template <typename F, typename = std::enable_if_t<std::is_same<T, real_type<F>>::value>>
-    //void apply_h_s(sddk::spin_range spins__, int N__, int n__, sddk::Wave_functions<T>& phi__,
-    //               sddk::Wave_functions<T>* hphi__, sddk::Wave_functions<T>* sphi__);
-
-    /** \tparam F  Type of the subspace matrix.
      */
     template <typename F>
     std::enable_if_t<std::is_same<T, real_type<F>>::value, void>

--- a/src/k_point/k_point.hpp
+++ b/src/k_point/k_point.hpp
@@ -421,6 +421,15 @@ class K_point
         band_energies_(j__, get_ispn(ispn__)) = e__;
     }
 
+    inline auto band_energies(int ispn__) const
+    {
+        std::vector<double> result(ctx_.num_bands());
+        for (int j = 0; j < ctx_.num_bands(); j++) {
+            result[j] = this->band_energy(j, ispn__);
+        }
+        return result;
+    }
+
     /// Get band occupancy.
     inline double band_occupancy(int j__, int ispn__) const
     {

--- a/src/k_point/k_point_set.hpp
+++ b/src/k_point/k_point_set.hpp
@@ -155,7 +155,14 @@ class K_point_set
 
     /// Get a list of band energies for a given k-point index.
     template <typename T>
-    std::vector<double> get_band_energies(int ik__, int ispn__) const;
+    auto get_band_energies(int ik__, int ispn__) const
+    {
+        std::vector<double> bnd_e(ctx_.num_bands());
+        for (int j = 0; j < ctx_.num_bands(); j++) {
+            bnd_e[j] = (*this).get<T>(ik__)->band_energy(j, ispn__);
+        }
+        return bnd_e;
+    }
 
     /// Return maximum number of G+k vectors among all k-points.
     int max_num_gkvec() const
@@ -283,16 +290,6 @@ inline K_point<float>* K_point_set::get<float>(int ik__) const
     RTE_THROW("not compiled with FP32 support");
     return nullptr; // make compiler happy
 #endif
-}
-
-template <typename T>
-std::vector<double> K_point_set::get_band_energies(int ik__, int ispn__) const
-{
-    std::vector<double> bnd_e(ctx_.num_bands());
-    for (int j = 0; j < ctx_.num_bands(); j++) {
-        bnd_e[j] = (*this).get<T>(ik__)->band_energy(j, ispn__);
-    }
-    return bnd_e;
 }
 
 }; // namespace sirius


### PR DESCRIPTION
This is needed to check wave-fuctions after the SCF loop and before doing the linear-response. 