### PR TITLE
Pin DLA-Future version in Spack package with some fixes and improvements

### DIFF
--- a/apps/mini_app/CMakeLists.txt
+++ b/apps/mini_app/CMakeLists.txt
@@ -7,7 +7,6 @@ if(SIRIUS_USE_VCSQNM)
   target_link_libraries (sirius.scf PRIVATE Eigen3::Eigen sirius)
 endif()
 install(TARGETS sirius.scf RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
-set_property(TARGET sirius.scf PROPERTY POSITION_INDEPENDENT_CODE OFF)
 
 # Register verification tests as well
 set(SIRIUS_SCF_LABELS cpu_serial cpu_band_parallel)

--- a/apps/nlcg/CMakeLists.txt
+++ b/apps/nlcg/CMakeLists.txt
@@ -3,7 +3,6 @@ find_package(Kokkos REQUIRED)
 target_link_libraries(sirius.nlcg PRIVATE sirius)
 target_link_libraries(sirius.nlcg PRIVATE nlcglib::nlcglib)
 target_link_libraries(sirius.nlcg PRIVATE ${KOKKOS_LIBRARIES})
-set_property(TARGET sirius.nlcg PROPERTY POSITION_INDEPENDENT_CODE OFF)
 install(TARGETS sirius.nlcg RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
 
 

--- a/apps/utils/CMakeLists.txt
+++ b/apps/utils/CMakeLists.txt
@@ -1,4 +1,3 @@
 add_executable(unit_cell_tools unit_cell_tools.cpp)
 target_link_libraries(unit_cell_tools PRIVATE sirius)
 install(TARGETS unit_cell_tools RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
-set_property(TARGET unit_cell_tools PROPERTY POSITION_INDEPENDENT_CODE OFF)

--- a/spack/packages/sirius/package.py
+++ b/spack/packages/sirius/package.py
@@ -83,7 +83,7 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
     variant("python", default=False, description="Build Python bindings")
     variant("memory_pool", default=True, description="Build with memory pool")
     variant("elpa", default=False, description="Use ELPA")
-    variant("dlaf", default=False, description="Use DLA-Future")
+    variant("dlaf", default=False, when="@develop", description="Use DLA-Future")
     variant("vdwxc", default=False, description="Enable libvdwxc support")
     variant("scalapack", default=False, description="Enable scalapack support")
     variant("magma", default=False, description="Enable MAGMA support")
@@ -147,13 +147,11 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("scalapack", when="+scalapack")
 
-    # TODO: Change version when generalised eigensolver C API is relased
-    depends_on("dla-future@master ~cuda ~rocm", when="+dlaf~cuda~rocm")
-    depends_on("dla-future@master +scalapack ~cuda~rocm", when="+dlaf+scalapack~cuda~rocm")
-    depends_on("dla-future@master +cuda", when="+dlaf+cuda")
-    depends_on("dla-future@master +rocm", when="+dlaf+rocm")
-    depends_on("dla-future@master +cuda+scalapack", when="+dlaf+cuda+scalapack")
-    depends_on("dla-future@master +rocm+scalapack", when="+dlaf+rocm+scalapack")
+    with when("+dlaf"):
+        depends_on("dla-future@0.3.0:")
+        depends_on("dla-future +scalapack", when="+scalapack")
+        depends_on("dla-future +cuda", when="+cuda")
+        depends_on("dla-future +rocm", when="+rocm")
 
     depends_on("rocblas", when="+rocm")
     depends_on("rocsolver", when="@7.5.0: +rocm")
@@ -203,15 +201,16 @@ class Sirius(CMakePackage, CudaPackage, ROCmPackage):
             self.define_from_variant(cm_label + "USE_VDWXC", "vdwxc"),
             self.define_from_variant(cm_label + "USE_MEMORY_POOL", "memory_pool"),
             self.define_from_variant(cm_label + "USE_SCALAPACK", "scalapack"),
+            self.define_from_variant(cm_label + "USE_DLAF", "dlaf"),
             self.define_from_variant(cm_label + "CREATE_FORTRAN_BINDINGS", "fortran"),
             self.define_from_variant(cm_label + "CREATE_PYTHON_MODULE", "python"),
             self.define_from_variant(cm_label + "USE_CUDA", "cuda"),
             self.define_from_variant(cm_label + "USE_ROCM", "rocm"),
             self.define_from_variant(cm_label + "BUILD_APPS", "apps"),
-            self.define_from_variant(cm_label + "BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant(cm_label + "USE_FP32", "single_precision"),
             self.define_from_variant(cm_label + "USE_PROFILER", "profiler"),
             self.define_from_variant(cm_label + "USE_WANNIER90", "wannier90"),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define_from_variant("BUILD_TESTING", "tests"),
         ]
 

--- a/spack/repo.yaml
+++ b/spack/repo.yaml
@@ -1,2 +1,2 @@
 repo:
-  namespace: sirius
+  namespace: sirius-repo


### PR DESCRIPTION
* Pin DLA-Future to freshly released version `0.3.0`

Improvements
* Enable `dlaf` variant only with `@develop`
* Change repo name from `sirius` to `sirius-repo` to avoid confusion with package name

Fixes:
* Add `SIRIUS_USE_DLAF` so that `spack install sirius+dlaf` actually works
  * Previously I only used the package to manage dependencies, so I missed this
* Remove `SIRIUS_` prefix from `BUILD_SHARED_LIBS`

`pika+cuda` sets `INTERFACE_POSITION_INDEPENDENT_CODE=ON`, therefore it is incompatible with the hard-coded `PISITION_INDEPENEDENT_CODE=OFF` in some of the apps/utils. I removed this constraint, but I'm not sure why it was there in the first place.