### PR TITLE
siriusConfig.cmake: USE_MEMORY_POOL -> SIRIUS_USE_MEMORY_POOL

### DIFF
--- a/cmake/siriusConfig.cmake.in
+++ b/cmake/siriusConfig.cmake.in
@@ -80,7 +80,7 @@ if(NOT TARGET sirius::sirius)
     find_package(rocsolver CONFIG ${mode})
   endif()
 
-  if(@USE_MEMORY_POOL@)
+  if(@SIRIUS_USE_MEMORY_POOL@)
     find_package(umpire ${mode})
   endif()
 


### PR DESCRIPTION
in `siriusConfig.cmake.in` memory pool was missing `SIRIUS_` prefix