### PR TITLE
Remove boost / const correctness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,21 +146,14 @@ if(NOT SIRIUS_USE_FP32 STREQUAL "OFF")
   endif()
 endif()
 
-# Either find std::filesystem or boost::filesystem
 find_package(Filesystem COMPONENTS Final Experimental)
 
 add_library(sirius::filesystem INTERFACE IMPORTED)
-if(TARGET std::filesystem)
   target_link_libraries(sirius::filesystem INTERFACE std::filesystem)
   target_compile_definitions(sirius::filesystem INTERFACE
     $<$<BOOL:${Filesystem_FOUND}>:SIRIUS_STD_FILESYSTEM>
     $<$<BOOL:${CXX_FILESYSTEM_IS_EXPERIMENTAL}>:SIRIUS_STD_FILESYSTEM_EXPERIMENTAL>
   )
-else()
-  find_package(Boost 1.65 REQUIRED COMPONENTS filesystem)
-  target_link_libraries(sirius::filesystem INTERFACE Boost::filesystem)
-  target_compile_definitions(sirius::filesystem INTERFACE SIRIUS_BOOST_FILESYSTEM)
-endif()
 
 if (SIRIUS_USE_OPENMP)
   find_package(OpenMP REQUIRED)

--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ and optionally any of the additional libraries:
  * [ELPA](https://elpa.mpcdf.mpg.de/software)
  * [MAGMA](https://icl.cs.utk.edu/magma/)
  * CUDA/ROCm
- * [Boost Filesystem](https://www.boost.org/doc/libs/1_73_0/libs/filesystem/doc/index.htm)*
  * [Eigen3](https://eigen.tuxfamily.org/index.php?title=Main_Page)**
 
 \* Only required when `SIRIUS_BUILD_APPS=On` and your compiler does not support `std::filesystem` or `std::experimental::filesystem`.

--- a/spack/packages/sirius/package.py
+++ b/spack/packages/sirius/package.py
@@ -91,13 +91,6 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
 
     variant("shared", default=True, description="Build shared libraries")
     variant("openmp", default=True, description="Build with OpenMP support")
-    variant(
-        "boost_filesystem",
-        default=False,
-        description="Use Boost filesystem for self-consistent field method "
-        "mini-app. Only required when the compiler does not "
-        "support std::experimental::filesystem nor std::filesystem",
-    )
     variant("fortran", default=False, description="Build Fortran bindings")
     variant("python", default=False, description="Build Python bindings")
     variant("memory_pool", default=True, description="Build with memory pool")
@@ -144,7 +137,6 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     extends("python", when="+python")
 
     depends_on("magma", when="+magma")
-    depends_on("boost cxxstd=14 +filesystem", when="+boost_filesystem")
 
     depends_on("spfft@0.9.13:", when="@7.0.1:")
     depends_on("spfft+single_precision", when="+single_precision ^spfft")
@@ -171,7 +163,6 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     # FindHIP cmake script only works for < 4.1
     depends_on("hip@:4.0", when="@:7.2.0 +rocm")
 
-    conflicts("+boost_filesystem", when="~apps")
     conflicts("^libxc@5.0.0")  # known to produce incorrect results
     conflicts("+single_precision", when="@:7.2.4")
     conflicts("+scalapack", when="^cray-libsci")

--- a/src/density/density.cpp
+++ b/src/density/density.cpp
@@ -1371,7 +1371,7 @@ Density::generate_valence(K_point_set const& ks__)
 }
 
 sddk::mdarray<std::complex<double>, 2>
-Density::generate_rho_aug()
+Density::generate_rho_aug() const
 {
     PROFILE("sirius::Density::generate_rho_aug");
 

--- a/src/density/density.hpp
+++ b/src/density/density.hpp
@@ -403,7 +403,7 @@ class Density : public Field4D
     void augment();
 
     /// Generate augmentation charge density.
-    sddk::mdarray<std::complex<double>, 2> generate_rho_aug();
+    sddk::mdarray<std::complex<double>, 2> generate_rho_aug() const;
 
     /// Return core leakage for a specific atom symmetry class
     inline double core_leakage(int ic) const

--- a/src/utils/filesystem.hpp
+++ b/src/utils/filesystem.hpp
@@ -1,24 +1,9 @@
 #ifndef __FILESYSTEM_HPP__
 #define __FILESYSTEM_HPP__
 
-#if defined(SIRIUS_BOOST_FILESYSTEM)
-
-#include <boost/filesystem.hpp>
-
-namespace fs = boost::filesystem;
-
-#elif defined(SIRIUS_STD_FILESYSTEM_EXPERIMENTAL)
-
-#include <experimental/filesystem>
-
-namespace fs = std::experimental::filesystem;
-
-#else
-
 #include <filesystem>
 
 namespace fs = std::filesystem;
 
-#endif // BOOST_FILESYSTEM__
 
 #endif // __FILESYSTEM_HPP__


### PR DESCRIPTION
- remove boost (std::filesystem is part of  cpp17, which is a hard dependency)
- mark `generate_rho_aug` as const