### PR TITLE
C++17 for Python module

### DIFF
--- a/python_module/CMakeLists.txt
+++ b/python_module/CMakeLists.txt
@@ -2,9 +2,9 @@ find_package(Python3 COMPONENTS Development REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 find_package(mpi4py REQUIRED)
 
-# TODO: for some reason PYBIND11 is not happy here; explicit export of PYBIND11_CPP14 is needed for Intel compiler
+# TODO: for some reason PYBIND11 is not happy here; explicit export of PYBIND11_CPP17 is needed for Intel compiler
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Intel")
-  add_definitions("-DPYBIND11_CPP14")
+  add_definitions("-DPYBIND11_CPP17")
 endif()
 
 set(pb11_src_dir "${PROJECT_SOURCE_DIR}/python_module/pybind11")

--- a/python_module/CMakeLists.txt
+++ b/python_module/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(Python3 COMPONENTS Development REQUIRED)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 find_package(mpi4py REQUIRED)
 
 # TODO: for some reason PYBIND11 is not happy here; explicit export of PYBIND11_CPP14 is needed for Intel compiler


### PR DESCRIPTION
PR https://github.com/electronic-structure/SIRIUS/pull/863 switched to C++17, but it did not include the Python module.

Should fix [CI in PR #872](https://github.com/electronic-structure/SIRIUS/actions/runs/5608608758/jobs/10261192299).