### PR TITLE
[fix] add contribution from PAW density to inner product of mixing density residuals

### DIFF
--- a/src/function3d/paw_field4d.hpp
+++ b/src/function3d/paw_field4d.hpp
@@ -115,7 +115,23 @@ class PAW_field4D
     {
         return uc_;
     }
+
+    template <typename T_>
+    friend T_
+    inner(PAW_field4D<T_> const& x__, PAW_field4D<T_> const& y__);
 };
+
+template <typename T>
+T
+inner(PAW_field4D<T> const& x__, PAW_field4D<T> const& y__)
+{
+    T result{0};
+    for (int j = 0; j < x__.uc_.parameters().num_mag_dims() + 1; j++) {
+        result += inner(x__.ae_components_[j], y__.ae_components_[j]);
+        result += inner(x__.ps_components_[j], y__.ps_components_[j]);
+    }
+    return result;
+}
 
 
 } // namespace sirius

--- a/src/mixer/mixer_functions.cpp
+++ b/src/mixer/mixer_functions.cpp
@@ -220,8 +220,7 @@ FunctionProperties<PAW_density<double>> paw_density_function_property()
 
     auto inner_prod_func = [](PAW_density<double> const& x, PAW_density<double> const& y) -> double
     {
-        /* do not contribute to mixing */
-        return 0.0;
+        return inner(x, y);
     };
 
     auto scale_func = [](double alpha, PAW_density<double>& x) -> void


### PR DESCRIPTION
This might be the reason for unstable magnetic paw calculations. Why the non-magnetic paw converge in general - is still unclear.