### PR TITLE
[fix] BUILD_TESTING is a CMake variable and should not be scoped

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ option(SIRIUS_USE_OPENMP              "use OpenMP" ON)
 option(SIRIUS_USE_PROFILER            "measure execution of functions with timer" ON)
 option(SIRIUS_USE_MEMORY_POOL         "use memory pool" ON)
 option(SIRIUS_USE_POWER_COUNTER       "measure energy consumption with power counters" OFF)
-option(SIRIUS_BUILD_TESTING           "build test executables" OFF) # override default setting in CTest module
+option(BUILD_TESTING                   "build test executables" OFF) # override default setting in CTest module
 option(SIRIUS_USE_VCSQNM              "use variable cell stabilized quasi Newton method" OFF)
 
 set(SIRIUS_GPU_MEMORY_ALIGMENT "512" CACHE STRING "memory alignment of the GPU")

--- a/apps/dft_loop/CMakeLists.txt
+++ b/apps/dft_loop/CMakeLists.txt
@@ -22,7 +22,7 @@ set(SIRIUS_SCF_FLAGS_cpu_band_parallel    --control.processing_unit=cpu --contro
 
 # todo: Add OMP_NUM_THREADS + srun / mpiexec flags here too?
 
-if(SIRIUS_BUILD_TESTING)
+if(BUILD_TESTING)
     file(GLOB dirs LIST_DIRECTORIES true "${CMAKE_SOURCE_DIR}/verification/test*")
 
     foreach(full_path ${dirs})

--- a/verification/test25/sirius.json
+++ b/verification/test25/sirius.json
@@ -37,7 +37,7 @@
         "type": "davidson"
     },
     "mixer": {
-        "beta": 0.7,
+        "beta": 0.5,
         "beta0": 0.15,
         "beta_scaling_factor": 1.0,
         "max_history": 8,


### PR DESCRIPTION
spack PR: https://github.com/spack/spack/pull/39866