### PR TITLE
[fix] cmake config for rocsolver

### DIFF
--- a/cmake/siriusConfig.cmake.in
+++ b/cmake/siriusConfig.cmake.in
@@ -77,6 +77,7 @@ if(NOT TARGET sirius::sirius)
   if(@USE_ROCM@)
     find_package(hip CONFIG ${mode})
     find_package(rocblas CONFIG ${mode})
+    find_package(rocsolver CONFIG ${mode})
   endif()
 
   # Clean-up module path.

--- a/cmake/siriusConfig.cmake.in
+++ b/cmake/siriusConfig.cmake.in
@@ -80,6 +80,10 @@ if(NOT TARGET sirius::sirius)
     find_package(rocsolver CONFIG ${mode})
   endif()
 
+  if(@USE_MEMORY_POOL@)
+    find_package(umpire ${mode})
+  endif()
+
   # Clean-up module path.
   list(REMOVE_ITEM CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
 


### PR DESCRIPTION
`find_package` was missing for rocsolver in `siriusConfig.cmake`. Same for `umpire`.