### PR TITLE
[feature] control muffin-tin lapw radii from the main input file

### DIFF
--- a/src/context/config.hpp
+++ b/src/context/config.hpp
@@ -399,6 +399,12 @@ class config_t
             nlohmann::json::json_pointer p("/unit_cell/atom_files");
             return dict_.at(p / label__).get<std::string>();
         }
+        /// Mapping between atom type labels and muffin-tin radii (LAPW only)
+        inline auto atom_type_rmt(std::string label__) const
+        {
+            nlohmann::json::json_pointer p("/unit_cell/atom_type_rmt");
+            return dict_.at(p / label__).get<double>();
+        }
         /// Atomic coordinates
         inline auto atoms(std::string label__) const
         {

--- a/src/context/input_schema.json
+++ b/src/context/input_schema.json
@@ -224,6 +224,17 @@
                     },
                     "additionalProperties": false
                 },
+                "atom_type_rmt": {
+                    "type": "object",
+                    "title": "Mapping between atom type labels and muffin-tin radii (LAPW only)",
+                    "default": {},
+                    "patternProperties": {
+                        ".*": {
+                            "type": "number"
+                        }
+                    },
+                    "additionalProperties": false
+                },
                 "atoms": {
                     "type": "object",
                     "title": "Atomic coordinates",

--- a/src/context/simulation_parameters.cpp
+++ b/src/context/simulation_parameters.cpp
@@ -60,7 +60,7 @@ compose_default_json(nlohmann::json const& schema__, nlohmann::json& output__)
             if (it.value().contains("default")) {
                 output__[key] = it.value()["default"];
             }
-        } else { /* otherwise continue to traverse the shcema */
+        } else { /* otherwise continue to traverse the schema */
             if (!output__.contains(key)) {
                 output__[key] = nlohmann::json{};
             }
@@ -98,12 +98,13 @@ compose_json(nlohmann::json const& schema__, nlohmann::json const& in__, nlohman
                 /* copy the new input */
                 inout__[key] = in__[key];
             }
-        } else { /* otherwise continue to traverse the shcema */
+        } else { /* otherwise continue to traverse the schema */
+            /* not simple data type : a section with parameter, a dictionary map, etc.*/
             if (it.value().contains("properties")) {
                 compose_json(it.value()["properties"], in__.contains(key) ? in__[key] : nlohmann::json{}, inout__[key]);
             } else if (in__.contains(key)) {
                 inout__[key] = in__[key];
-            } else {
+            } else if (!inout__.contains(key)) {
                 inout__[key] = nlohmann::json();
             }
         }
@@ -136,7 +137,7 @@ nlohmann::json const&
 get_options_dictionary()
 {
     if (input_schema.size() == 0) {
-        throw std::runtime_error("Dictionary not initialized\n");
+        RTE_THROW("Dictionary not initialized");
     }
     return input_schema;
 }
@@ -146,7 +147,7 @@ nlohmann::json const&
 get_section_options(std::string const& section__)
 {
     if (input_schema.size() == 0) {
-        throw std::runtime_error("Dictionary not initialized\n");
+        RTE_THROW("Dictionary not initialized");
     }
     return input_schema["properties"][section__]["properties"];
 }

--- a/src/unit_cell/atom_type.cpp
+++ b/src/unit_cell/atom_type.cpp
@@ -143,7 +143,6 @@ Atom_type::init()
 
     if (!parameters_.full_potential()) {
         RTE_ASSERT(mt_radial_basis_size() == num_beta_radial_functions());
-        // RTE_ASSERT(lmax_beta() == indexr1().lmax());
     }
 
     /* get number of valence electrons */
@@ -725,6 +724,11 @@ Atom_type::read_input(std::string const& str__)
         zn_             = parser["number"].get<int>();
         double r0       = parser["rmin"].get<double>();
         double R        = parser["rmt"].get<double>();
+        try { /* overwrite the muffin-tin radius with the value from the inpupt */
+            R = parameters_.cfg().unit_cell().atom_type_rmt(label_);
+        } catch (...) {
+        }
+
         int nmtp        = parser["nrmt"].get<int>();
         this->lmax_apw_ = parser.value("lmax_apw", this->lmax_apw_);
 

--- a/src/unit_cell/atom_type.cpp
+++ b/src/unit_cell/atom_type.cpp
@@ -718,12 +718,12 @@ Atom_type::read_input(std::string const& str__)
     }
 
     if (parameters_.full_potential()) {
-        name_           = parser["name"].get<std::string>();
-        symbol_         = parser["symbol"].get<std::string>();
-        mass_           = parser["mass"].get<double>();
-        zn_             = parser["number"].get<int>();
-        double r0       = parser["rmin"].get<double>();
-        double R        = parser["rmt"].get<double>();
+        name_     = parser["name"].get<std::string>();
+        symbol_   = parser["symbol"].get<std::string>();
+        mass_     = parser["mass"].get<double>();
+        zn_       = parser["number"].get<int>();
+        double r0 = parser["rmin"].get<double>();
+        double R  = parser["rmt"].get<double>();
         try { /* overwrite the muffin-tin radius with the value from the inpupt */
             R = parameters_.cfg().unit_cell().atom_type_rmt(label_);
         } catch (...) {


### PR DESCRIPTION
For the LAPW project we need a mechanism to control muffin-tin radii using input file and not be limited by the speciec file only. Introduce `atom_type_rmt` key-value dictionary in the `unit_cell` section. Key is the speciec label. 