### PR TITLE
Make verification tests fail if exception is thrown

### DIFF
--- a/apps/dft_loop/sirius.scf.cpp
+++ b/apps/dft_loop/sirius.scf.cpp
@@ -589,12 +589,15 @@ int main(int argn, char** argv)
 
     int my_rank = mpi::Communicator::world().rank();
 
+    bool exception_thrown{false};
     try {
         run_tasks(args);
     } catch (std::exception const& e) {
         std::cout << e.what() << std::endl;
+        exception_thrown = true;
     } catch (...) {
         std::cout << "unknown exception" << std::endl;
+        exception_thrown = true;
     }
 
     sirius::finalize(1);
@@ -621,5 +624,5 @@ int main(int argn, char** argv)
         std::cout << "FE_OVERFLOW exception\n";
     }
 
-    return 0;
+    return exception_thrown ? -1 : 0;
 }


### PR DESCRIPTION
The verification tests pass in `ctest` even if an exception is thrown before the output is checked against the expected reference with `--test_against`, because the exception is captured.

This PR ensures that `ctest` fails for the verification tests if an exception is thrown.

---

```
test 34
    Start 34: sirius.scf_test01_cpu_serial

34: Test command: /home/rmeli/git/SIRIUS/build/apps/dft_loop/sirius.scf "--test_against=output_ref.json" "--control.processing_unit=cpu"
34: Working Directory: /home/rmeli/git/SIRIUS/verification/test01
34: Test timeout computed to be: 1500
34: SIRIUS 7.5.0, git hash: 321a939e7e177b263ae24474874fca6ebb75b3ee
34: 
34: [get_ev_solver_t] /home/rmeli/git/SIRIUS/src/linalg/eigensolver.hpp:71
34: [get_ev_solver_t] wrong label of eigen-solver : dlaf
34: 
34: =========================================================================================================================================
34:                                                           #         Total          %     Self %        Median           Min           Max
34: -----------------------------------------------------------------------------------------------------------------------------------------
34: sirius                                                    1      47.91 ms     100.00       1.22      47.91 ms      47.91 ms      47.91 ms
34: ├ sirius::initialize                                      1      23.15 ms      48.33     100.00      23.15 ms      23.15 ms      23.15 ms
34: ├ sirius::Simulation_context::initialize                  1      23.70 ms      49.47       1.08      23.70 ms      23.70 ms      23.70 ms
34: │ ├ sirius::Simulation_context::init_comm                 1      28.90 us       0.06     100.00      28.90 us      28.90 us      28.90 us
34: │ └ sirius::Unit_cell::initialize                         1      23.42 ms      48.88       0.05      23.42 ms      23.42 ms      23.42 ms
34: │   ├ sirius::Atom_type::init                             3      19.36 ms      40.41     100.00       7.15 ms       4.31 ms       7.89 ms
34: │   └ sirius::Unit_cell::update                           1       4.05 ms       8.44       0.05       4.05 ms       4.05 ms       4.05 ms
34: │     ├ sirius::Unit_cell::find_nearest_neighbours        1     885.83 us       1.85     100.00     885.83 us     885.83 us     885.83 us
34: │     └ sirius::Unit_cell::get_symmetry                   1       3.16 ms       6.59       0.55       3.16 ms       3.16 ms       3.16 ms
34: │       └ sirius::Crystal_symmetry                        1       3.14 ms       6.56       5.94       3.14 ms       3.14 ms       3.14 ms
34: │         ├ sirius::Crystal_symmetry|spg                  1       2.91 ms       6.07     100.00       2.91 ms       2.91 ms       2.91 ms
34: │         ├ sirius::find_sym_atom                        96      31.28 us       0.07     100.00     290.00 ns     210.00 ns       1.88 us
34: │         └ sirius::Crystal_symmetry|mag                  1      14.15 us       0.03     100.00      14.15 us      14.15 us      14.15 us
34: └ sirius::finalize                                        1     467.88 us       0.98     100.00     467.88 us     467.88 us     467.88 us
34: 
34: =========================================================================================================================================
1/1 Test #34: sirius.scf_test01_cpu_serial .....   Passed    0.09 sec

The following tests passed:
	sirius.scf_test01_cpu_serial

100% tests passed, 0 tests failed out of 1

Label Time Summary:
integration_test cpu_serial    =   0.09 sec*proc (1 test)

Total Test time (real) =   0.09 sec
```

Test pass, despite the `wrong label of eigen-solver : dlaf` error.