### PR TITLE
Add initial support for HDF5 ATTRIBUTEs

### DIFF
--- a/apps/tests/test_hdf5.cpp
+++ b/apps/tests/test_hdf5.cpp
@@ -1,34 +1,35 @@
 #include <sirius.hpp>
 
-void test1()
+void
+test1()
 {
-    sddk::HDF5_tree f("f.h5", sddk::hdf5_access_t::truncate);
-    
+    sddk::HDF5_tree f("f1.h5", sddk::hdf5_access_t::truncate);
+
     sddk::mdarray<double, 2> dat(2, 4);
     dat.zero();
-    
+
     dat(0, 0) = 1.1;
     dat(0, 1) = 2.2;
     dat(0, 2) = 3.3;
     dat(1, 0) = 4.4;
     dat(1, 1) = 5.5;
     dat(1, 2) = 6.6;
-    
+
     std::cout << "hash  = " << dat.hash() << std::endl;
-    
+
     f.create_node("aaa");
     f["aaa"].write("dat_name", dat);
     dat.zero();
     f["aaa"].read("dat_name", dat);
     std::cout << "hash  = " << dat.hash() << std::endl;
-    
+
     f.write("dat_name", dat);
-    
 }
 
-void test2()
+void
+test2()
 {
-    sddk::HDF5_tree f("f.h5", sddk::hdf5_access_t::truncate);
+    sddk::HDF5_tree f("f2.h5", sddk::hdf5_access_t::truncate);
     f.create_node("node1");
 
     sddk::mdarray<double, 2> md1(2, 4);
@@ -47,9 +48,10 @@ void test2()
     f["node1"].write(2, md3);
 }
 
-void test3()
+void
+test3()
 {
-    sddk::HDF5_tree f("f.h5", sddk::hdf5_access_t::read_only);
+    sddk::HDF5_tree f("f2.h5", sddk::hdf5_access_t::read_only);
 
     sddk::mdarray<double, 2> md1(2, 4);
     f["node1"].read("md1", md1);
@@ -66,11 +68,37 @@ void test3()
     f["node1"].read(2, md3);
 }
 
-
-int main(int argn, char** argv)
+void
+test4()
 {
-    test1();
+    sddk::HDF5_tree f("qe.h5", sddk::hdf5_access_t::truncate);
+
+    sddk::mdarray<double, 2> dat(2, 4);
+    dat.zero();
+
+    dat(0, 0) = 1.1;
+    dat(0, 1) = 2.2;
+    dat(0, 2) = 3.3;
+    dat(1, 0) = 4.4;
+    dat(1, 1) = 5.5;
+    dat(1, 2) = 6.6;
+
+    std::cout << "hash  = " << dat.hash() << std::endl;
+
+    f.create_node("aaa");
+    f["aaa"].write("dat_name", dat);
+    dat.zero();
+    f["aaa"].read("dat_name", dat);
+    std::cout << "hash  = " << dat.hash() << std::endl;
+
+    f.write("dat_name", dat);
+}
+
+int
+main(int argn, char** argv)
+{
     test1();
     test2();
     test3();
+    test4();
 }

--- a/apps/tests/test_hdf5.cpp
+++ b/apps/tests/test_hdf5.cpp
@@ -77,7 +77,7 @@ test4()
     using namespace std::string_literals;
     sddk::HDF5_tree f("qe.h5", sddk::hdf5_access_t::truncate);
 
-    sddk::mdarray<double, 2> miller(2, 3); // Dataset
+    sddk::mdarray<int, 2> miller(2, 3); // Dataset
     miller.zero();
 
     sddk::mdarray<double, 2> evc(3, 4); // Dataset

--- a/apps/tests/test_hdf5.cpp
+++ b/apps/tests/test_hdf5.cpp
@@ -1,5 +1,8 @@
 #include <sirius.hpp>
 
