### PR TITLE
[fix] missing includes

### DIFF
--- a/src/core/math_tools.hpp
+++ b/src/core/math_tools.hpp
@@ -25,6 +25,11 @@
 #ifndef __MATH_TOOLS_HPP__
 #define __MATH_TOOLS_HPP__
 
+#include <cmath>
+#include <complex>
+#include <iomanip>
+#include "core/rte/rte.hpp"
+
 namespace sirius {
 
 inline auto


### PR DESCRIPTION
recently added `math_tools.hpp` didn't compile with gcc12.