### PR TITLE
Fix build

### DIFF
--- a/apps/tests/test_lr_solver.cpp
+++ b/apps/tests/test_lr_solver.cpp
@@ -174,7 +174,7 @@ void init_wf(K_point<T> const& kp__, wf::Wave_functions<T>& phi__, int num_bands
 {
     std::vector<double> tmp(0xFFFF);
     for (int i = 0; i < 0xFFFF; i++) {
-        tmp[i] = utils::random<double>();
+        tmp[i] = random<double>();
     }
 
     phi__.zero(sddk::memory_t::host, wf::spin_index(0), wf::band_range(0, num_bands__));


### PR DESCRIPTION
Fix [building issue](https://github.com/electronic-structure/SIRIUS/actions/runs/6651109359/job/18072486253) caused by #907 using the `utils::` namespace, removed by #896.