+#include <string>
+#include <vector>
+
 void
 test1()
 {
@@ -71,27 +74,23 @@ test3()
 void
 test4()
 {
+    using namespace std::string_literals;
     sddk::HDF5_tree f("qe.h5", sddk::hdf5_access_t::truncate);
 
-    sddk::mdarray<double, 2> dat(2, 4);
-    dat.zero();
+    sddk::mdarray<double, 2> miller(2, 3);
+    miller.zero();
 
-    dat(0, 0) = 1.1;
-    dat(0, 1) = 2.2;
-    dat(0, 2) = 3.3;
-    dat(1, 0) = 4.4;
-    dat(1, 1) = 5.5;
-    dat(1, 2) = 6.6;
+    sddk::mdarray<double, 2> evec(3, 4);
+    evec.zero();
 
-    std::cout << "hash  = " << dat.hash() << std::endl;
+    std::vector<double> xk = {0.00, 0.13, 0.10};
 
-    f.create_node("aaa");
-    f["aaa"].write("dat_name", dat);
-    dat.zero();
-    f["aaa"].read("dat_name", dat);
-    std::cout << "hash  = " << dat.hash() << std::endl;
-
-    f.write("dat_name", dat);
+    f.write_attribute("gamma_only", ".FALSE."s);
+    f.write_attribute("igwx", 4572);
+    f.write_attribute("scale_factor", 1.0);
+    f.write_attribute("xk", xk);
+    f.write("MillerIndices", miller);
+    f.write("evec", evec);
 }
 
 int

--- a/apps/tests/test_hdf5.cpp
+++ b/apps/tests/test_hdf5.cpp
@@ -77,20 +77,24 @@ test4()
     using namespace std::string_literals;
     sddk::HDF5_tree f("qe.h5", sddk::hdf5_access_t::truncate);
 
-    sddk::mdarray<double, 2> miller(2, 3);
+    sddk::mdarray<double, 2> miller(2, 3); // Dataset
     miller.zero();
 
-    sddk::mdarray<double, 2> evec(3, 4);
-    evec.zero();
+    sddk::mdarray<double, 2> evc(3, 4); // Dataset
+    evc.zero();
 
-    std::vector<double> xk = {0.00, 0.13, 0.10};
+    std::vector<double> xk = {0.00, 0.13, 0.10}; // Group '/' attribute
+    std::vector<double> bg1 = {0.00, 0.13, 0.10}; // Dataset 'MillerIndices' attribute
 
     f.write_attribute("gamma_only", ".FALSE."s);
     f.write_attribute("igwx", 4572);
     f.write_attribute("scale_factor", 1.0);
     f.write_attribute("xk", xk);
     f.write("MillerIndices", miller);
-    f.write("evec", evec);
+    f.write_attribute("bg1", bg1, "MillerIndices"s);
+    f.write_attribute("doc", "Miller Indices of the wave-vectors"s, "MillerIndices"s);
+    f.write("evc", evc);
+    f.write_attribute("doc", "Wave Functions, (npwx, nbnd)"s, "evc"s);
 }
 
 int

--- a/apps/tests/test_hdf5.cpp
+++ b/apps/tests/test_hdf5.cpp
@@ -84,17 +84,16 @@ test4()
     evc.zero();
 
     std::vector<double> xk = {0.00, 0.13, 0.10}; // Group '/' attribute
-    std::vector<double> bg1 = {0.00, 0.13, 0.10}; // Dataset 'MillerIndices' attribute
 
-    f.write_attribute("gamma_only", ".FALSE."s);
+    f.write_attribute("gamma_only", ".FALSE.");
     f.write_attribute("igwx", 4572);
     f.write_attribute("scale_factor", 1.0);
     f.write_attribute("xk", xk);
     f.write("MillerIndices", miller);
-    f.write_attribute("bg1", bg1, "MillerIndices"s);
-    f.write_attribute("doc", "Miller Indices of the wave-vectors"s, "MillerIndices"s);
+    f.write_attribute("bg1", {0.67, 0.39, 0.00}, "MillerIndices");
+    f.write_attribute("doc", "Miller Indices of the wave-vectors", "MillerIndices");
     f.write("evc", evc);
