### PR TITLE
Fix datatype for mpi bool

### DIFF
--- a/src/mpi/communicator.hpp
+++ b/src/mpi/communicator.hpp
@@ -162,7 +162,7 @@ struct type_wrapper<unsigned long>
 template <>
 struct type_wrapper<bool>
 {
-    operator MPI_Datatype() const noexcept {return MPI_CXX_BOOL;}
+    operator MPI_Datatype() const noexcept {return MPI_C_BOOL;}
 };
 
 template <>


### PR DESCRIPTION
Without this change we are getting this error

```
aborting job:
Fatal error in PMPI_Allreduce: Invalid MPI_Op, error stack:
PMPI_Allreduce(497)......: MPI_Allreduce(sbuf=MPI_IN_PLACE, rbuf=0x7ffc8aa9a593, count=1, datatype=dtype=0x4c000133, op=MPI_LAND, comm=comm=0x840000
05) failed
MPIR_LAND_check_dtype(92): MPI_Op MPI_LAND operation not defined for this datatype 
srun: error: nid005000: tasks 0-7: Exited with exit code 255
srun: launch/slurm: _step_signal: Terminating StepId=4605641.0
```

When running on LUMI.