### PR TITLE
[enhancement] tweaks for profiling

### DIFF
--- a/apps/tests/test_lr_solver.cpp
+++ b/apps/tests/test_lr_solver.cpp
@@ -150,7 +150,7 @@ void linear_solver_executor(Simulation_context const& sctx, Hamiltonian0<double>
         linear_operator,
         preconditioner,
         X_wrap, B_wrap, U_wrap, C_wrap, // state vectors
-        1000, // iters
+        20, // iters
         tol // tol
     );
     mg.clear();
@@ -215,7 +215,8 @@ solve_lr(Simulation_context& ctx__, std::array<double, 3> vk__, Potential& pot__
     K_point<T> kp(ctx__, &vk__[0], 1.0);
     kp.initialize();
     if (mpi::Communicator::world().rank() == 0) {
-        std::cout << "num_gkvec=" << kp.num_gkvec() << "\n";
+        std::cout << "num_gkvec: " << kp.num_gkvec() << "\n";
+        std::cout << "num_bands: " << ctx__.num_bands() << "\n";
     }
     for (int i = 0; i < ctx__.num_bands(); i++) {
         kp.band_occupancy(i, 0, 2);

--- a/spack/packages/sirius/package.py
+++ b/spack/packages/sirius/package.py
@@ -101,6 +101,9 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     variant(
         "profiler", default=True, description="Use internal profiler to measure execution time"
     )
+    variant(
+        "nvtx", default=False, description="Use NVTX profiler"
+    )
 
     depends_on("cmake@3.23:", type="build")
     depends_on("mpi")
@@ -211,6 +214,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant(cm_label + "BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant(cm_label + "USE_FP32", "single_precision"),
             self.define_from_variant(cm_label + "USE_PROFILER", "profiler"),
+            self.define_from_variant(cm_label + "USE_NVTX", "nvtx"),
             self.define_from_variant(cm_label + "USE_WANNIER90", "wannier90"),
             self.define_from_variant("BUILD_TESTING", "tests"),
         ]

--- a/src/core/wf/wave_functions.hpp
+++ b/src/core/wf/wave_functions.hpp
@@ -81,11 +81,11 @@ axpby_gpu_double_double(int nwf__, void const* alpha__, void const* x__, int ld1
 
 void
 axpy_scatter_gpu_double_complex_double(int nwf__, void const* alpha__, void const* x__, int ld1__,
-        void const* idx__, void* y__, int ld2__, int ngv_loc__);
+        int const* idx__, void* y__, int ld2__, int ngv_loc__);
 
 void
 axpy_scatter_gpu_double_double(int nwf__, void const* alpha__, void const* x__, int ld1__,
-        void const* idx__, void* y__, int ld2__, int ngv_loc__);
+        int const* idx__, void* y__, int ld2__, int ngv_loc__);
 }
 #endif
 
@@ -1393,9 +1393,9 @@ void axpby(memory_t mem__, wf::spin_range spins__, wf::band_range br__, F const*
     }
 }
 
-template <typename T, typename F, typename G>
+template <typename T, typename F>
 void axpy_scatter(memory_t mem__, wf::spin_range spins__, F const*  alphas__,
-        Wave_functions<T> const* x__, G const* idx__, Wave_functions<T>* y__, int n__)
+        Wave_functions<T> const* x__, int const* idx__, Wave_functions<T>* y__, int n__)
 {
     PROFILE("wf::axpy_scatter");
     if (is_host_memory(mem__)) {
@@ -1426,7 +1426,7 @@ void axpy_scatter(memory_t mem__, wf::spin_range spins__, F const*  alphas__,
             mdarray<F, 1> alpha({n__}, const_cast<F*>(alphas__));
             alpha.allocate(mem__).copy_to(mem__);
 
-            mdarray<G, 1> idx({n__}, const_cast<G*>(idx__));
+            mdarray<int, 1> idx({n__}, const_cast<int*>(idx__));
             idx.allocate(mem__).copy_to(mem__);
 
             if (std::is_same<T, double>::value) {
@@ -1450,7 +1450,7 @@ template <typename T, typename F = T>
 void copy(memory_t mem__, Wave_functions<T> const& in__, wf::spin_index s_in__, wf::band_range br_in__,
           Wave_functions<F>& out__, wf::spin_index s_out__, wf::band_range br_out__)
 {
-    PROFILE("wf::copy");
+    //PROFILE("wf::copy");
     RTE_ASSERT(br_in__.size() == br_out__.size());
     if (in__.ld() != out__.ld()) {
         std::stringstream s;

--- a/src/function3d/periodic_function.hpp
+++ b/src/function3d/periodic_function.hpp
@@ -287,7 +287,7 @@ class Periodic_function
 template <typename T>
 inline T inner(Periodic_function<T> const& f__, Periodic_function<T> const& g__)
 {
-    PROFILE("sirius::inner");
+    PROFILE("sirius::inner::pf");
     if (f__.ctx().full_potential()) {
         auto result = sirius::inner_local(f__.rg(), g__.rg(),
                 [&](int ir) { return f__.ctx().theta(ir); });

--- a/src/function3d/smooth_periodic_function.hpp
+++ b/src/function3d/smooth_periodic_function.hpp
@@ -529,7 +529,7 @@ template <typename T, typename F>
 inline T
 inner(Smooth_periodic_function<T> const& f__, Smooth_periodic_function<T> const& g__, F&& theta__)
 {
-    PROFILE("sirius::inner");
+    PROFILE("sirius::inner::spf");
 
     T result_rg = inner_local(f__, g__, std::forward<F>(theta__));
     mpi::Communicator(f__.spfft().communicator()).allreduce(&result_rg, 1);

--- a/src/multi_cg/multi_cg.hpp
+++ b/src/multi_cg/multi_cg.hpp
@@ -229,7 +229,7 @@ struct Wave_functions_wrap {
     void block_axpy_scatter(std::vector<value_type> const& alphas__, Wave_functions_wrap const &y__,
             std::vector<int> const &idx__, int n__)
     {
-        wf::axpy_scatter<double, value_type, int>(mem, wf::spin_range(0), alphas__.data(), y__.x, idx__.data(), x, n__);
+        wf::axpy_scatter<double, value_type>(mem, wf::spin_range(0), alphas__.data(), y__.x, idx__.data(), x, n__);
     }
 
     void block_axpy(std::vector<value_type> const &alphas__, Wave_functions_wrap const &y__, int N__) {


### PR DESCRIPTION
 * name collision in timers is removed
 * nvtx option is added to spack recipe
 * index is int*, not anything else

 TODO: make beta-projectors stay on GPU for the entire lifetime of H(k)