-    f.write_attribute("doc", "Wave Functions, (npwx, nbnd)"s, "evc"s);
+    f.write_attribute("doc", "Wave Functions, (npwx, nbnd)"s, "evc");
 }
 
 int

--- a/src/SDDK/hdf5_tree.hpp
+++ b/src/SDDK/hdf5_tree.hpp
@@ -31,7 +31,8 @@
 
 namespace sddk {
 
-enum class hdf5_access_t {
+enum class hdf5_access_t
+{
     truncate,
     read_write,
     read_only
@@ -40,28 +41,40 @@ enum class hdf5_access_t {
 template <typename T>
 struct hdf5_type_wrapper;
 
-template<>
+template <>
 struct hdf5_type_wrapper<float>
 {
-    operator hid_t() const noexcept {return H5T_NATIVE_FLOAT;};
+    operator hid_t() const noexcept
+    {
+        return H5T_NATIVE_FLOAT;
+    };
 };
 
-template<>
+template <>
 struct hdf5_type_wrapper<double>
 {
-    operator hid_t() const noexcept {return H5T_NATIVE_DOUBLE;};
+    operator hid_t() const noexcept
+    {
+        return H5T_NATIVE_DOUBLE;
+    };
 };
 
-template<>
+template <>
 struct hdf5_type_wrapper<int>
 {
-    operator hid_t() const noexcept {return H5T_NATIVE_INT;};
+    operator hid_t() const noexcept
+    {
+        return H5T_NATIVE_INT;
+    };
 };
 
-template<>
+template <>
 struct hdf5_type_wrapper<uint8_t>
 {
-    operator hid_t() const noexcept {return H5T_NATIVE_UCHAR;};
+    operator hid_t() const noexcept
+    {
+        return H5T_NATIVE_UCHAR;
+    };
 };
 
 /// Interface to the HDF5 library.
@@ -199,6 +212,44 @@ class HDF5_tree
         }
     };
 
+    /// Auxiliary
+    class HDF5_attribute
+    {
+      private:
+        /// HDF5 id of the current object
+        hid_t id_;
+
+      public:
+        /// Constructor which opens the existing dataset object
+        HDF5_attribute(hid_t group_id, const std::string& name)
+        {
+            if ((id_ = H5Aopen(group_id, name.c_str(), H5P_DEFAULT)) < 0)
+                RTE_THROW("error in H5Aopen()");
+        }
+
+        /// Constructor which creates the new attribute object
+        HDF5_attribute(HDF5_dataset& dataset, HDF5_dataspace& dataspace, const std::string& name, hid_t type_id)
+        {
+            if ((id_ = H5Acreate(dataset.id(), name.c_str(), type_id, dataspace.id(), H5P_DEFAULT, H5P_DEFAULT)) < 0) {
+                RTE_THROW("error in H5Acreate()");
+            }
+        }
+
+        /// Destructor
+        ~HDF5_attribute()
+        {
+            if (H5Aclose(id_) < 0) {
+                RTE_THROW("error in H5Aclose()");
+            }
+        }
+
+        /// Return HDF5 id of the current object
+        inline hid_t id() const
+        {
+            return id_;
+        }
+    };
+
     /// Constructor to create branches of the HDF5 tree.
     HDF5_tree(hid_t file_id__, const std::string& path__)
         : path_(path__)
@@ -246,7 +297,6 @@ class HDF5_tree
     // HDF5_tree& operator=(HDF5_tree const& src) = delete;
 
   public:
-
     /// Constructor to create the HDF5 tree.
     HDF5_tree(const std::string& file_name__, hdf5_access_t access__)
         : file_name_(file_name__)

--- a/src/SDDK/hdf5_tree.hpp
+++ b/src/SDDK/hdf5_tree.hpp
@@ -315,10 +315,7 @@ class HDF5_tree
         }
     }
 
-    /// Write attribure to current GROUP or to specifc DATASET within the GROUP
-    ///
-    /// @remark The attribute is attached to the current GROUP by default, but it can be optionally attached to a
-    /// DATASET (within the current GROUP)
+    /// Write attribure to current GROUP
     ///
     /// @param name Name of the attribute
     /// @param data Attribute data
