### PR TITLE
use const where possible

### DIFF
--- a/apps/tests/test_davidson.cpp
+++ b/apps/tests/test_davidson.cpp
@@ -57,7 +57,7 @@ diagonalize(Simulation_context& ctx__, std::array<double, 3> vk__, Potential& po
 
     Hamiltonian0<T> H0(pot__, true);
     auto Hk = H0(kp);
-    sirius::initialize_subspace<T, F>(Hk, ctx__.unit_cell().num_ps_atomic_wf().first);
+    sirius::initialize_subspace<T, F>(Hk, kp, ctx__.unit_cell().num_ps_atomic_wf().first);
     for (int i = 0; i < ctx__.num_bands(); i++) {
         kp.band_energy(i, 0, 0);
     }
@@ -67,7 +67,7 @@ diagonalize(Simulation_context& ctx__, std::array<double, 3> vk__, Potential& po
     const int num_bands = ctx__.num_bands();
     bool locking{true};
 
-    auto result = davidson<T, F, davidson_evp_t::hamiltonian>(Hk, wf::num_bands(num_bands),
+    auto result = davidson<T, F, davidson_evp_t::hamiltonian>(Hk, kp, wf::num_bands(num_bands),
             wf::num_mag_dims(ctx__.num_mag_dims()), kp.spinor_wave_functions(), [&](int i, int ispn){return eval_tol__;}, res_tol__,
             60, locking, subspace_size__, estimate_eval__, extra_ortho__, std::cout, 2);
 

--- a/src/SDDK/memory.hpp
+++ b/src/SDDK/memory.hpp
@@ -1531,7 +1531,8 @@ auto_copy(mdarray<T, N>& dst, const mdarray<T, N>& src, device_t device)
 
 template <class numeric_t, std::size_t... Ts>
 auto
-_empty_like_inner(std::index_sequence<Ts...>& seq, std::size_t (&dims)[sizeof...(Ts)], memory_pool* mempool)
+_empty_like_inner(std::index_sequence<Ts...>& seq [[maybe_unused]], std::size_t (&dims)[sizeof...(Ts)],
+                  memory_pool* mempool)
 {
     if (mempool == nullptr) {
         return mdarray<numeric_t, sizeof...(Ts)>{dims[Ts]...};

--- a/src/SDDK/memory.hpp
+++ b/src/SDDK/memory.hpp
@@ -364,7 +364,7 @@ class memory_pool
 #endif
   public:
     /// Constructor
-    memory_pool(memory_t M__, size_t initial_size__ = 0)
+    memory_pool(memory_t M__)
         : M_(M__)
     {
         std::string mem_type;
@@ -612,7 +612,7 @@ class mdarray_index_descriptor
         return size_;
     }
 
-    inline bool check_range(index_type i__) const
+    inline bool check_range([[maybe_unused]] index_type i__) const
     {
 #ifdef NDEBUG
         return true;

--- a/src/dft/dft_ground_state.cpp
+++ b/src/dft/dft_ground_state.cpp
@@ -41,14 +41,14 @@ DFT_ground_state::initial_state()
         if (ctx_.cfg().parameters().precision_wf() == "fp32") {
 #if defined(SIRIUS_USE_FP32)
             Hamiltonian0<float> H0(potential_, true);
-            ::sirius::initialize_subspace(kset_, H0);
+            initialize_subspace(kset_, H0);
 #else
             RTE_THROW("not compiled with FP32 support");
 #endif
 
         } else {
             Hamiltonian0<double> H0(potential_, true);
-            ::sirius::initialize_subspace(kset_, H0);
+            initialize_subspace(kset_, H0);
         }
     }
 }

--- a/src/hamiltonian/check_wave_functions.hpp
+++ b/src/hamiltonian/check_wave_functions.hpp
@@ -25,6 +25,9 @@
 #ifndef __CHECK_WAVE_FUNCTIONS_HPP__
 #define __CHECK_WAVE_FUNCTIONS_HPP__
 
+#include "SDDK/wave_functions.hpp"
+#include "hamiltonian/hamiltonian.hpp"
+
 namespace sirius {
 
 template <typename T, typename F>

--- a/src/hamiltonian/check_wave_functions.hpp
+++ b/src/hamiltonian/check_wave_functions.hpp
@@ -31,7 +31,7 @@
 namespace sirius {
 
 template <typename T, typename F>
-void check_wave_functions(Hamiltonian_k<real_type<T>>& Hk__, wf::Wave_functions<T>& psi__, wf::spin_range sr__,
+void check_wave_functions(Hamiltonian_k<real_type<T>> const& Hk__, wf::Wave_functions<T>& psi__, wf::spin_range sr__,
         wf::band_range br__, double* eval__)
 {
     wf::Wave_functions<T> hpsi(psi__.gkvec_sptr(), psi__.num_md(), wf::num_bands(br__.size()), sddk::memory_t::host);
@@ -71,4 +71,3 @@ void check_wave_functions(Hamiltonian_k<real_type<T>>& Hk__, wf::Wave_functions<
 }
 
 #endif
-

--- a/src/hamiltonian/diagonalize.hpp
+++ b/src/hamiltonian/diagonalize.hpp
@@ -69,20 +69,20 @@ diagonalize(Hamiltonian0<T> const& H0__, K_point_set& kset__, double itsol_tol__
 
         auto Hk = H0__(*kp);
         if (ctx.full_potential()) {
-            diagonalize_fp<T>(Hk, itsol_tol__);
+            diagonalize_fp<T>(Hk, *kp, itsol_tol__);
         } else {
             if (itso.type() == "exact") {
                 if (ctx.gamma_point() || ctx.num_mag_dims() == 3) {
                     RTE_THROW("not implemented");
                 }
                 for (int ispn = 0; ispn < ctx.num_spins(); ispn++) {
-                    diagonalize_pp_exact<T, std::complex<F>>(ispn, Hk);
+                    diagonalize_pp_exact<T, std::complex<F>>(ispn, Hk, *kp);
                 }
             } else {
                 if (ctx.gamma_point() && (ctx.so_correction() == false)) {
-                    result.davidson_result = diagonalize_pp<T, F>(Hk, itsol_tol__, empy_tol);
+                    result.davidson_result = diagonalize_pp<T, F>(Hk, *kp, itsol_tol__, empy_tol);
                 } else {
-                    result.davidson_result = diagonalize_pp<T, std::complex<F>>(Hk, itsol_tol__, empy_tol);
+                    result.davidson_result = diagonalize_pp<T, std::complex<F>>(Hk, *kp, itsol_tol__, empy_tol);
                 }
                 num_dav_iter += result.davidson_result.niter;
                 converged = converged & result.davidson_result.converged;

--- a/src/hamiltonian/diagonalize.hpp
+++ b/src/hamiltonian/diagonalize.hpp
@@ -43,7 +43,7 @@ struct diagonalize_result_t {
  */
 template <typename T, typename F>
 inline auto
-diagonalize(Hamiltonian0<T>& H0__, K_point_set& kset__, double itsol_tol__) 
+diagonalize(Hamiltonian0<T> const& H0__, K_point_set& kset__, double itsol_tol__)
 {
     PROFILE("sirius::diagonalize");
 

--- a/src/hamiltonian/diagonalize.hpp
+++ b/src/hamiltonian/diagonalize.hpp
@@ -27,6 +27,7 @@
 
 #include "diagonalize_fp.hpp"
 #include "diagonalize_pp.hpp"
+#include "k_point/k_point_set.hpp"
 
 namespace sirius {
 
@@ -127,4 +128,3 @@ diagonalize(Hamiltonian0<T>& H0__, K_point_set& kset__, double itsol_tol__)
 }
 
 #endif
-

--- a/src/hamiltonian/diagonalize_fp.hpp
+++ b/src/hamiltonian/diagonalize_fp.hpp
@@ -26,6 +26,7 @@
 #define __DIAGONALIZE_FP_HPP__
 
 #include "davidson.hpp"
+#include "k_point/k_point.hpp"
 
 namespace sirius {
 

--- a/src/hamiltonian/diagonalize_fp.hpp
+++ b/src/hamiltonian/diagonalize_fp.hpp
@@ -31,23 +31,22 @@
 namespace sirius {
 
 inline void
-diagonalize_fp_fv_exact(Hamiltonian_k<float>& Hk__)
+diagonalize_fp_fv_exact(Hamiltonian_k<float> const&, K_point<float>&)
 {
     RTE_THROW("not implemented");
 }
 
 inline void
-diagonalize_fp_fv_exact(Hamiltonian_k<double>& Hk__)
+diagonalize_fp_fv_exact(Hamiltonian_k<double> const& Hk__, K_point<double>& kp__)
 {
     PROFILE("sirius::diagonalize_fp_fv_exact");
 
-    auto& kp = Hk__.kp();
     auto& ctx = Hk__.H0().ctx();
 
     auto& solver = ctx.gen_evp_solver();
 
     /* total eigen-value problem size */
-    int ngklo = kp.gklo_basis_size();
+    int ngklo = kp__.gklo_basis_size();
 
     /* block size of scalapack 2d block-cyclic distribution */
     int bs = ctx.cyclic_block_size();
@@ -64,7 +63,7 @@ diagonalize_fp_fv_exact(Hamiltonian_k<double>& Hk__)
         auto& mpd = get_memory_pool(sddk::memory_t::device);
         h.allocate(mpd);
         o.allocate(mpd);
-        kp.fv_eigen_vectors().allocate(mpd);
+        kp__.fv_eigen_vectors().allocate(mpd);
     }
 
     if (ctx.cfg().control().verification() >= 1) {
@@ -91,12 +90,12 @@ diagonalize_fp_fv_exact(Hamiltonian_k<double>& Hk__)
         utils::print_checksum("o_lapw", z2, ctx.out());
     }
 
-    RTE_ASSERT(kp.gklo_basis_size() > ctx.num_fv_states());
+    RTE_ASSERT(kp__.gklo_basis_size() > ctx.num_fv_states());
 
     std::vector<double> eval(ctx.num_fv_states());
 
     print_memory_usage(ctx.out(), FILE_LINE);
-    if (solver.solve(kp.gklo_basis_size(), ctx.num_fv_states(), h, o, eval.data(), kp.fv_eigen_vectors())) {
+    if (solver.solve(kp__.gklo_basis_size(), ctx.num_fv_states(), h, o, eval.data(), kp__.fv_eigen_vectors())) {
         RTE_THROW("error in generalized eigen-value problem");
     }
     print_memory_usage(ctx.out(), FILE_LINE);
@@ -104,43 +103,43 @@ diagonalize_fp_fv_exact(Hamiltonian_k<double>& Hk__)
     if (ctx.gen_evp_solver().type() == la::ev_solver_t::cusolver) {
         h.deallocate(sddk::memory_t::device);
         o.deallocate(sddk::memory_t::device);
-        kp.fv_eigen_vectors().deallocate(sddk::memory_t::device);
+        kp__.fv_eigen_vectors().deallocate(sddk::memory_t::device);
     }
-    kp.set_fv_eigen_values(&eval[0]);
+    kp__.set_fv_eigen_values(&eval[0]);
 
     {
-        rte::ostream out(kp.out(4), std::string(__func__));
+        rte::ostream out(kp__.out(4), std::string(__func__));
         for (int i = 0; i < ctx.num_fv_states(); i++) {
             out << "eval[" << i << "]=" << eval[i] << std::endl;
         }
     }
 
     if (pcs) {
-        auto z1 = kp.fv_eigen_vectors().checksum(kp.gklo_basis_size(), ctx.num_fv_states());
-        utils::print_checksum("fv_eigen_vectors", z1, kp.out(1));
+        auto z1 = kp__.fv_eigen_vectors().checksum(kp__.gklo_basis_size(), ctx.num_fv_states());
+        utils::print_checksum("fv_eigen_vectors", z1, kp__.out(1));
     }
 
     /* remap to slab */
     {
         /* G+k vector part */
-        auto layout_in = kp.fv_eigen_vectors().grid_layout(0, 0, kp.gkvec().num_gvec(), ctx.num_fv_states());
-        auto layout_out = kp.fv_eigen_vectors_slab().grid_layout_pw(wf::spin_index(0), wf::band_range(0, ctx.num_fv_states()));
+        auto layout_in = kp__.fv_eigen_vectors().grid_layout(0, 0, kp__.gkvec().num_gvec(), ctx.num_fv_states());
+        auto layout_out = kp__.fv_eigen_vectors_slab().grid_layout_pw(wf::spin_index(0), wf::band_range(0, ctx.num_fv_states()));
         costa::transform(layout_in, layout_out, 'N', la::constant<std::complex<double>>::one(),
-            la::constant<std::complex<double>>::zero(), kp.comm().native());
+            la::constant<std::complex<double>>::zero(), kp__.comm().native());
     }
     {
         /* muffin-tin part */
-        auto layout_in = kp.fv_eigen_vectors().grid_layout(kp.gkvec().num_gvec(), 0,
+        auto layout_in = kp__.fv_eigen_vectors().grid_layout(kp__.gkvec().num_gvec(), 0,
                 ctx.unit_cell().mt_lo_basis_size(), ctx.num_fv_states());
-        auto layout_out = kp.fv_eigen_vectors_slab().grid_layout_mt(wf::spin_index(0), wf::band_range(0, ctx.num_fv_states()));
+        auto layout_out = kp__.fv_eigen_vectors_slab().grid_layout_mt(wf::spin_index(0), wf::band_range(0, ctx.num_fv_states()));
         costa::transform(layout_in, layout_out, 'N', la::constant<std::complex<double>>::one(),
-            la::constant<std::complex<double>>::zero(), kp.comm().native());
+            la::constant<std::complex<double>>::zero(), kp__.comm().native());
     }
 
     if (pcs) {
-        auto z1 = kp.fv_eigen_vectors_slab().checksum_pw(sddk::memory_t::host, wf::spin_index(0), wf::band_range(0, ctx.num_fv_states()));
-        auto z2 = kp.fv_eigen_vectors_slab().checksum_mt(sddk::memory_t::host, wf::spin_index(0), wf::band_range(0, ctx.num_fv_states()));
-        utils::print_checksum("fv_eigen_vectors_slab", z1 + z2, kp.out(1));
+        auto z1 = kp__.fv_eigen_vectors_slab().checksum_pw(sddk::memory_t::host, wf::spin_index(0), wf::band_range(0, ctx.num_fv_states()));
+        auto z2 = kp__.fv_eigen_vectors_slab().checksum_mt(sddk::memory_t::host, wf::spin_index(0), wf::band_range(0, ctx.num_fv_states()));
+        utils::print_checksum("fv_eigen_vectors_slab", z1 + z2, kp__.out(1));
     }
 
     /* renormalize wave-functions */
@@ -150,19 +149,19 @@ diagonalize_fp_fv_exact(Hamiltonian_k<double>& Hk__)
         for (int ia = 0; ia < ctx.unit_cell().num_atoms(); ia++) {
             num_mt_coeffs[ia] = ctx.unit_cell().atom(ia).mt_lo_basis_size();
         }
-        wf::Wave_functions<double> ofv_new(kp.gkvec_sptr(), num_mt_coeffs, wf::num_mag_dims(0),
+        wf::Wave_functions<double> ofv_new(kp__.gkvec_sptr(), num_mt_coeffs, wf::num_mag_dims(0),
                 wf::num_bands(ctx.num_fv_states()), sddk::memory_t::host);
 
         {
             auto mem = ctx.processing_unit() == sddk::device_t::CPU ? sddk::memory_t::host : sddk::memory_t::device;
-            auto mg1 = kp.fv_eigen_vectors_slab().memory_guard(mem, wf::copy_to::device);
+            auto mg1 = kp__.fv_eigen_vectors_slab().memory_guard(mem, wf::copy_to::device);
             auto mg2 = ofv_new.memory_guard(mem, wf::copy_to::host);
 
-            Hk__.apply_fv_h_o(false, false, wf::band_range(0, ctx.num_fv_states()), kp.fv_eigen_vectors_slab(),
+            Hk__.apply_fv_h_o(false, false, wf::band_range(0, ctx.num_fv_states()), kp__.fv_eigen_vectors_slab(),
                     nullptr, &ofv_new);
         }
 
-        auto norm1 = wf::inner_diag<double, std::complex<double>>(sddk::memory_t::host, kp.fv_eigen_vectors_slab(),
+        auto norm1 = wf::inner_diag<double, std::complex<double>>(sddk::memory_t::host, kp__.fv_eigen_vectors_slab(),
                 ofv_new, wf::spin_range(0), wf::num_bands(ctx.num_fv_states()));
 
         std::vector<double> norm;
@@ -171,7 +170,7 @@ diagonalize_fp_fv_exact(Hamiltonian_k<double>& Hk__)
         }
 
         wf::axpby<double, double>(sddk::memory_t::host, wf::spin_range(0), wf::band_range(0, ctx.num_fv_states()),
-                nullptr, nullptr, norm.data(), &kp.fv_eigen_vectors_slab());
+                nullptr, nullptr, norm.data(), &kp__.fv_eigen_vectors_slab());
     }
 
     //if (ctx.cfg().control().verification() >= 2) {
@@ -242,66 +241,64 @@ diagonalize_fp_fv_exact(Hamiltonian_k<double>& Hk__)
 }
 
 inline void
-get_singular_components(Hamiltonian_k<double>& Hk__, double itsol_tol__)
+get_singular_components(Hamiltonian_k<double> const& Hk__, K_point<double>& kp__, double itsol_tol__)
 {
     PROFILE("sirius::get_singular_components");
 
-    auto& kp = Hk__.kp();
     auto& ctx = Hk__.H0().ctx();
 
-    int ncomp = kp.singular_components().num_wf().get();
+    int ncomp = kp__.singular_components().num_wf().get();
 
     RTE_OUT(ctx.out(3)) << "number of singular components: " << ncomp << std::endl;
 
     auto& itso = ctx.cfg().iterative_solver();
 
     std::stringstream s;
-    std::ostream* out = (kp.comm().rank() == 0) ? &std::cout : &s;
+    std::ostream* out = (kp__.comm().rank() == 0) ? &std::cout : &s;
 
-    auto result = davidson<double, std::complex<double>, davidson_evp_t::overlap>(Hk__, wf::num_bands(ncomp), wf::num_mag_dims(0),
-            kp.singular_components(),
+    auto result = davidson<double, std::complex<double>, davidson_evp_t::overlap>(Hk__, kp__, wf::num_bands(ncomp), wf::num_mag_dims(0),
+                                                                                  kp__.singular_components(),
             [&](int i, int ispn){ return itsol_tol__; }, itso.residual_tolerance(), itso.num_steps(), itso.locking(),
             itso.subspace_size(), itso.converge_by_energy(), itso.extra_ortho(), *out, ctx.verbosity() - 2);
 
-    RTE_OUT(kp.out(2)) << "smallest eigen-value of the singular components: " << result.eval[0] << std::endl;
+    RTE_OUT(kp__.out(2)) << "smallest eigen-value of the singular components: " << result.eval[0] << std::endl;
     for (int i = 0; i < ncomp; i++) {
-        RTE_OUT(kp.out(3)) << "singular component eigen-value[" << i << "]=" << result.eval[i] << std::endl;
+        RTE_OUT(kp__.out(3)) << "singular component eigen-value[" << i << "]=" << result.eval[i] << std::endl;
     }
 }
 
 inline void
-diagonalize_fp_fv_davidson(Hamiltonian_k<float>& Hk__, double itsol_tol__)
+diagonalize_fp_fv_davidson(Hamiltonian_k<float> const&, K_point<float>&, double)
 {
     RTE_THROW("not implemented");
 }
 
 inline void
-diagonalize_fp_fv_davidson(Hamiltonian_k<double>& Hk__, double itsol_tol__)
+diagonalize_fp_fv_davidson(Hamiltonian_k<double> const& Hk__, K_point<double>& kp__, double itsol_tol__)
 {
     PROFILE("sirius::diagonalize_fp_fv_davidson");
 
-    auto& kp = Hk__.kp();
     auto& ctx = Hk__.H0().ctx();
 
     auto& itso = ctx.cfg().iterative_solver();
 
     /* number of singular components */
-    int ncomp = kp.singular_components().num_wf().get();
+    int ncomp = kp__.singular_components().num_wf().get();
 
     if (ncomp) {
         /* compute eigen-vectors of O^{APW-APW} */
-        get_singular_components(Hk__, itsol_tol__);
+        get_singular_components(Hk__, kp__, itsol_tol__);
     }
 
     /* total number of local orbitals */
     int nlo = ctx.unit_cell().mt_lo_basis_size();
 
-    auto phi_extra_new = wave_function_factory(ctx, kp, wf::num_bands(nlo + ncomp), wf::num_mag_dims(0), true);
+    auto phi_extra_new = wave_function_factory(ctx, kp__, wf::num_bands(nlo + ncomp), wf::num_mag_dims(0), true);
     phi_extra_new->zero(sddk::memory_t::host, wf::spin_index(0), wf::band_range(0, nlo + ncomp));
 
     if (ncomp) {
         /* copy [0, ncomp) from kp.singular_components() to [0, ncomp) in phi_extra */
-        wf::copy(sddk::memory_t::host, kp.singular_components(), wf::spin_index(0), wf::band_range(0, ncomp),
+        wf::copy(sddk::memory_t::host, kp__.singular_components(), wf::spin_index(0), wf::band_range(0, ncomp),
                 *phi_extra_new, wf::spin_index(0), wf::band_range(0, ncomp));
     }
 
@@ -325,7 +322,7 @@ diagonalize_fp_fv_davidson(Hamiltonian_k<double>& Hk__, double itsol_tol__)
     }
     if (env::print_checksum()) {
         auto cs = phi_extra_new->checksum(sddk::memory_t::host, wf::band_range(0, nlo + ncomp));
-        if (kp.comm().rank() == 0) {
+        if (kp__.comm().rank() == 0) {
             utils::print_checksum("phi_extra", cs, RTE_OUT(ctx.out()));
         }
     }
@@ -335,30 +332,30 @@ diagonalize_fp_fv_davidson(Hamiltonian_k<double>& Hk__, double itsol_tol__)
     };
 
     std::stringstream s;
-    std::ostream* out = (kp.comm().rank() == 0) ? &std::cout : &s;
+    std::ostream* out = (kp__.comm().rank() == 0) ? &std::cout : &s;
 
-    auto result = davidson<double, std::complex<double>, davidson_evp_t::hamiltonian>(Hk__,
-            wf::num_bands(ctx.num_fv_states()), wf::num_mag_dims(0), kp.fv_eigen_vectors_slab(), tolerance,
+    auto result = davidson<double, std::complex<double>, davidson_evp_t::hamiltonian>(Hk__, kp__,
+            wf::num_bands(ctx.num_fv_states()), wf::num_mag_dims(0), kp__.fv_eigen_vectors_slab(), tolerance,
             itso.residual_tolerance(), itso.num_steps(), itso.locking(), itso.subspace_size(),
             itso.converge_by_energy(), itso.extra_ortho(), *out, ctx.verbosity() - 2,
             phi_extra_new.get());
 
-    kp.set_fv_eigen_values(&result.eval[0]);
+    kp__.set_fv_eigen_values(&result.eval[0]);
 }
 
 inline void
-diagonalize_fp_sv(Hamiltonian_k<float>& Hk__)
+diagonalize_fp_sv(Hamiltonian_k<float> const&, K_point<float>&)
 {
     RTE_THROW("not implemented");
 }
 
 /// Diagonalize second-variational Hamiltonian.
 inline void
-diagonalize_fp_sv(Hamiltonian_k<double>& Hk__)
+diagonalize_fp_sv(Hamiltonian_k<double> const& Hk__, K_point<double>& kp)
 {
     PROFILE("sirius::diagonalize_fp_sv");
 
-    auto& kp = Hk__.kp();
+    // auto& kp = Hk__.kp();
     auto& ctx = Hk__.H0().ctx();
 
     if (!ctx.need_sv()) {
@@ -381,7 +378,7 @@ diagonalize_fp_sv(Hamiltonian_k<double>& Hk__)
     /* product of the second-variational Hamiltonian and a first-variational wave-function */
     std::vector<wf::Wave_functions<double>> hpsi;
     for (int i = 0; i < ctx.num_mag_comp(); i++) {
-        hpsi.push_back(wf::Wave_functions<double>(kp.gkvec_sptr(), num_mt_coeffs, 
+        hpsi.push_back(wf::Wave_functions<double>(kp.gkvec_sptr(), num_mt_coeffs,
                     wf::num_mag_dims(0), wf::num_bands(nfv), ctx.host_memory_t()));
     }
 
@@ -502,7 +499,7 @@ diagonalize_fp_sv(Hamiltonian_k<double>& Hk__)
 /// Diagonalize a full-potential LAPW Hamiltonian.
 template <typename T>
 inline void
-diagonalize_fp(Hamiltonian_k<T>& Hk__, double itsol_tol__)
+diagonalize_fp(Hamiltonian_k<T> const& Hk__, K_point<T>& kp__, double itsol_tol__)
 {
     auto& ctx = Hk__.H0().ctx();
     print_memory_usage(ctx.out(), FILE_LINE);
@@ -510,16 +507,16 @@ diagonalize_fp(Hamiltonian_k<T>& Hk__, double itsol_tol__)
         /* solve non-magnetic Hamiltonian (so-called first variation) */
         auto& itso = ctx.cfg().iterative_solver();
         if (itso.type() == "exact") {
-            diagonalize_fp_fv_exact(Hk__);
+            diagonalize_fp_fv_exact(Hk__, kp__);
         } else if (itso.type() == "davidson") {
-            diagonalize_fp_fv_davidson(Hk__, itsol_tol__);
+            diagonalize_fp_fv_davidson(Hk__, kp__, itsol_tol__);
         }
         /* generate first-variational states */
-        Hk__.kp().generate_fv_states();
+        kp__.generate_fv_states();
         /* solve magnetic Hamiltonian */
-        diagonalize_fp_sv(Hk__);
+        diagonalize_fp_sv(Hk__, kp__);
         /* generate spinor wave-functions */
-        Hk__.kp().generate_spinor_wave_functions();
+        kp__.generate_spinor_wave_functions();
     } else {
         RTE_THROW("not implemented");
         //diag_full_potential_single_variation();

--- a/src/hamiltonian/diagonalize_pp.hpp
+++ b/src/hamiltonian/diagonalize_pp.hpp
@@ -26,6 +26,7 @@
 
 #include "davidson.hpp"
 #include "check_wave_functions.hpp"
+#include "k_point/k_point.hpp"
 
 namespace sirius {
 

--- a/src/hamiltonian/diagonalize_pp.hpp
+++ b/src/hamiltonian/diagonalize_pp.hpp
@@ -32,18 +32,17 @@ namespace sirius {
 
 template <typename T, typename F>
 inline std::enable_if_t<!std::is_same<T, real_type<F>>::value, void>
-diagonalize_pp_exact(int ispn__, Hamiltonian_k<T>& Hk__)
+diagonalize_pp_exact(int ispn__, Hamiltonian_k<T> const& Hk__, K_point<T>& kp)
 {
     RTE_THROW("not implemented");
 }
 
 template <typename T, typename F>
 inline std::enable_if_t<std::is_same<T, real_type<F>>::value, void>
-diagonalize_pp_exact(int ispn__, Hamiltonian_k<T>& Hk__)
+diagonalize_pp_exact(int ispn__, Hamiltonian_k<T> const& Hk__, K_point<T>& kp__)
 {
     PROFILE("sirius::diagonalize_pp_exact");
 
-    auto& kp = Hk__.kp();
     auto& ctx = Hk__.H0().ctx();
 
     if (ctx.gamma_point()) {
@@ -51,18 +50,19 @@ diagonalize_pp_exact(int ispn__, Hamiltonian_k<T>& Hk__)
     }
 
     const int bs = ctx.cyclic_block_size();
-    la::dmatrix<F> hmlt(kp.num_gkvec(), kp.num_gkvec(), ctx.blacs_grid(), bs, bs);
-    la::dmatrix<F> ovlp(kp.num_gkvec(), kp.num_gkvec(), ctx.blacs_grid(), bs, bs);
-    la::dmatrix<F> evec(kp.num_gkvec(), kp.num_gkvec(), ctx.blacs_grid(), bs, bs);
-    std::vector<real_type<F>> eval(kp.num_gkvec());
+    la::dmatrix<F> hmlt(kp__.num_gkvec(), kp__.num_gkvec(), ctx.blacs_grid(), bs, bs);
+    la::dmatrix<F> ovlp(kp__.num_gkvec(), kp__.num_gkvec(), ctx.blacs_grid(), bs, bs);
+    la::dmatrix<F> evec(kp__.num_gkvec(), kp__.num_gkvec(), ctx.blacs_grid(), bs, bs);
+    std::vector<real_type<F>> eval(kp__.num_gkvec());
 
     hmlt.zero();
     ovlp.zero();
 
     auto& gen_solver = ctx.gen_evp_solver();
 
-    for (int ig = 0; ig < kp.num_gkvec(); ig++) {
-        hmlt.set(ig, ig, 0.5 * std::pow(kp.gkvec().template gkvec_cart<sddk::index_domain_t::global>(ig).length(), 2));
+    for (int ig = 0; ig < kp__.num_gkvec(); ig++) {
+        hmlt.set(ig, ig,
+                 0.5 * std::pow(kp__.gkvec().template gkvec_cart<sddk::index_domain_t::global>(ig).length(), 2));
         ovlp.set(ig, ig, 1);
     }
 
@@ -71,19 +71,19 @@ diagonalize_pp_exact(int ispn__, Hamiltonian_k<T>& Hk__)
     if (ctx.num_mag_dims() == 1) {
         beff = Hk__.H0().potential().effective_magnetic_field(0).rg().gather_f_pw();
         for (int ig = 0; ig < ctx.gvec().num_gvec(); ig++) {
-            auto z1 = veff[ig];
-            auto z2 = beff[ig];
+            auto z1  = veff[ig];
+            auto z2  = beff[ig];
             veff[ig] = z1 + z2;
             beff[ig] = z1 - z2;
         }
     }
 
     #pragma omp parallel for schedule(static)
-    for (int igk_col = 0; igk_col < kp.num_gkvec_col(); igk_col++) {
-        auto gvec_col = kp.gkvec_col().template gvec<sddk::index_domain_t::local>(igk_col);
-        for (int igk_row = 0; igk_row < kp.num_gkvec_row(); igk_row++) {
-            auto gvec_row = kp.gkvec_row().template gvec<sddk::index_domain_t::local>(igk_row);
-            auto ig12 = ctx.gvec().index_g12_safe(gvec_row, gvec_col);
+    for (int igk_col = 0; igk_col < kp__.num_gkvec_col(); igk_col++) {
+        auto gvec_col = kp__.gkvec_col().template gvec<sddk::index_domain_t::local>(igk_col);
+        for (int igk_row = 0; igk_row < kp__.num_gkvec_row(); igk_row++) {
+            auto gvec_row = kp__.gkvec_row().template gvec<sddk::index_domain_t::local>(igk_row);
+            auto ig12     = ctx.gvec().index_g12_safe(gvec_row, gvec_col);
 
             if (ispn__ == 0) {
                 if (ig12.second) {
@@ -107,15 +107,15 @@ diagonalize_pp_exact(int ispn__, Hamiltonian_k<T>& Hk__)
     sddk::mdarray<F, 2> dop(ctx.unit_cell().max_mt_basis_size(), ctx.unit_cell().max_mt_basis_size());
     sddk::mdarray<F, 2> qop(ctx.unit_cell().max_mt_basis_size(), ctx.unit_cell().max_mt_basis_size());
 
-    sddk::mdarray<F, 2> btmp(kp.num_gkvec_row(), ctx.unit_cell().max_mt_basis_size());
+    sddk::mdarray<F, 2> btmp(kp__.num_gkvec_row(), ctx.unit_cell().max_mt_basis_size());
 
-    auto bp_gen_row        = kp.beta_projectors_row().make_generator();
+    auto bp_gen_row    = kp__.beta_projectors_row().make_generator();
     auto bp_coeffs_row = bp_gen_row.prepare();
 
-    auto bp_gen_col = kp.beta_projectors_col().make_generator();
+    auto bp_gen_col    = kp__.beta_projectors_col().make_generator();
     auto bp_coeffs_col = bp_gen_col.prepare();
 
-    for (int ichunk = 0; ichunk <  kp.beta_projectors_row().num_chunks(); ichunk++) {
+    for (int ichunk = 0; ichunk < kp__.beta_projectors_row().num_chunks(); ichunk++) {
         /* generate beta-projectors for a block of atoms */
 
         bp_gen_row.generate(bp_coeffs_row, ichunk);
@@ -124,7 +124,7 @@ diagonalize_pp_exact(int ispn__, Hamiltonian_k<T>& Hk__)
         auto& beta_row = bp_coeffs_row.pw_coeffs_a_;
         auto& beta_col = bp_coeffs_col.pw_coeffs_a_;
 
-        for (int i = 0; i <  bp_coeffs_row.beta_chunk_.num_atoms_; i++) {
+        for (int i = 0; i < bp_coeffs_row.beta_chunk_.num_atoms_; i++) {
             /* number of beta functions for a given atom */
             int nbf  = bp_coeffs_row.beta_chunk_.desc_(beta_desc_idx::nbf, i);
             int offs = bp_coeffs_row.beta_chunk_.desc_(beta_desc_idx::offset, i);
@@ -137,21 +137,22 @@ diagonalize_pp_exact(int ispn__, Hamiltonian_k<T>& Hk__)
                 }
             }
             /* compute <G+k|beta> D */
-            la::wrap(la::lib_t::blas).gemm('N', 'N', kp.num_gkvec_row(), nbf, nbf,
-                &la::constant<F>::one(), &beta_row(0, offs), beta_row.ld(), &dop(0, 0), dop.ld(),
-                &la::constant<F>::zero(), &btmp(0, 0), btmp.ld());
+            la::wrap(la::lib_t::blas)
+                .gemm('N', 'N', kp__.num_gkvec_row(), nbf, nbf, &la::constant<F>::one(), &beta_row(0, offs),
+                      beta_row.ld(), &dop(0, 0), dop.ld(), &la::constant<F>::zero(), &btmp(0, 0), btmp.ld());
             /* compute (<G+k|beta> D ) <beta|G+k> */
-            la::wrap(la::lib_t::blas).gemm('N', 'C', kp.num_gkvec_row(), kp.num_gkvec_col(), nbf,
-                &la::constant<F>::one(), &btmp(0, 0), btmp.ld(), &beta_col(0, offs), beta_col.ld(),
-                &la::constant<F>::one(), &hmlt(0, 0), hmlt.ld());
+            la::wrap(la::lib_t::blas)
+                .gemm('N', 'C', kp__.num_gkvec_row(), kp__.num_gkvec_col(), nbf, &la::constant<F>::one(), &btmp(0, 0),
+                      btmp.ld(), &beta_col(0, offs), beta_col.ld(), &la::constant<F>::one(), &hmlt(0, 0), hmlt.ld());
             /* update the overlap matrix */
             if (ctx.unit_cell().atom(ia).type().augment()) {
-                la::wrap(la::lib_t::blas).gemm('N', 'N', kp.num_gkvec_row(), nbf, nbf,
-                    &la::constant<F>::one(), &beta_row(0, offs), beta_row.ld(), &qop(0, 0), qop.ld(),
-                    &la::constant<F>::zero(), &btmp(0, 0), btmp.ld());
-                la::wrap(la::lib_t::blas).gemm('N', 'C', kp.num_gkvec_row(), kp.num_gkvec_col(), nbf,
-                    &la::constant<F>::one(), &btmp(0, 0), btmp.ld(), &beta_col(0, offs), beta_col.ld(),
-                    &la::constant<F>::one(), &ovlp(0, 0), ovlp.ld());
+                la::wrap(la::lib_t::blas)
+                    .gemm('N', 'N', kp__.num_gkvec_row(), nbf, nbf, &la::constant<F>::one(), &beta_row(0, offs),
+                          beta_row.ld(), &qop(0, 0), qop.ld(), &la::constant<F>::zero(), &btmp(0, 0), btmp.ld());
+                la::wrap(la::lib_t::blas)
+                    .gemm('N', 'C', kp__.num_gkvec_row(), kp__.num_gkvec_col(), nbf, &la::constant<F>::one(),
+                          &btmp(0, 0), btmp.ld(), &beta_col(0, offs), beta_col.ld(), &la::constant<F>::one(),
+                          &ovlp(0, 0), ovlp.ld());
             }
         } // i (atoms in chunk)
     }
@@ -159,13 +160,13 @@ diagonalize_pp_exact(int ispn__, Hamiltonian_k<T>& Hk__)
     // kp.beta_projectors_col().dismiss();
 
     if (ctx.cfg().control().verification() >= 1) {
-        double max_diff = check_hermitian(ovlp, kp.num_gkvec());
+        double max_diff = check_hermitian(ovlp, kp__.num_gkvec());
         if (max_diff > 1e-12) {
             std::stringstream s;
             s << "overlap matrix is not hermitian, max_err = " << max_diff;
             RTE_THROW(s);
         }
-        max_diff = check_hermitian(hmlt, kp.num_gkvec());
+        max_diff = check_hermitian(hmlt, kp__.num_gkvec());
         if (max_diff > 1e-12) {
             std::stringstream s;
             s << "Hamiltonian matrix is not hermitian, max_err = " << max_diff;
@@ -175,51 +176,51 @@ diagonalize_pp_exact(int ispn__, Hamiltonian_k<T>& Hk__)
     if (ctx.cfg().control().verification() >= 2) {
         RTE_OUT(ctx.out()) << "checking eigen-values of S-matrix\n";
 
-        la::dmatrix<F> ovlp1(kp.num_gkvec(), kp.num_gkvec(), ctx.blacs_grid(), bs, bs);
-        la::dmatrix<F> evec(kp.num_gkvec(), kp.num_gkvec(), ctx.blacs_grid(), bs, bs);
+        la::dmatrix<F> ovlp1(kp__.num_gkvec(), kp__.num_gkvec(), ctx.blacs_grid(), bs, bs);
+        la::dmatrix<F> evec(kp__.num_gkvec(), kp__.num_gkvec(), ctx.blacs_grid(), bs, bs);
 
         sddk::copy(ovlp, ovlp1);
 
-        std::vector<real_type<F>> eo(kp.num_gkvec());
+        std::vector<real_type<F>> eo(kp__.num_gkvec());
 
         auto solver = la::Eigensolver_factory("scalapack");
-        solver->solve(kp.num_gkvec(), ovlp1, eo.data(), evec);
+        solver->solve(kp__.num_gkvec(), ovlp1, eo.data(), evec);
 
-        for (int i = 0; i < kp.num_gkvec(); i++) {
+        for (int i = 0; i < kp__.num_gkvec(); i++) {
             if (eo[i] < 1e-6) {
                 RTE_OUT(ctx.out()) << "small eigen-value: " << eo[i] << std::endl;
             }
         }
     }
 
-    if (gen_solver.solve(kp.num_gkvec(), ctx.num_bands(), hmlt, ovlp, eval.data(), evec)) {
+    if (gen_solver.solve(kp__.num_gkvec(), ctx.num_bands(), hmlt, ovlp, eval.data(), evec)) {
         std::stringstream s;
         s << "error in full diagonalization";
         RTE_THROW(s);
     }
 
     for (int j = 0; j < ctx.num_bands(); j++) {
-        kp.band_energy(j, ispn__, eval[j]);
+        kp__.band_energy(j, ispn__, eval[j]);
     }
 
-    auto layout_in  = evec.grid_layout(0, 0, kp.num_gkvec(), ctx.num_bands());
-    auto layout_out = kp.spinor_wave_functions().grid_layout_pw(wf::spin_index(ispn__), wf::band_range(0, ctx.num_bands()));
+    auto layout_in = evec.grid_layout(0, 0, kp__.num_gkvec(), ctx.num_bands());
+    auto layout_out =
+        kp__.spinor_wave_functions().grid_layout_pw(wf::spin_index(ispn__), wf::band_range(0, ctx.num_bands()));
 
     costa::transform(layout_in, layout_out, 'N', la::constant<std::complex<T>>::one(),
-            la::constant<std::complex<T>>::zero(), kp.gkvec().comm().native());
+                     la::constant<std::complex<T>>::zero(), kp__.gkvec().comm().native());
 }
 
 /// Diagonalize S-operator of the ultrasoft or PAW methods.
 /** Sometimes this is needed to check the quality of pseudopotential. */
 template <typename T, typename F>
 inline sddk::mdarray<real_type<F>, 1>
-diag_S_davidson(Hamiltonian_k<T>& Hk__)
+diag_S_davidson(Hamiltonian_k<T> const& Hk__, K_point<T>& kp__)
 {
     PROFILE("sirius::diag_S_davidson");
 
     RTE_THROW("implement this");
 
-    auto& kp = Hk__.kp();
     auto& ctx = Hk__.H0().ctx();
 
     auto& itso = ctx.cfg().iterative_solver();
@@ -237,14 +238,14 @@ diag_S_davidson(Hamiltonian_k<T>& Hk__)
     const int nevec{1};
 
     /* eigen-vectors */
-    auto psi = wave_function_factory(ctx, kp, wf::num_bands(nevec), num_mag_dims, false);
+    auto psi = wave_function_factory(ctx, kp__, wf::num_bands(nevec), num_mag_dims, false);
     for (int i = 0; i < nevec; i++) {
         auto ib = wf::band_index(i);
         for (int ispn = 0; ispn < num_sc; ispn++) {
             auto s = wf::spin_index(ispn);
-            for (int igk_loc = 0; igk_loc < kp.num_gkvec_loc(); igk_loc++) {
+            for (int igk_loc = 0; igk_loc < kp__.num_gkvec_loc(); igk_loc++) {
                 /* global index of G+k vector */
-                int igk = kp.gkvec().offset() + igk_loc;
+                int igk = kp__.gkvec().offset() + igk_loc;
                 if (igk == i + 1) {
                     psi->pw_coeffs(igk_loc, s, ib) = 1.0;
                 }
@@ -267,17 +268,18 @@ diag_S_davidson(Hamiltonian_k<T>& Hk__)
     #pragma omp parallel for schedule(static)
     for (int i = 0; i < nevec; i++) {
         for (int ispn = 0; ispn < num_sc; ispn++) {
-            for (int igk_loc = kp.gkvec().skip_g0(); igk_loc < kp.num_gkvec_loc(); igk_loc++) {
+            for (int igk_loc = kp__.gkvec().skip_g0(); igk_loc < kp__.num_gkvec_loc(); igk_loc++) {
                 /* global index of G+k vector */
-                int igk = kp.gkvec().offset() + igk_loc;
+                int igk = kp__.gkvec().offset() + igk_loc;
                 psi->pw_coeffs(igk_loc, wf::spin_index(ispn), wf::band_index(i)) += tmp[igk & 0xFFF] * 1e-5;
             }
         }
     }
 
-    auto result = davidson<T, F, davidson_evp_t::overlap>(Hk__, wf::num_bands(nevec), num_mag_dims, *psi,
-            [](int i, int ispn){ return 1e-10; }, itso.residual_tolerance(), itso.num_steps(), itso.locking(),
-            10, itso.converge_by_energy(), itso.extra_ortho(), std::cout, 0);
+    auto result = davidson<T, F, davidson_evp_t::overlap>(
+        Hk__, kp__, wf::num_bands(nevec), num_mag_dims, *psi, [](int i, int ispn) { return 1e-10; },
+        itso.residual_tolerance(), itso.num_steps(), itso.locking(), 10, itso.converge_by_energy(), itso.extra_ortho(),
+        std::cout, 0);
 
     sddk::mdarray<real_type<F>, 1> eval(nevec);
     for (int i = 0; i < nevec; i++) {
@@ -289,7 +291,7 @@ diag_S_davidson(Hamiltonian_k<T>& Hk__)
 
 template <typename T, typename F>
 inline auto
-diagonalize_pp(Hamiltonian_k<T>& Hk__, double itsol_tol__, double empy_tol__)
+diagonalize_pp(Hamiltonian_k<T> const& Hk__, K_point<T>& kp__, double itsol_tol__, double empy_tol__)
 {
     auto& ctx = Hk__.H0().ctx();
     print_memory_usage(ctx.out(), FILE_LINE);
@@ -298,15 +300,12 @@ diagonalize_pp(Hamiltonian_k<T>& Hk__, double itsol_tol__, double empy_tol__)
 
     auto& itso = ctx.cfg().iterative_solver();
     if (itso.type() == "davidson") {
-        auto& kp = Hk__.kp();
-
         auto tolerance = [&](int j__, int ispn__) -> double {
-
             /* tolerance for occupied states */
             double tol = itsol_tol__;
             /* if band is empty, make tolerance larger (in most cases we don't need high precision on
              * unoccupied states) */
-            if (std::abs(kp.band_occupancy(j__, ispn__)) < ctx.min_occupancy() * ctx.max_occupancy()) {
+            if (std::abs(kp__.band_occupancy(j__, ispn__)) < ctx.min_occupancy() * ctx.max_occupancy()) {
                 tol += empy_tol__;
             }
 
@@ -314,15 +313,15 @@ diagonalize_pp(Hamiltonian_k<T>& Hk__, double itsol_tol__, double empy_tol__)
         };
 
         std::stringstream s;
-        std::ostream* out = (kp.comm().rank() == 0) ? &std::cout : &s;
+        std::ostream* out = (kp__.comm().rank() == 0) ? &std::cout : &s;
 
-        result = davidson<T, F, davidson_evp_t::hamiltonian>(Hk__, wf::num_bands(ctx.num_bands()),
-                wf::num_mag_dims(ctx.num_mag_dims()), kp.spinor_wave_functions(), tolerance,
-                itso.residual_tolerance(), itso.num_steps(), itso.locking(), itso.subspace_size(),
-                itso.converge_by_energy(), itso.extra_ortho(), *out, 0);
+        result = davidson<T, F, davidson_evp_t::hamiltonian>(
+            Hk__, kp__, wf::num_bands(ctx.num_bands()), wf::num_mag_dims(ctx.num_mag_dims()),
+            kp__.spinor_wave_functions(), tolerance, itso.residual_tolerance(), itso.num_steps(), itso.locking(),
+            itso.subspace_size(), itso.converge_by_energy(), itso.extra_ortho(), *out, 0);
         for (int ispn = 0; ispn < ctx.num_spinors(); ispn++) {
             for (int j = 0; j < ctx.num_bands(); j++) {
-                kp.band_energy(j, ispn, result.eval(j, ispn));
+                kp__.band_energy(j, ispn, result.eval(j, ispn));
             }
         }
     } else {
@@ -332,14 +331,14 @@ diagonalize_pp(Hamiltonian_k<T>& Hk__, double itsol_tol__, double empy_tol__)
     /* check wave-functions */
     if (ctx.cfg().control().verification() >= 2) {
         if (ctx.num_mag_dims() == 3) {
-            auto eval = Hk__.kp().band_energies(0);
-            check_wave_functions<T, F>(Hk__, Hk__.kp().spinor_wave_functions(), wf::spin_range(0, 2),
-                    wf::band_range(0, ctx.num_bands()), eval.data());
+            auto eval = kp__.band_energies(0);
+            check_wave_functions<T, F>(Hk__, kp__.spinor_wave_functions(), wf::spin_range(0, 2),
+                                       wf::band_range(0, ctx.num_bands()), eval.data());
         } else {
             for (int ispn = 0; ispn < ctx.num_spins(); ispn++) {
-                auto eval = Hk__.kp().band_energies(ispn);
-                check_wave_functions<T, F>(Hk__, Hk__.kp().spinor_wave_functions(), wf::spin_range(ispn),
-                        wf::band_range(0, ctx.num_bands()), eval.data());
+                auto eval = kp__.band_energies(ispn);
+                check_wave_functions<T, F>(Hk__, kp__.spinor_wave_functions(), wf::spin_range(ispn),
+                                           wf::band_range(0, ctx.num_bands()), eval.data());
             }
         }
     }
@@ -349,6 +348,6 @@ diagonalize_pp(Hamiltonian_k<T>& Hk__, double itsol_tol__, double empy_tol__)
     return result;
 }
 
-}
+} // namespace sirius
 
 #endif

--- a/src/hamiltonian/generate_subspace_matrix.hpp
+++ b/src/hamiltonian/generate_subspace_matrix.hpp
@@ -25,6 +25,9 @@
 #ifndef __GENERATE_SUBSPACE_MATRIX_HPP__
 #define __GENERATE_SUBSPACE_MATRIX_HPP__
 
+#include "context/simulation_context.hpp"
+#include "SDDK/wave_functions.hpp"
+
 namespace sirius {
 
 /// Generate subspace matrix for the iterative diagonalization.
@@ -143,4 +146,3 @@ void generate_subspace_matrix(Simulation_context& ctx__, int N__, int n__, int n
 }
 
 #endif
-

--- a/src/hamiltonian/hamiltonian.hpp
+++ b/src/hamiltonian/hamiltonian.hpp
@@ -109,7 +109,7 @@ class Hamiltonian0
     Hamiltonian0(Hamiltonian0<T>&& src) = default;
 
     /// Return a Hamiltonian for the given k-point.
-    inline Hamiltonian_k<T> operator()(K_point<T>& kp__);
+    inline Hamiltonian_k<T> operator()(K_point<T>& kp__) const;
 
     Simulation_context& ctx() const
     {
@@ -175,7 +175,7 @@ class Hamiltonian_k
 {
   private:
     /// K-point independent part of Hamiltonian.
-    Hamiltonian0<T>& H0_;
+    Hamiltonian0<T> const& H0_;
     K_point<T>& kp_;
     /// Hubbard correction.
     /** In general case it is a k-dependent matrix */
@@ -188,7 +188,7 @@ class Hamiltonian_k
     Hamiltonian_k<T>& operator=(Hamiltonian_k<T> const& src__) = delete;
 
   public:
-    Hamiltonian_k(Hamiltonian0<T>& H0__, K_point<T>& kp__);
+    Hamiltonian_k(Hamiltonian0<T> const& H0__, K_point<T>& kp__);
 
     Hamiltonian_k(Hamiltonian_k<T>&& src__);
 
@@ -215,7 +215,7 @@ class Hamiltonian_k
     template <int what>
     std::pair<sddk::mdarray<T, 2>, sddk::mdarray<T, 2>> get_h_o_diag_lapw() const;
 
-    auto& U()
+    auto& U() const
     {
         return *u_op_;
     }
@@ -447,7 +447,7 @@ class Hamiltonian_k
     template <typename F>
     std::enable_if_t<std::is_same<T, real_type<F>>::value, void>
     apply_h_s(wf::spin_range spins__, wf::band_range br__, wf::Wave_functions<T> const& phi__,
-              wf::Wave_functions<T>* hphi__, wf::Wave_functions<T>* sphi__)
+              wf::Wave_functions<T>* hphi__, wf::Wave_functions<T>* sphi__) const
     {
         PROFILE("sirius::Hamiltonian_k::apply_h_s");
 
@@ -506,7 +506,7 @@ class Hamiltonian_k
     template <typename F>
     std::enable_if_t<!std::is_same<T, real_type<F>>::value, void>
     apply_h_s(wf::spin_range spins__, wf::band_range br__, wf::Wave_functions<T> const& phi__,
-              wf::Wave_functions<T>* hphi__, wf::Wave_functions<T>* sphi__)
+              wf::Wave_functions<T>* hphi__, wf::Wave_functions<T>* sphi__) const
     {
         RTE_THROW("implementat this");
     }
@@ -517,7 +517,7 @@ class Hamiltonian_k
 
 template <typename T>
 Hamiltonian_k<T>
-Hamiltonian0<T>::operator()(K_point<T>& kp__)
+Hamiltonian0<T>::operator()(K_point<T>& kp__) const
 {
     return Hamiltonian_k<T>(*this, kp__);
 }

--- a/src/hamiltonian/hamiltonian.hpp
+++ b/src/hamiltonian/hamiltonian.hpp
@@ -215,7 +215,7 @@ class Hamiltonian_k
     template <int what>
     std::pair<sddk::mdarray<T, 2>, sddk::mdarray<T, 2>> get_h_o_diag_lapw() const;
 
-    auto& U() const
+    auto U() const -> U_operator<T> const&
     {
         return *u_op_;
     }

--- a/src/hamiltonian/hamiltonian.hpp
+++ b/src/hamiltonian/hamiltonian.hpp
@@ -501,6 +501,26 @@ class Hamiltonian_k
         RTE_THROW("implementat this");
     }
 
+    /// apply S operator
+    /** \tparam F    Type of the subspace matrix.
+     *  \param [in]  spins Range of spins.
+     *  \param [in]  br    Range of bands.
+     *  \param [in]  phi   Input wave-functions [storage: CPU && GPU].
+     *  \param [out] sphi  Result of S-operator, applied to wave-functions [storage: CPU || GPU].
+     *
+     *  In non-collinear case (spins in [0,1]) the S operator is applied to both components of spinor
+     *  wave-functions. Otherwise they are applied to a single component.
+     */
+    template <typename F>
+    std::enable_if_t<std::is_same<T, real_type<F>>::value, void>
+    apply_s(wf::spin_range spin__, wf::band_range br__, wf::Wave_functions<T> const& phi__, wf::Wave_functions<T>& sphi__) const {
+        auto mem = H0().ctx().processing_unit_memory_t();
+        auto bp_gen    = kp_.beta_projectors().make_generator();
+        auto bp_coeffs = bp_gen.prepare();
+        apply_S_operator<T, F>(mem, spin__, br__,
+                               bp_gen, bp_coeffs, phi__, &H0().Q(), sphi__);
+    }
+
     /// Apply magnetic field to first-variational LAPW wave-functions.
     void apply_b(wf::Wave_functions<T>& psi__, std::vector<wf::Wave_functions<T>>& bpsi__) const;
 };

--- a/src/hamiltonian/hamiltonian.hpp
+++ b/src/hamiltonian/hamiltonian.hpp
@@ -199,16 +199,6 @@ class Hamiltonian_k
         return H0_;
     }
 
-    auto& kp()
-    {
-        return kp_;
-    }
-
-    auto const& kp() const
-    {
-        return kp_;
-    }
-
     template <typename F, int what>
     std::pair<sddk::mdarray<T, 2>, sddk::mdarray<T, 2>> get_h_o_diag_pw() const;
 
@@ -351,7 +341,7 @@ class Hamiltonian_k
      *  \param [out] ophi       Result of overlap operator, applied to wave-functions.
      */
     void apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range b__, wf::Wave_functions<T>& phi__,
-                      wf::Wave_functions<T>* hphi__, wf::Wave_functions<T>* ophi__);
+                      wf::Wave_functions<T>* hphi__, wf::Wave_functions<T>* ophi__) const;
 
     /// Setup the Hamiltonian and overlap matrices in APW+lo basis
     /** The Hamiltonian matrix has the following expression:
@@ -455,8 +445,8 @@ class Hamiltonian_k
 
         if (hphi__ != nullptr) {
             /* apply local part of Hamiltonian */
-            H0().local_op().apply_h(reinterpret_cast<fft::spfft_transform_type<T>&>(kp().spfft_transform()),
-                                    kp().gkvec_fft_sptr(), spins__, phi__, *hphi__, br__);
+            H0().local_op().apply_h(reinterpret_cast<fft::spfft_transform_type<T>&>(kp_.spfft_transform()),
+                                    kp_.gkvec_fft_sptr(), spins__, phi__, *hphi__, br__);
         }
 
         auto mem = H0().ctx().processing_unit_memory_t();
@@ -480,7 +470,7 @@ class Hamiltonian_k
 
         /* return if there are no beta-projectors */
         if (H0().ctx().unit_cell().max_mt_basis_size()) {
-            auto bp_generator = kp().beta_projectors().make_generator();
+            auto bp_generator = kp_.beta_projectors().make_generator();
             auto beta_coeffs  = bp_generator.prepare();
             apply_non_local_D_Q<T, F>(mem, spins__, br__, bp_generator, beta_coeffs, phi__, &H0().D(), hphi__, &H0().Q(), sphi__);
         }
@@ -488,7 +478,7 @@ class Hamiltonian_k
         /* apply the hubbard potential if relevant */
         if (H0().ctx().hubbard_correction() && !H0().ctx().gamma_point() && hphi__) {
             /* apply the hubbard potential */
-            apply_U_operator(H0().ctx(), spins__, br__, kp().hubbard_wave_functions_S(), phi__, this->U(), *hphi__);
+            apply_U_operator(H0().ctx(), spins__, br__, kp_.hubbard_wave_functions_S(), phi__, this->U(), *hphi__);
         }
 
         if (pcs) {
@@ -512,7 +502,7 @@ class Hamiltonian_k
     }
 
     /// Apply magnetic field to first-variational LAPW wave-functions.
-    void apply_b(wf::Wave_functions<T>& psi__, std::vector<wf::Wave_functions<T>>& bpsi__);
+    void apply_b(wf::Wave_functions<T>& psi__, std::vector<wf::Wave_functions<T>>& bpsi__) const;
 };
 
 template <typename T>

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -37,7 +37,7 @@
 namespace sirius {
 
 template <typename T>
-Hamiltonian_k<T>::Hamiltonian_k(Hamiltonian0<T>& H0__, K_point<T>& kp__)
+Hamiltonian_k<T>::Hamiltonian_k(Hamiltonian0<T> const& H0__, K_point<T>& kp__)
     : H0_(H0__)
     , kp_(kp__)
 {

--- a/src/hamiltonian/initialize_subspace.hpp
+++ b/src/hamiltonian/initialize_subspace.hpp
@@ -19,7 +19,7 @@
 
 /** \file initialize_subspace.hpp
  *
- *  \brief Create intial subspace from atomic-like wave-functions 
+ *  \brief Create intial subspace from atomic-like wave-functions
  */
 
 #ifndef __INITIALIZE_SUBSPACE_HPP__
@@ -34,14 +34,15 @@ namespace sirius {
 /** If the number of atomic orbitals is smaller than the number of bands, the rest of the initial wave-functions
  *  are created from the random numbers. */
 template <typename T, typename F>
-inline void initialize_subspace(Hamiltonian_k<T>& Hk__, int num_ao__)
+inline void
+initialize_subspace(Hamiltonian_k<T> const& Hk__, K_point<T>& kp__, int num_ao__)
 {
     PROFILE("sirius::initialize_subspace|kp");
 
     auto& ctx = Hk__.H0().ctx();
 
     if (ctx.cfg().control().verification() >= 2) {
-        auto eval = diag_S_davidson<T, F>(Hk__);
+        auto eval = diag_S_davidson<T, F>(Hk__, kp__);
         if (eval[0] <= 0) {
             std::stringstream s;
             s << "S-operator matrix is not positive definite\n"
@@ -72,8 +73,8 @@ inline void initialize_subspace(Hamiltonian_k<T>& Hk__, int num_ao__)
     print_memory_usage(ctx.out(), FILE_LINE);
 
     /* initial basis functions */
-    wf::Wave_functions<T> phi(Hk__.kp().gkvec_sptr(), wf::num_mag_dims(ctx.num_mag_dims() == 3 ? 3 : 0),
-            wf::num_bands(num_phi_tot), sddk::memory_t::host);
+    wf::Wave_functions<T> phi(kp__.gkvec_sptr(), wf::num_mag_dims(ctx.num_mag_dims() == 3 ? 3 : 0),
+                              wf::num_bands(num_phi_tot), sddk::memory_t::host);
 
     for (int ispn = 0; ispn < num_sc; ispn++) {
         phi.zero(sddk::memory_t::host, wf::spin_index(ispn), wf::band_range(0, num_phi_tot));
@@ -82,8 +83,8 @@ inline void initialize_subspace(Hamiltonian_k<T>& Hk__, int num_ao__)
     /* generate the initial atomic wavefunctions */
     std::vector<int> atoms(ctx.unit_cell().num_atoms());
     std::iota(atoms.begin(), atoms.end(), 0);
-    Hk__.kp().generate_atomic_wave_functions(atoms, [&](int iat){return &ctx.unit_cell().atom_type(iat).indexb_wfs();},
-                                             *ctx.ri().ps_atomic_wf_, phi);
+    kp__.generate_atomic_wave_functions(
+        atoms, [&](int iat) { return &ctx.unit_cell().atom_type(iat).indexb_wfs(); }, *ctx.ri().ps_atomic_wf_, phi);
 
     /* generate some random noise */
     std::vector<T> tmp(4096);
@@ -93,14 +94,14 @@ inline void initialize_subspace(Hamiltonian_k<T>& Hk__, int num_ao__)
     }
     PROFILE_START("sirius::initialize_subspace|kp|wf");
     /* fill remaining wave-functions with pseudo-random guess */
-    RTE_ASSERT(Hk__.kp().num_gkvec() > num_phi + 10);
+    RTE_ASSERT(kp__.num_gkvec() > num_phi + 10);
     #pragma omp parallel
     {
         for (int i = 0; i < num_phi - num_ao__; i++) {
             #pragma omp for schedule(static) nowait
-            for (int igk_loc = 0; igk_loc < Hk__.kp().num_gkvec_loc(); igk_loc++) {
+            for (int igk_loc = 0; igk_loc < kp__.num_gkvec_loc(); igk_loc++) {
                 /* global index of G+k vector */
-                int igk = Hk__.kp().gkvec().offset() + igk_loc; //Hk__.kp().idxgk(igk_loc);
+                int igk = kp__.gkvec().offset() + igk_loc; // Hk__.kp().idxgk(igk_loc);
                 if (igk == i + 1) {
                     phi.pw_coeffs(igk_loc, wf::spin_index(0), wf::band_index(num_ao__ + i)) = 1.0;
                 }
@@ -115,9 +116,9 @@ inline void initialize_subspace(Hamiltonian_k<T>& Hk__, int num_ao__)
         /* add random noise */
         for (int i = 0; i < num_phi; i++) {
             #pragma omp for schedule(static) nowait
-            for (int igk_loc = Hk__.kp().gkvec().skip_g0(); igk_loc < Hk__.kp().num_gkvec_loc(); igk_loc++) {
+            for (int igk_loc = kp__.gkvec().skip_g0(); igk_loc < kp__.num_gkvec_loc(); igk_loc++) {
                 /* global index of G+k vector */
-                int igk = Hk__.kp().gkvec().offset() + igk_loc;
+                int igk = kp__.gkvec().offset() + igk_loc;
                 phi.pw_coeffs(igk_loc, wf::spin_index(0), wf::band_index(i)) += tmp[igk & 0xFFF];
             }
         }
@@ -126,18 +127,18 @@ inline void initialize_subspace(Hamiltonian_k<T>& Hk__, int num_ao__)
     if (ctx.num_mag_dims() == 3) {
         /* make pure spinor up- and dn- wave functions */
         wf::copy(sddk::memory_t::host, phi, wf::spin_index(0), wf::band_range(0, num_phi), phi, wf::spin_index(1),
-                wf::band_range(num_phi, num_phi_tot));
+                 wf::band_range(num_phi, num_phi_tot));
     }
     PROFILE_STOP("sirius::initialize_subspace|kp|wf");
 
     /* allocate wave-functions */
-    wf::Wave_functions<T> hphi(Hk__.kp().gkvec_sptr(), wf::num_mag_dims(ctx.num_mag_dims() == 3 ? 3 : 0),
-            wf::num_bands(num_phi_tot), sddk::memory_t::host);
-    wf::Wave_functions<T> ophi(Hk__.kp().gkvec_sptr(), wf::num_mag_dims(ctx.num_mag_dims() == 3 ? 3 : 0),
-            wf::num_bands(num_phi_tot), sddk::memory_t::host);
+    wf::Wave_functions<T> hphi(kp__.gkvec_sptr(), wf::num_mag_dims(ctx.num_mag_dims() == 3 ? 3 : 0),
+                               wf::num_bands(num_phi_tot), sddk::memory_t::host);
+    wf::Wave_functions<T> ophi(kp__.gkvec_sptr(), wf::num_mag_dims(ctx.num_mag_dims() == 3 ? 3 : 0),
+                               wf::num_bands(num_phi_tot), sddk::memory_t::host);
     /* temporary wave-functions required as a storage during orthogonalization */
-    wf::Wave_functions<T> wf_tmp(Hk__.kp().gkvec_sptr(), wf::num_mag_dims(ctx.num_mag_dims() == 3 ? 3 : 0),
-            wf::num_bands(num_phi_tot), sddk::memory_t::host);
+    wf::Wave_functions<T> wf_tmp(kp__.gkvec_sptr(), wf::num_mag_dims(ctx.num_mag_dims() == 3 ? 3 : 0),
+                                 wf::num_bands(num_phi_tot), sddk::memory_t::host);
 
     int bs = ctx.cyclic_block_size();
 
@@ -154,7 +155,7 @@ inline void initialize_subspace(Hamiltonian_k<T>& Hk__, int num_ao__)
     auto mem = ctx.processing_unit() == sddk::device_t::CPU ? sddk::memory_t::host : sddk::memory_t::device;
 
     std::vector<wf::device_memory_guard> mg;
-    mg.emplace_back(Hk__.kp().spinor_wave_functions().memory_guard(mem, wf::copy_to::host));
+    mg.emplace_back(kp__.spinor_wave_functions().memory_guard(mem, wf::copy_to::host));
     mg.emplace_back(phi.memory_guard(mem, wf::copy_to::device));
     mg.emplace_back(hphi.memory_guard(mem));
     mg.emplace_back(ophi.memory_guard(mem));
@@ -172,7 +173,7 @@ inline void initialize_subspace(Hamiltonian_k<T>& Hk__, int num_ao__)
     if (pcs) {
         for (int ispn = 0; ispn < num_sc; ispn++) {
             auto cs = phi.checksum(mem, wf::spin_index(ispn), wf::band_range(0, num_phi_tot));
-            if (Hk__.kp().comm().rank() == 0) {
+            if (kp__.comm().rank() == 0) {
                 std::stringstream s;
                 s << "initial_phi" << ispn;
                 utils::print_checksum(s.str(), cs, RTE_OUT(std::cout));
@@ -183,37 +184,37 @@ inline void initialize_subspace(Hamiltonian_k<T>& Hk__, int num_ao__)
     for (int ispn_step = 0; ispn_step < ctx.num_spinors(); ispn_step++) {
         /* apply Hamiltonian and overlap operators to the new basis functions */
         Hk__.template apply_h_s<F>(ctx.num_mag_dims() == 3 ? wf::spin_range(0, 2) : wf::spin_range(ispn_step),
-            wf::band_range(0, num_phi_tot), phi, &hphi, &ophi);
+                                   wf::band_range(0, num_phi_tot), phi, &hphi, &ophi);
 
         /* do some checks */
-    //    if (ctx_.cfg().control().verification() >= 1) {
+        //    if (ctx_.cfg().control().verification() >= 1) {
 
-    //        set_subspace_mtrx<T>(0, num_phi_tot, 0, phi, ophi, ovlp);
-    //        if (ctx_.cfg().control().verification() >= 2 && ctx_.verbosity() >= 2) {
-    //            auto s = ovlp.serialize("overlap", num_phi_tot, num_phi_tot);
-    //            if (Hk__.kp().comm().rank() == 0) {
-    //                ctx_.out() << s.str() << std::endl;
-    //            }
-    //        }
+        //        set_subspace_mtrx<T>(0, num_phi_tot, 0, phi, ophi, ovlp);
+        //        if (ctx_.cfg().control().verification() >= 2 && ctx_.verbosity() >= 2) {
+        //            auto s = ovlp.serialize("overlap", num_phi_tot, num_phi_tot);
+        //            if (Hk__.kp().comm().rank() == 0) {
+        //                ctx_.out() << s.str() << std::endl;
+        //            }
+        //        }
 
-    //        double max_diff = check_hermitian(ovlp, num_phi_tot);
-    //        if (max_diff > 1e-12) {
-    //            std::stringstream s;
-    //            s << "overlap matrix is not hermitian, max_err = " << max_diff;
-    //            WARNING(s);
-    //        }
-    //        std::vector<real_type<T>> eo(num_phi_tot);
-    //        auto& std_solver = ctx_.std_evp_solver();
-    //        if (std_solver.solve(num_phi_tot, num_phi_tot, ovlp, eo.data(), evec)) {
-    //            std::stringstream s;
-    //            s << "error in diagonalization";
-    //            WARNING(s);
-    //        }
-    //        Hk__.kp().message(1, __function_name__, "minimum eigen-value of the overlap matrix: %18.12f\n", eo[0]);
-    //        if (eo[0] < 0) {
-    //            WARNING("overlap matrix is not positively defined");
-    //        }
-    //    }
+        //        double max_diff = check_hermitian(ovlp, num_phi_tot);
+        //        if (max_diff > 1e-12) {
+        //            std::stringstream s;
+        //            s << "overlap matrix is not hermitian, max_err = " << max_diff;
+        //            WARNING(s);
+        //        }
+        //        std::vector<real_type<T>> eo(num_phi_tot);
+        //        auto& std_solver = ctx_.std_evp_solver();
+        //        if (std_solver.solve(num_phi_tot, num_phi_tot, ovlp, eo.data(), evec)) {
+        //            std::stringstream s;
+        //            s << "error in diagonalization";
+        //            WARNING(s);
+        //        }
+        //        Hk__.kp().message(1, __function_name__, "minimum eigen-value of the overlap matrix: %18.12f\n",
+        //        eo[0]); if (eo[0] < 0) {
+        //            WARNING("overlap matrix is not positively defined");
+        //        }
+        //    }
 
         /* setup eigen-value problem */
         generate_subspace_matrix(ctx, 0, num_phi_tot, 0, phi, hphi, hmlt);
@@ -222,38 +223,38 @@ inline void initialize_subspace(Hamiltonian_k<T>& Hk__, int num_ao__)
         if (pcs) {
             auto cs1 = hmlt.checksum(num_phi_tot, num_phi_tot);
             auto cs2 = ovlp.checksum(num_phi_tot, num_phi_tot);
-            if (Hk__.kp().comm().rank() == 0) {
+            if (kp__.comm().rank() == 0) {
                 utils::print_checksum("hmlt", cs1, RTE_OUT(std::cout));
                 utils::print_checksum("ovlp", cs2, RTE_OUT(std::cout));
             }
         }
 
-    //    if (ctx_.cfg().control().verification() >= 2 && ctx_.verbosity() >= 2) {
-    //        auto s1 = hmlt.serialize("hmlt", num_phi_tot, num_phi_tot);
-    //        auto s2 = hmlt.serialize("ovlp", num_phi_tot, num_phi_tot);
-    //        if (Hk__.kp().comm().rank() == 0) {
-    //            ctx_.out() << s1.str() << std::endl << s2.str() << std::endl;
-    //        }
-    //    }
+        //    if (ctx_.cfg().control().verification() >= 2 && ctx_.verbosity() >= 2) {
+        //        auto s1 = hmlt.serialize("hmlt", num_phi_tot, num_phi_tot);
+        //        auto s2 = hmlt.serialize("ovlp", num_phi_tot, num_phi_tot);
+        //        if (Hk__.kp().comm().rank() == 0) {
+        //            ctx_.out() << s1.str() << std::endl << s2.str() << std::endl;
+        //        }
+        //    }
 
         /* solve generalized eigen-value problem with the size N and get lowest num_bands eigen-vectors */
         if (gen_solver.solve(num_phi_tot, num_bands, hmlt, ovlp, eval.data(), evec)) {
             RTE_THROW("error in diagonalization");
         }
 
-    //    if (ctx_.print_checksum()) {
-    //        auto cs = evec.checksum(num_phi_tot, num_bands);
-    //        real_type<T> cs1{0};
-    //        for (int i = 0; i < num_bands; i++) {
-    //            cs1 += eval[i];
-    //        }
-    //        if (Hk__.kp().comm().rank() == 0) {
-    //            utils::print_checksum("evec", cs);
-    //            utils::print_checksum("eval", cs1);
-    //        }
-    //    }
+        //    if (ctx_.print_checksum()) {
+        //        auto cs = evec.checksum(num_phi_tot, num_bands);
+        //        real_type<T> cs1{0};
+        //        for (int i = 0; i < num_bands; i++) {
+        //            cs1 += eval[i];
+        //        }
+        //        if (Hk__.kp().comm().rank() == 0) {
+        //            utils::print_checksum("evec", cs);
+        //            utils::print_checksum("eval", cs1);
+        //        }
+        //    }
         {
-            rte::ostream out(Hk__.kp().out(3), std::string(__func__));
+            rte::ostream out(kp__.out(3), std::string(__func__));
             for (int i = 0; i < num_bands; i++) {
                 out << "eval[" << i << "]=" << eval[i] << std::endl;
             }
@@ -262,24 +263,22 @@ inline void initialize_subspace(Hamiltonian_k<T>& Hk__, int num_ao__)
         /* compute wave-functions */
         /* \Psi_{i} = \sum_{mu} \phi_{mu} * Z_{mu, i} */
         for (int ispn = 0; ispn < num_sc; ispn++) {
-            wf::transform(ctx.spla_context(), mem, evec, 0, 0, 1.0, phi,
-                    wf::spin_index(num_sc == 2 ? ispn : 0), wf::band_range(0, num_phi_tot), 0.0,
-                    Hk__.kp().spinor_wave_functions(), wf::spin_index(num_sc == 2 ? ispn : ispn_step),
-                    wf::band_range(0, num_bands));
+            wf::transform(ctx.spla_context(), mem, evec, 0, 0, 1.0, phi, wf::spin_index(num_sc == 2 ? ispn : 0),
+                          wf::band_range(0, num_phi_tot), 0.0, kp__.spinor_wave_functions(),
+                          wf::spin_index(num_sc == 2 ? ispn : ispn_step), wf::band_range(0, num_bands));
         }
 
         for (int j = 0; j < num_bands; j++) {
-            Hk__.kp().band_energy(j, ispn_step, eval[j]);
+            kp__.band_energy(j, ispn_step, eval[j]);
         }
     }
 
     if (pcs) {
         for (int ispn = 0; ispn < ctx.num_spins(); ispn++) {
-            auto cs = Hk__.kp().spinor_wave_functions().checksum(mem, wf::spin_index(ispn),
-                    wf::band_range(0, num_bands));
+            auto cs = kp__.spinor_wave_functions().checksum(mem, wf::spin_index(ispn), wf::band_range(0, num_bands));
             std::stringstream s;
             s << "initial_spinor_wave_functions_" << ispn;
-            if (Hk__.kp().comm().rank() == 0) {
+            if (kp__.comm().rank() == 0) {
                 utils::print_checksum(s.str(), cs, RTE_OUT(std::cout));
             }
         }
@@ -301,13 +300,13 @@ initialize_subspace(K_point_set& kset__, Hamiltonian0<T>& H0__)
         N = ctx.unit_cell().num_ps_atomic_wf().first;
     }
 
-    for (auto it: kset__.spl_num_kpoints()) {
+    for (auto it : kset__.spl_num_kpoints()) {
         auto kp = kset__.get<T>(it.i);
         auto Hk = H0__(*kp);
         if (ctx.gamma_point() && (ctx.so_correction() == false)) {
-            initialize_subspace<T, T>(Hk, N);
+            initialize_subspace<T, T>(Hk, *kp, N);
         } else {
-            initialize_subspace<T, std::complex<T>>(Hk, N);
+            initialize_subspace<T, std::complex<T>>(Hk, *kp, N);
         }
     }
 
@@ -322,6 +321,6 @@ initialize_subspace(K_point_set& kset__, Hamiltonian0<T>& H0__)
     }
 }
 
-}
+} // namespace sirius
 
 #endif

--- a/src/hamiltonian/initialize_subspace.hpp
+++ b/src/hamiltonian/initialize_subspace.hpp
@@ -305,9 +305,9 @@ initialize_subspace(K_point_set& kset__, Hamiltonian0<T>& H0__)
         auto kp = kset__.get<T>(it.i);
         auto Hk = H0__(*kp);
         if (ctx.gamma_point() && (ctx.so_correction() == false)) {
-            ::sirius::initialize_subspace<T, T>(Hk, N);
+            initialize_subspace<T, T>(Hk, N);
         } else {
-            ::sirius::initialize_subspace<T, std::complex<T>>(Hk, N);
+            initialize_subspace<T, std::complex<T>>(Hk, N);
         }
     }
 

--- a/src/hamiltonian/non_local_operator.hpp
+++ b/src/hamiltonian/non_local_operator.hpp
@@ -95,12 +95,12 @@ class U_operator
         return offset_[ia__];
     }
 
-    std::complex<T> operator()(int m1, int m2, int j)
+    std::complex<T> const& operator()(int m1, int m2, int j) const
     {
         return um_[j](m1, m2);
     }
 
-    std::complex<T>* at(sddk::memory_t mem__, const int idx1, const int idx2, const int idx3)
+    std::complex<T> const* at(sddk::memory_t mem__, const int idx1, const int idx2, const int idx3) const
     {
         return um_[idx3].at(mem__, idx1, idx2);
     }
@@ -192,7 +192,7 @@ apply_S_operator(sddk::memory_t mem__, wf::spin_range spins__, wf::band_range br
  */
 template <typename T>
 void apply_U_operator(Simulation_context& ctx__, wf::spin_range spins__, wf::band_range br__,
-                      wf::Wave_functions<T> const& hub_wf__, wf::Wave_functions<T> const& phi__, U_operator<T>& um__,
+                      wf::Wave_functions<T> const& hub_wf__, wf::Wave_functions<T> const& phi__, U_operator<T> const& um__,
                       wf::Wave_functions<T>& hphi__);
 /// Apply strain derivative of S-operator to all scalar functions.
 void apply_S_operator_strain_deriv(sddk::memory_t mem__, int comp__, Beta_projector_generator<double>& bp__,

--- a/src/hamiltonian/non_local_operator.hpp
+++ b/src/hamiltonian/non_local_operator.hpp
@@ -105,7 +105,7 @@ class U_operator
         return um_[idx3].at(mem__, idx1, idx2);
     }
 
-    const int find_orbital_index(const int ia__, const int n__, const int l__) const;
+    int find_orbital_index(const int ia__, const int n__, const int l__) const;
 };
 
 /** \tparam T  Precision of the wave-functions.

--- a/src/hamiltonian/s_u_operator.cpp
+++ b/src/hamiltonian/s_u_operator.cpp
@@ -74,7 +74,7 @@ U_operator<T>::U_operator(Simulation_context const& ctx__, Hubbard_matrix const&
 }
 
 template <class T>
-const int
+int
 U_operator<T>::find_orbital_index(const int ia__, const int n__, const int l__) const
 {
     int at_lvl = 0;

--- a/src/hamiltonian/s_u_operator.cpp
+++ b/src/hamiltonian/s_u_operator.cpp
@@ -108,7 +108,7 @@ template class U_operator<float>;
 template <typename T>
 void
 apply_U_operator(Simulation_context& ctx__, wf::spin_range spins__, wf::band_range br__,
-                 wf::Wave_functions<T> const& hub_wf__, wf::Wave_functions<T> const& phi__, U_operator<T>& um__,
+                 wf::Wave_functions<T> const& hub_wf__, wf::Wave_functions<T> const& phi__, U_operator<T> const& um__,
                  wf::Wave_functions<T>& hphi__)
 {
     if (!ctx__.hubbard_correction()) {
@@ -180,12 +180,12 @@ apply_U_operator(Simulation_context& ctx__, wf::spin_range spins__, wf::band_ran
 
 template void apply_U_operator<double>(Simulation_context&, wf::spin_range, wf::band_range,
                                        const wf::Wave_functions<double>&, const wf::Wave_functions<double>&,
-                                       U_operator<double>&, wf::Wave_functions<double>&);
+                                       U_operator<double> const&, wf::Wave_functions<double>&);
 
 #ifdef SIRIUS_USE_FP32
 template void apply_U_operator<float>(Simulation_context&, wf::spin_range, wf::band_range,
                                       const wf::Wave_functions<float>&, const wf::Wave_functions<float>&,
-                                      U_operator<float>&, wf::Wave_functions<float>&);
+                                      U_operator<float> const&, wf::Wave_functions<float>&);
 #endif
 
 /// Apply strain derivative of S-operator to all scalar functions.

--- a/src/hubbard/hubbard_matrix.hpp
+++ b/src/hubbard/hubbard_matrix.hpp
@@ -109,7 +109,7 @@ class Hubbard_matrix
         return atomic_orbitals_[idx__];
     }
 
-    const int offset(const int idx__) const
+    int offset(const int idx__) const
     {
         return offset_[idx__];
     }
@@ -124,7 +124,7 @@ class Hubbard_matrix
         return ctx_;
     }
 
-    const int find_orbital_index(const int ia__, const int n__, const int l__) const
+    int find_orbital_index(const int ia__, const int n__, const int l__) const
     {
         int at_lvl = 0;
         for (at_lvl = 0; at_lvl < static_cast<int>(atomic_orbitals_.size()); at_lvl++) {

--- a/src/k_point/k_point.hpp
+++ b/src/k_point/k_point.hpp
@@ -69,7 +69,7 @@ class K_point
     /// G-vector distribution for the FFT transformation.
     std::shared_ptr<fft::Gvec_fft> gkvec_partition_;
 
-    std::unique_ptr<fft::spfft_transform_type<T>> spfft_transform_;
+    mutable std::unique_ptr<fft::spfft_transform_type<T>> spfft_transform_;
 
     /// First-variational eigen values
     sddk::mdarray<double, 1> fv_eigen_values_;
@@ -735,12 +735,7 @@ class K_point
         }
     }
 
-    auto& spfft_transform()
-    {
-        return *spfft_transform_;
-    }
-
-    auto const& spfft_transform() const
+    auto& spfft_transform() const
     {
         return *spfft_transform_;
     }

--- a/src/multi_cg/multi_cg.hpp
+++ b/src/multi_cg/multi_cg.hpp
@@ -352,14 +352,7 @@ struct Linear_response_operator {
             1.0, *evq, wf::spin_index(0), br,
             0.0, *Hphi, wf::spin_index(0), wf::band_range(0, num_active));
 
-        auto bp_gen    = Hk.kp().beta_projectors().make_generator();
-        auto bp_coeffs = bp_gen.prepare();
-        // Sphi := S * Hphi = S * (evq * (evq' * (S * x)))
-        sirius::apply_S_operator<double, std::complex<double>>(
-            mem,
-            wf::spin_range(0), wf::band_range(0, num_active),
-            bp_gen, bp_coeffs,
-            *Hphi, &Hk.H0().Q(), *Sphi);
+        Hk.apply_s<std::complex<double>>(wf::spin_range(0), wf::band_range(0, num_active), *Hphi, *Sphi);
 
         // tmp := alpha_pv * Sphi + tmp = (H - e * S) * x + alpha_pv * (S * (evq * (evq' * (S * x))))
         std::vector<double> alpha_pvs(num_active, alpha_pv);

--- a/src/unit_cell/atomic_data.hpp
+++ b/src/unit_cell/atomic_data.hpp
@@ -26,7 +26,7 @@ struct atomic_level_descriptor
     double occupancy;
 
     /// True if this is a core level.
-    bool core;
+    bool core{false};
 };
 
 const std::vector<std::string> atomic_symb = {


### PR DESCRIPTION
WIP (after #889).


- Modify all functions calling `H_k.apply*` to take `Hamiltonian_k` as const reference and a separate argument for non-const ref to `K_point`.
- Some other minor fixes proposed by `-Wextra` flag.
- add `Hamiltonian_k::apply_S` for the overlap operator (for LR)