### PR TITLE
fix compilation error for ~memory_pool+tests

### DIFF
--- a/src/core/memory.hpp
+++ b/src/core/memory.hpp
@@ -361,7 +361,7 @@ class memory_pool
 
         return static_cast<T*>(memory_pool_allocator_.allocate(num_elements__ * sizeof(T)));
 #else
-        return allocate<T>(num_elements__, M_);
+        return sirius::allocate<T>(num_elements__, M_);
 #endif
     }
 


### PR DESCRIPTION
`test_mempool.cpp` failed to compile when the memory pool was disabled:
```
    /// Return a pointer to a memory block for n elements of type T.
    template <typename T>
    T*
    allocate(size_t num_elements__)
    {
#if defined(SIRIUS_USE_MEMORY_POOL)
        if (M_ == memory_t::none) {
            return nullptr;
        }

        return static_cast<T*>(memory_pool_allocator_.allocate(num_elements__ * sizeof(T)));
#else
        return sirius::allocate<T>(num_elements__, M_);
#endif
    }
```
Not quite clear to me why it `allocate<T>(size_t , memory_t)` from https://github.com/electronic-structure/SIRIUS/blob/develop/src/core/memory.hpp#L169 was not considered. Adding `sirius::` fixed it.

```
  1338    In file included from /home/simon/work/SIRIUS--wt-develop/apps/unit_tests/test_mempool.cpp:
             2:
     1339    /home/simon/work/SIRIUS--wt-develop/src/core/memory.hpp: In instantiation of 'T* sirius::me
             mory_pool::allocate(size_t) [with T = std::complex<double>; size_t = long unsigned int]':
     1340    /home/simon/work/SIRIUS--wt-develop/apps/unit_tests/test_mempool.cpp:14:50:   required from
              here
  >> 1341    /home/simon/work/SIRIUS--wt-develop/src/core/memory.hpp:364:27: error: no matching function
              for call to 'sirius::memory_pool::allocate<std::complex<double> >(size_t&, sirius::memory_
             t&)'
     1342      364 |         return allocate<T>(num_elements__, M_);
     1343          |                ~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~
     1344    /home/simon/work/SIRIUS--wt-develop/src/core/memory.hpp:355:5: note: candidate: 'template<c
             lass T> T* sirius::memory_pool::allocate(size_t)'
     1345      355 |     allocate(size_t num_elements__)
     1346          |     ^~~~~~~~
     1347    /home/simon/work/SIRIUS--wt-develop/src/core/memory.hpp:355:5: note:   candidate expects 1 
             argument, 2 provided
     1348    /home/simon/work/SIRIUS--wt-develop/src/core/memory.hpp: In instantiation of 'T* sirius::me
             mory_pool::allocate(size_t) [with T = double; size_t = long unsigned int]':
     1349    /home/simon/work/SIRIUS--wt-develop/apps/unit_tests/test_mempool.cpp:49:46:   required from
              here
```