@@ -335,10 +332,7 @@ class HDF5_tree
         }
     }
 
-    /// Write attribure to current GROUP or to specifc DATASET within the GROUP
-    ///
-    /// @remark The attribute is attached to the current GROUP by default, but it can be optionally attached to a
-    /// DATASET (within the current GROUP)
+    /// Write attribure to DATASET within the GROUP
     ///
     /// @param name Name of the attribute
     /// @param data Attribute data


### PR DESCRIPTION
Add initial (limited) support for HDF5 `ATTRIBUTE`s. The support is focused on the output of HDF5 files compatible with [QuantumESPRESSO HDF5 wave functions files](https://gitlab.com/QEF/q-e/-/snippets/1869219).

Current limitations:
* `ATTRIBUTE`s can only be added to the current `GROUP` or in a `DATASET` belonging to the current group 
* `ATTRIBUTE`'s `DATASCPACE` is assumed to be `HD5_SCALAR`
* Reading `ATTRIBUTE`s is not implemented

---

HDF5 file produced by `test4`:

```text
HDF5 "qe.h5" {
GROUP "/" {
   ATTRIBUTE "gamma_only" {
      DATATYPE  H5T_STRING {
         STRSIZE 7;
         STRPAD H5T_STR_SPACEPAD;
         CSET H5T_CSET_ASCII;
         CTYPE H5T_C_S1;
      }
      DATASPACE  SCALAR
      DATA {
      (0): ".FALSE."
      }
   }
   ATTRIBUTE "igwx" {
      DATATYPE  H5T_STD_I32LE
      DATASPACE  SCALAR
      DATA {
      (0): 4572
      }
   }
   ATTRIBUTE "scale_factor" {
      DATATYPE  H5T_IEEE_F64LE
      DATASPACE  SCALAR
      DATA {
      (0): 1
      }
   }
   ATTRIBUTE "xk" {
      DATATYPE  H5T_ARRAY { [3] H5T_IEEE_F64LE }
      DATASPACE  SCALAR
      DATA {
      (0): [ 0, 0.13, 0.1 ]
      }
   }
   DATASET "MillerIndices" {
      DATATYPE  H5T_STD_I32LE
      DATASPACE  SIMPLE { ( 3, 2 ) / ( 3, 2 ) }
      DATA {
      (0,0): 0, 0,
      (1,0): 0, 0,
      (2,0): 0, 0
      }
      ATTRIBUTE "bg1" {
         DATATYPE  H5T_ARRAY { [3] H5T_IEEE_F64LE }
         DATASPACE  SCALAR
         DATA {
         (0): [ 0.67, 0.39, 0 ]
         }
      }
      ATTRIBUTE "doc" {
         DATATYPE  H5T_STRING {
            STRSIZE 34;
            STRPAD H5T_STR_SPACEPAD;
            CSET H5T_CSET_ASCII;
            CTYPE H5T_C_S1;
         }
         DATASPACE  SCALAR
         DATA {
         (0): "Miller Indices of the wave-vectors"
         }
      }
   }
   DATASET "evc" {
      DATATYPE  H5T_IEEE_F64LE
      DATASPACE  SIMPLE { ( 4, 3 ) / ( 4, 3 ) }
      DATA {
      (0,0): 0, 0, 0,
      (1,0): 0, 0, 0,
      (2,0): 0, 0, 0,
      (3,0): 0, 0, 0
      }
      ATTRIBUTE "doc" {
         DATATYPE  H5T_STRING {
            STRSIZE 28;
            STRPAD H5T_STR_SPACEPAD;
            CSET H5T_CSET_ASCII;
            CTYPE H5T_C_S1;
         }
         DATASPACE  SCALAR
         DATA {
         (0): "Wave Functions, (npwx, nbnd)"
         }
      }
   }
}
}
```

(Compare with [QuantumESPRESSO HDF5 wave functions files](https://gitlab.com/QEF/q-e/-/snippets/1869219))