### PR TITLE
[fix] performace of symmetrize_mt_function()

### DIFF
--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -815,7 +815,7 @@ Simulation_context::update()
     unit_cell().update();
 
     /* cache rotation symmetry matrices */
-    int lmax = this->full_potential() ? std::max(this->lmax_pot(), this->lmax_rho()) : 2 * this->unit_cell().lmax();
+    int lmax  = this->full_potential() ? std::max(this->lmax_pot(), this->lmax_rho()) : 2 * this->unit_cell().lmax();
     int lmmax = sf::lmmax(lmax);
     rotm_.resize(this->unit_cell().symmetry().size());
     /* loop over crystal symmetries */
@@ -824,7 +824,7 @@ Simulation_context::update()
         rotm_[i] = mdarray<double, 2>({lmmax, lmmax});
         /* compute Rlm rotation matrix */
         sht::rotation_matrix(lmax, this->unit_cell().symmetry()[i].spg_op.euler_angles,
-                this->unit_cell().symmetry()[i].spg_op.proper, rotm_[i]);
+                             this->unit_cell().symmetry()[i].spg_op.proper, rotm_[i]);
     }
 
     /* get new reciprocal vector */

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -478,6 +478,22 @@ Simulation_context::initialize()
     /* set the smearing */
     smearing(cfg().parameters().smearing());
 
+    /* create auxiliary mpi grid for symmetrization */
+    auto make_mpi_grid_mt_sym = [](int na, int np) {
+        std::vector<int> result;
+        for (int ia = 1; ia <= na; ia++) {
+            if (na % ia == 0 && np % ia == 0) {
+                result = std::vector<int>({ia, np / ia});
+            }
+        }
+        return result;
+    };
+
+    for (int ic = 0; ic < unit_cell().num_atom_symmetry_classes(); ic++) {
+        auto r = make_mpi_grid_mt_sym(unit_cell().atom_symmetry_class(ic).num_atoms(), this->comm().size());
+        mpi_grid_mt_sym_.push_back(std::make_unique<mpi::Grid>(r, this->comm()));
+    }
+
     /* create G-vectors on the first call to update() */
     update();
 
@@ -505,21 +521,6 @@ Simulation_context::initialize()
              << "   | " << std::setw(6) << blacs_grid().comm().rank() << std::setw(6) << blacs_grid().comm_row().rank()
              << std::setw(6) << blacs_grid().comm_col().rank() << std::endl;
         rte::ostream(this->out(), "info") << pout.flush(0);
-    }
-
-    auto make_mpi_grid_mt_sym = [](int na, int np) {
-        std::vector<int> result;
-        for (int ia = 1; ia <= na; ia++) {
-            if (na % ia == 0 && np % ia == 0) {
-                result = std::vector<int>({ia, np / ia});
-            }
-        }
-        return result;
-    };
-
-    for (int ic = 0; ic < unit_cell().num_atom_symmetry_classes(); ic++) {
-        auto r = make_mpi_grid_mt_sym(unit_cell().atom_symmetry_class(ic).num_atoms(), this->comm().size());
-        mpi_grid_mt_sym_.push_back(std::make_unique<mpi::Grid>(r, this->comm()));
     }
 
     initialized_ = true;
@@ -812,6 +813,19 @@ Simulation_context::update()
 
     /* update unit cell (reciprocal lattice, etc.) */
     unit_cell().update();
+
+    /* cache rotation symmetry matrices */
+    int lmax = this->full_potential() ? std::max(this->lmax_pot(), this->lmax_rho()) : 2 * this->unit_cell().lmax();
+    int lmmax = sf::lmmax(lmax);
+    rotm_.resize(this->unit_cell().symmetry().size());
+    /* loop over crystal symmetries */
+    #pragma omp parallel for
+    for (int i = 0; i < this->unit_cell().symmetry().size(); i++) {
+        rotm_[i] = mdarray<double, 2>({lmmax, lmmax});
+        /* compute Rlm rotation matrix */
+        sht::rotation_matrix(lmax, this->unit_cell().symmetry()[i].spg_op.euler_angles,
+                this->unit_cell().symmetry()[i].spg_op.proper, rotm_[i]);
+    }
 
     /* get new reciprocal vector */
     auto rlv = unit_cell().reciprocal_lattice_vectors();

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -490,8 +490,12 @@ Simulation_context::initialize()
     };
 
     for (int ic = 0; ic < unit_cell().num_atom_symmetry_classes(); ic++) {
-        auto r = make_mpi_grid_mt_sym(unit_cell().atom_symmetry_class(ic).num_atoms(), this->comm().size());
-        mpi_grid_mt_sym_.push_back(std::make_unique<mpi::Grid>(r, this->comm()));
+        if (this->full_potential() || unit_cell().atom_symmetry_class(ic).atom_type().is_paw()) {
+            auto r = make_mpi_grid_mt_sym(unit_cell().atom_symmetry_class(ic).num_atoms(), this->comm().size());
+            mpi_grid_mt_sym_.push_back(std::make_unique<mpi::Grid>(r, this->comm()));
+        } else {
+            mpi_grid_mt_sym_.push_back(nullptr);
+        }
     }
 
     /* create G-vectors on the first call to update() */

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -507,6 +507,21 @@ Simulation_context::initialize()
         rte::ostream(this->out(), "info") << pout.flush(0);
     }
 
+    auto make_mpi_grid_mt_sym = [](int na, int np) {
+        std::vector<int> result;
+        for (int ia = 1; ia <= na; ia++) {
+            if (na % ia == 0 && np % ia == 0) {
+                result = std::vector<int>({ia, np / ia});
+            }
+        }
+        return result;
+    };
+
+    for (int ic = 0; ic < unit_cell().num_atom_symmetry_classes(); ic++) {
+        auto r = make_mpi_grid_mt_sym(unit_cell().atom_symmetry_class(ic).num_atoms(), this->comm().size());
+        mpi_grid_mt_sym_.push_back(std::make_unique<mpi::Grid>(r, this->comm()));
+    }
+
     initialized_ = true;
     cfg().lock();
 }

--- a/src/context/simulation_context.hpp
+++ b/src/context/simulation_context.hpp
@@ -286,7 +286,9 @@ class Simulation_context : public Simulation_parameters
     radial_integrals_t ri_;
 
     /// MPI grid for muffin-tin symmetrization.
+    /** MPI grid is defined for each atom symmetry class */
     std::vector<std::unique_ptr<mpi::Grid>> mpi_grid_mt_sym_;
+    std::vector<mdarray<double, 2>> rotm_;
 
     mutable double evp_work_count_{0};
     mutable int num_loc_op_applied_{0};
@@ -854,6 +856,12 @@ class Simulation_context : public Simulation_parameters
     mpi_grid_mt_sym(int ic__) const
     {
         return *mpi_grid_mt_sym_[ic__];
+    }
+
+    inline auto const&
+    rotm() const
+    {
+        return rotm_;
     }
 };
 

--- a/src/context/simulation_context.hpp
+++ b/src/context/simulation_context.hpp
@@ -288,6 +288,8 @@ class Simulation_context : public Simulation_parameters
     /// MPI grid for muffin-tin symmetrization.
     /** MPI grid is defined for each atom symmetry class */
     std::vector<std::unique_ptr<mpi::Grid>> mpi_grid_mt_sym_;
+
+    /// Rotation matrices for real spherical harmonics.
     std::vector<mdarray<double, 2>> rotm_;
 
     mutable double evp_work_count_{0};
@@ -853,9 +855,9 @@ class Simulation_context : public Simulation_parameters
     }
 
     inline auto const&
-    mpi_grid_mt_sym(int ic__) const
+    mpi_grid_mt_sym() const
     {
-        return *mpi_grid_mt_sym_[ic__];
+        return mpi_grid_mt_sym_;
     }
 
     inline auto const&

--- a/src/context/simulation_context.hpp
+++ b/src/context/simulation_context.hpp
@@ -285,6 +285,9 @@ class Simulation_context : public Simulation_parameters
     /// Stores all radial integrals.
     radial_integrals_t ri_;
 
+    /// MPI grid for muffin-tin symmetrization.
+    std::vector<std::unique_ptr<mpi::Grid>> mpi_grid_mt_sym_;
+
     mutable double evp_work_count_{0};
     mutable int num_loc_op_applied_{0};
     /// Total number of iterative solver steps.
@@ -845,6 +848,12 @@ class Simulation_context : public Simulation_parameters
             ptr = &pf_ext_ptr.at(label__);
         }
         return ptr;
+    }
+
+    inline auto const&
+    mpi_grid_mt_sym(int ic__) const
+    {
+        return *mpi_grid_mt_sym_[ic__];
     }
 };
 

--- a/src/density/density.cpp
+++ b/src/density/density.cpp
@@ -416,6 +416,10 @@ Density::initial_density_full_pot()
                 }
             }
         }
+        /* synchronize muffin-tin part */
+        for (int iv = 0; iv < ctx_.num_mag_dims(); iv++) {
+            this->component(1 + iv).mt().sync(ctx_.unit_cell().spl_num_atoms());
+        }
     }
 }
 

--- a/src/density/density.hpp
+++ b/src/density/density.hpp
@@ -70,7 +70,7 @@ inline auto
 get_rho_up_dn(int num_mag_dims__, double rho__, r3::vector<double> mag__)
 {
     if (rho__ < 0.0) {
-        return std::pair<double, double>(0.0, 0.0);
+        return std::make_pair<double, double>(0.0, 0.0);
     }
 
     double mag{0};

--- a/src/function3d/spheric_function_set.hpp
+++ b/src/function3d/spheric_function_set.hpp
@@ -33,7 +33,7 @@ class Spheric_function_set
     std::vector<Spheric_function<function_domain_t::spectral, T>> func_;
     /// Store lmax function.
     std::vector<int> lmax_;
-    /// True if atom index is not split between MPI ranks.
+    /// True if atoms of the unit cell are included (this is normal LAPW case).
     bool all_atoms_{false};
 
     void

--- a/src/function3d/spheric_function_set.hpp
+++ b/src/function3d/spheric_function_set.hpp
@@ -33,8 +33,6 @@ class Spheric_function_set
     std::vector<Spheric_function<function_domain_t::spectral, T>> func_;
     /// Store lmax function.
     std::vector<int> lmax_;
-    /// True if atoms of the unit cell are included (this is normal LAPW case).
-    bool all_atoms_{false};
 
     void
     init(std::function<lmax_t(int)> lmax__, spheric_function_set_ptr_t<T> const* sptr__ = nullptr)
@@ -80,7 +78,6 @@ class Spheric_function_set
         : unit_cell_{&unit_cell__}
         , label_{label__}
         , spl_atoms_{spl_atoms__}
-        , all_atoms_{true}
     {
         atoms_.resize(unit_cell__.num_atoms());
         std::iota(atoms_.begin(), atoms_.end(), 0);
@@ -99,7 +96,6 @@ class Spheric_function_set
         , label_{label__}
         , atoms_{atoms__}
         , spl_atoms_{spl_atoms__}
-        , all_atoms_{false}
     {
         if (spl_atoms_) {
             if (spl_atoms_->size() != static_cast<int>(atoms__.size())) {

--- a/src/function3d/spheric_function_set.hpp
+++ b/src/function3d/spheric_function_set.hpp
@@ -24,13 +24,16 @@ class Spheric_function_set
     /// Text label of the function set.
     std::string label_;
     /// List of atoms for which the spherical expansion is defined.
+    /** Global atom index in the range [0, unit_cell.num_atoms()) is stored here. */
     std::vector<int> atoms_;
     /// Split the number of atoms between MPI ranks.
     /** If the pointer is null, spheric functions set is treated as global, without MPI distribution */
     splindex_block<I> const* spl_atoms_{nullptr};
     /// List of spheric functions.
     std::vector<Spheric_function<function_domain_t::spectral, T>> func_;
-
+    /// Store lmax function.
+    std::function<lmax_t(int)> lmax_;
+    /// True if atom index is not split between MPI ranks.
     bool all_atoms_{false};
 
     void
@@ -72,6 +75,7 @@ class Spheric_function_set
         : unit_cell_{&unit_cell__}
         , label_{label__}
         , spl_atoms_{spl_atoms__}
+        , lmax_{lmax__}
         , all_atoms_{true}
     {
         atoms_.resize(unit_cell__.num_atoms());
@@ -91,6 +95,7 @@ class Spheric_function_set
         , label_{label__}
         , atoms_{atoms__}
         , spl_atoms_{spl_atoms__}
+        , lmax_{lmax__}
         , all_atoms_{false}
     {
         if (spl_atoms_) {
@@ -135,6 +140,12 @@ class Spheric_function_set
                 }
             }
         }
+    }
+
+    inline int
+    lmax(int ia__) const
+    {
+        return lmax_(ia__);
     }
 
     /// Synchronize global function.

--- a/src/function3d/spheric_function_set.hpp
+++ b/src/function3d/spheric_function_set.hpp
@@ -32,7 +32,7 @@ class Spheric_function_set
     /// List of spheric functions.
     std::vector<Spheric_function<function_domain_t::spectral, T>> func_;
     /// Store lmax function.
-    std::function<lmax_t(int)> lmax_;
+    std::vector<int> lmax_;
     /// True if atom index is not split between MPI ranks.
     bool all_atoms_{false};
 
@@ -40,6 +40,11 @@ class Spheric_function_set
     init(std::function<lmax_t(int)> lmax__, spheric_function_set_ptr_t<T> const* sptr__ = nullptr)
     {
         func_.resize(unit_cell_->num_atoms());
+
+        lmax_.resize(unit_cell_->num_atoms());
+        for (int ia = 0; ia < unit_cell_->num_atoms(); ia++) {
+            lmax_[ia] = lmax__(ia);
+        }
 
         auto set_func = [&](int ia) {
             if (sptr__) {
@@ -75,7 +80,6 @@ class Spheric_function_set
         : unit_cell_{&unit_cell__}
         , label_{label__}
         , spl_atoms_{spl_atoms__}
-        , lmax_{lmax__}
         , all_atoms_{true}
     {
         atoms_.resize(unit_cell__.num_atoms());
@@ -95,7 +99,6 @@ class Spheric_function_set
         , label_{label__}
         , atoms_{atoms__}
         , spl_atoms_{spl_atoms__}
-        , lmax_{lmax__}
         , all_atoms_{false}
     {
         if (spl_atoms_) {
@@ -145,7 +148,7 @@ class Spheric_function_set
     inline int
     lmax(int ia__) const
     {
-        return lmax_(ia__);
+        return lmax_[ia__];
     }
 
     /// Synchronize global function.

--- a/src/potential/paw_potential.cpp
+++ b/src/potential/paw_potential.cpp
@@ -71,20 +71,24 @@ Potential::generate_PAW_effective_potential(Density const& density)
         ae_comp.push_back(&paw_potential_->ae_component(j));
         ps_comp.push_back(&paw_potential_->ps_component(j));
     }
-    sirius::symmetrize_mt_function(unit_cell_.symmetry(), unit_cell_.comm(), ctx_.num_mag_dims(), ae_comp);
-    sirius::symmetrize_mt_function(unit_cell_.symmetry(), unit_cell_.comm(), ctx_.num_mag_dims(), ps_comp);
+    //sirius::symmetrize_mt_function(unit_cell_.symmetry(), unit_cell_.comm(), ctx_.num_mag_dims(), ae_comp);
+    //sirius::symmetrize_mt_function(unit_cell_.symmetry(), unit_cell_.comm(), ctx_.num_mag_dims(), ps_comp);
+    sirius::symmetrize_mt_function(unit_cell_, ctx_.rotm(), ctx_.mpi_grid_mt_sym(), ctx_.num_mag_dims(), ae_comp);
+    sirius::symmetrize_mt_function(unit_cell_, ctx_.rotm(), ctx_.mpi_grid_mt_sym(), ctx_.num_mag_dims(), ps_comp);
 
     /* symmetrize ae- component of Exc */
     paw_ae_exc_->sync(unit_cell_.spl_num_paw_atoms());
     ae_comp.clear();
     ae_comp.push_back(paw_ae_exc_.get());
-    sirius::symmetrize_mt_function(unit_cell_.symmetry(), unit_cell_.comm(), 0, ae_comp);
+    //sirius::symmetrize_mt_function(unit_cell_.symmetry(), unit_cell_.comm(), 0, ae_comp);
+    sirius::symmetrize_mt_function(unit_cell_, ctx_.rotm(), ctx_.mpi_grid_mt_sym(), 0, ae_comp);
 
     /* symmetrize ps- component of Exc */
     paw_ps_exc_->sync(unit_cell_.spl_num_paw_atoms());
     ps_comp.clear();
     ps_comp.push_back(paw_ps_exc_.get());
-    sirius::symmetrize_mt_function(unit_cell_.symmetry(), unit_cell_.comm(), 0, ps_comp);
+    //sirius::symmetrize_mt_function(unit_cell_.symmetry(), unit_cell_.comm(), 0, ps_comp);
+    sirius::symmetrize_mt_function(unit_cell_, ctx_.rotm(), ctx_.mpi_grid_mt_sym(), 0, ps_comp);
 
     /* calculate PAW Dij matrix */
     #pragma omp parallel for

--- a/src/potential/paw_potential.cpp
+++ b/src/potential/paw_potential.cpp
@@ -71,8 +71,6 @@ Potential::generate_PAW_effective_potential(Density const& density)
         ae_comp.push_back(&paw_potential_->ae_component(j));
         ps_comp.push_back(&paw_potential_->ps_component(j));
     }
-    //sirius::symmetrize_mt_function(unit_cell_.symmetry(), unit_cell_.comm(), ctx_.num_mag_dims(), ae_comp);
-    //sirius::symmetrize_mt_function(unit_cell_.symmetry(), unit_cell_.comm(), ctx_.num_mag_dims(), ps_comp);
     sirius::symmetrize_mt_function(unit_cell_, ctx_.rotm(), ctx_.mpi_grid_mt_sym(), ctx_.num_mag_dims(), ae_comp);
     sirius::symmetrize_mt_function(unit_cell_, ctx_.rotm(), ctx_.mpi_grid_mt_sym(), ctx_.num_mag_dims(), ps_comp);
 
@@ -80,14 +78,12 @@ Potential::generate_PAW_effective_potential(Density const& density)
     paw_ae_exc_->sync(unit_cell_.spl_num_paw_atoms());
     ae_comp.clear();
     ae_comp.push_back(paw_ae_exc_.get());
-    //sirius::symmetrize_mt_function(unit_cell_.symmetry(), unit_cell_.comm(), 0, ae_comp);
     sirius::symmetrize_mt_function(unit_cell_, ctx_.rotm(), ctx_.mpi_grid_mt_sym(), 0, ae_comp);
 
     /* symmetrize ps- component of Exc */
     paw_ps_exc_->sync(unit_cell_.spl_num_paw_atoms());
     ps_comp.clear();
     ps_comp.push_back(paw_ps_exc_.get());
-    //sirius::symmetrize_mt_function(unit_cell_.symmetry(), unit_cell_.comm(), 0, ps_comp);
     sirius::symmetrize_mt_function(unit_cell_, ctx_.rotm(), ctx_.mpi_grid_mt_sym(), 0, ps_comp);
 
     /* calculate PAW Dij matrix */

--- a/src/symmetry/symmetrize_field4d.hpp
+++ b/src/symmetry/symmetrize_field4d.hpp
@@ -35,13 +35,8 @@ symmetrize_field4d(Field4D& f__)
                            f__.pw_components());
 
     if (ctx.full_potential()) {
-         symmetrize_mt_function(ctx.unit_cell(), ctx.rotm(), ctx.mpi_grid_mt_sym(), ctx.num_mag_dims(),
-                 f__.mt_components());
-        // symmetrize_mt_function(ctx.unit_cell().symmetry(), ctx.comm(), ctx.num_mag_dims(), f__.mt_components());
-        //for (int ic = 0; ic < ctx.unit_cell().num_atom_symmetry_classes(); ic++) {
-        //    symmetrize_mt_function(ctx.unit_cell().symmetry(), ctx.rotm(), ctx.unit_cell().atom_symmetry_class(ic),
-        //                           ctx.mpi_grid_mt_sym(ic), ctx.num_mag_dims(), f__.mt_components());
-        //}
+        symmetrize_mt_function(ctx.unit_cell(), ctx.rotm(), ctx.mpi_grid_mt_sym(), ctx.num_mag_dims(),
+                               f__.mt_components());
     }
 }
 

--- a/src/symmetry/symmetrize_field4d.hpp
+++ b/src/symmetry/symmetrize_field4d.hpp
@@ -35,11 +35,13 @@ symmetrize_field4d(Field4D& f__)
                            f__.pw_components());
 
     if (ctx.full_potential()) {
+         symmetrize_mt_function(ctx.unit_cell(), ctx.rotm(), ctx.mpi_grid_mt_sym(), ctx.num_mag_dims(),
+                 f__.mt_components());
         // symmetrize_mt_function(ctx.unit_cell().symmetry(), ctx.comm(), ctx.num_mag_dims(), f__.mt_components());
-        for (int ic = 0; ic < ctx.unit_cell().num_atom_symmetry_classes(); ic++) {
-            symmetrize_mt_function(ctx.unit_cell().symmetry(), ctx.rotm(), ctx.unit_cell().atom_symmetry_class(ic),
-                                   ctx.mpi_grid_mt_sym(ic), ctx.num_mag_dims(), f__.mt_components());
-        }
+        //for (int ic = 0; ic < ctx.unit_cell().num_atom_symmetry_classes(); ic++) {
+        //    symmetrize_mt_function(ctx.unit_cell().symmetry(), ctx.rotm(), ctx.unit_cell().atom_symmetry_class(ic),
+        //                           ctx.mpi_grid_mt_sym(ic), ctx.num_mag_dims(), f__.mt_components());
+        //}
     }
 }
 

--- a/src/symmetry/symmetrize_field4d.hpp
+++ b/src/symmetry/symmetrize_field4d.hpp
@@ -37,7 +37,7 @@ symmetrize_field4d(Field4D& f__)
     if (ctx.full_potential()) {
         //symmetrize_mt_function(ctx.unit_cell().symmetry(), ctx.comm(), ctx.num_mag_dims(), f__.mt_components());
         for (int ic = 0; ic < ctx.unit_cell().num_atom_symmetry_classes(); ic++) {
-            symmetrize_mt_function(ctx.unit_cell().symmetry(), ctx.unit_cell().atom_symmetry_class(ic), 
+            symmetrize_mt_function(ctx.unit_cell().symmetry(), ctx.rotm(), ctx.unit_cell().atom_symmetry_class(ic),
                     ctx.mpi_grid_mt_sym(ic), ctx.num_mag_dims(), f__.mt_components());
         }
     }

--- a/src/symmetry/symmetrize_field4d.hpp
+++ b/src/symmetry/symmetrize_field4d.hpp
@@ -35,7 +35,11 @@ symmetrize_field4d(Field4D& f__)
                            f__.pw_components());
 
     if (ctx.full_potential()) {
-        symmetrize_mt_function(ctx.unit_cell().symmetry(), ctx.comm(), ctx.num_mag_dims(), f__.mt_components());
+        //symmetrize_mt_function(ctx.unit_cell().symmetry(), ctx.comm(), ctx.num_mag_dims(), f__.mt_components());
+        for (int ic = 0; ic < ctx.unit_cell().num_atom_symmetry_classes(); ic++) {
+            symmetrize_mt_function(ctx.unit_cell().symmetry(), ctx.unit_cell().atom_symmetry_class(ic), 
+                    ctx.mpi_grid_mt_sym(ic), ctx.num_mag_dims(), f__.mt_components());
+        }
     }
 }
 

--- a/src/symmetry/symmetrize_field4d.hpp
+++ b/src/symmetry/symmetrize_field4d.hpp
@@ -35,10 +35,10 @@ symmetrize_field4d(Field4D& f__)
                            f__.pw_components());
 
     if (ctx.full_potential()) {
-        //symmetrize_mt_function(ctx.unit_cell().symmetry(), ctx.comm(), ctx.num_mag_dims(), f__.mt_components());
+        // symmetrize_mt_function(ctx.unit_cell().symmetry(), ctx.comm(), ctx.num_mag_dims(), f__.mt_components());
         for (int ic = 0; ic < ctx.unit_cell().num_atom_symmetry_classes(); ic++) {
             symmetrize_mt_function(ctx.unit_cell().symmetry(), ctx.rotm(), ctx.unit_cell().atom_symmetry_class(ic),
-                    ctx.mpi_grid_mt_sym(ic), ctx.num_mag_dims(), f__.mt_components());
+                                   ctx.mpi_grid_mt_sym(ic), ctx.num_mag_dims(), f__.mt_components());
         }
     }
 }

--- a/src/symmetry/symmetrize_mt_function.hpp
+++ b/src/symmetry/symmetrize_mt_function.hpp
@@ -122,6 +122,129 @@ symmetrize_mt_function(Crystal_symmetry const& sym__, mpi::Communicator const& c
     }
 }
 
+/// Symmetrize spherical expansion coefficients of the scalar and vector function for atoms of the same symmetry class.
+template <typename Index_t>
+inline void
+symmetrize_mt_function(Crystal_symmetry const& sym__, Atom_symmetry_class const& atom_class__,
+        mpi::Grid const& mpi_grid__, int num_mag_dims__, std::vector<Spheric_function_set<double, Index_t>*> frlm__)
+{
+    PROFILE("sirius::symmetrize_mt_function");
+
+    /* first (scalar) component is always available */
+    auto& frlm = *frlm__[0];
+
+    /* get lmax */
+    int lmax = frlm.lmax(atom_class__.atom_id(0));
+
+    /* compute maximum lm size */
+    int lmmax = sf::lmmax(lmax);
+
+    /* split atoms of the same class over this communicator */
+    auto& comm_a = mpi_grid__.communicator(1 << 0);
+    /* split radial grid points over this communicator */
+    auto& comm_r = mpi_grid__.communicator(1 << 1);
+
+    /* number of atoms belonging to the same symmetry class */
+    int na = atom_class__.num_atoms();
+    /* number of muffin-tin points */
+    int nr = atom_class__.atom_type().num_mt_points();
+
+    /* split atoms of a given symmetry class between MPI ranks */
+    splindex_block<Index_t> spl_atoms(na, n_blocks(comm_a.size()), block_id(comm_a.rank()));
+    /* split radial grid points */
+    splindex_block spl_rgrid(nr, n_blocks(comm_r.size()), block_id(comm_r.rank()));
+    int nr_loc = spl_rgrid.local_size();
+    int ir_loc = spl_rgrid.global_offset();
+
+    /* space for real Rlm rotation matrix */
+    mdarray<double, 2> rotm({lmmax, lmmax});
+
+    /* symmetry-transformed functions */
+    mdarray<double, 4> fsym_loc({lmmax, nr, num_mag_dims__ + 1, spl_atoms.local_size()});
+    fsym_loc.zero();
+
+    mdarray<double, 3> ftmp({lmmax, nr, num_mag_dims__ + 1});
+
+    double alpha = 1.0 / sym__.size();
+
+    if (nr_loc) {
+        /* loop over crystal symmetries */
+        for (int i = 0; i < sym__.size(); i++) {
+            /* full space-group symmetry operation is S{R|t} */
+            auto S = sym__[i].spin_rotation;
+            /* compute Rlm rotation matrix */
+            sht::rotation_matrix(lmax, sym__[i].spg_op.euler_angles, sym__[i].spg_op.proper, rotm);
+
+            for (auto it : spl_atoms) {
+                /* get global index of the atom */
+                int ia = atom_class__.atom_id(it.i);
+                int ja = sym__[i].spg_op.inv_sym_atom[ia];
+                /* apply {R|t} part of symmetry operation to all components */
+                for (int j = 0; j < num_mag_dims__ + 1; j++) {
+                    la::wrap(la::lib_t::blas)
+                            .gemm('N', 'N', lmmax, nr_loc, lmmax, &alpha, rotm.at(memory_t::host), rotm.ld(),
+                                  (*frlm__[j])[ja].at(memory_t::host, 0, ir_loc), (*frlm__[j])[ja].ld(),
+                                  &la::constant<double>::zero(), ftmp.at(memory_t::host, 0, ir_loc, j), ftmp.ld());
+                }
+                /* always symmetrize the scalar component */
+                for (int ir = 0; ir < nr_loc; ir++) {
+                    for (int lm = 0; lm < lmmax; lm++) {
+                        fsym_loc(lm, ir + ir_loc, 0, it.li) += ftmp(lm, ir + ir_loc, 0);
+                    }
+                }
+                /* apply S part to [0, 0, z] collinear vector */
+                if (num_mag_dims__ == 1) {
+                    for (int ir = 0; ir < nr_loc; ir++) {
+                        for (int lm = 0; lm < lmmax; lm++) {
+                            fsym_loc(lm, ir + ir_loc, 1, it.li) += ftmp(lm, ir + ir_loc, 1) * S(2, 2);
+                        }
+                    }
+                }
+                /* apply 3x3 S-matrix to [x, y, z] vector */
+                if (num_mag_dims__ == 3) {
+                    for (int k : {0, 1, 2}) {
+                        for (int j : {0, 1, 2}) {
+                            for (int ir = 0; ir < nr_loc; ir++) {
+                                for (int lm = 0; lm < lmmax; lm++) {
+                                    fsym_loc(lm, ir + ir_loc, 1 + k, it.li) += ftmp(lm, ir + ir_loc, 1 + j) * S(k, j);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /* gather radial grid points */
+    for (int i = 0; i < spl_atoms.local_size(); i++) {
+        for (int j = 0; j < num_mag_dims__ + 1; j++) {
+            double* sbuf = nr_loc ? fsym_loc.at(memory_t::host, 0, ir_loc, j, i) : nullptr;
+            comm_r.allgather(sbuf, lmmax * nr_loc, lmmax * ir_loc);
+        }
+    }
+
+    /* gather full function */
+    double* sbuf = spl_atoms.local_size() ? fsym_loc.at(memory_t::host) : nullptr;
+    auto ld      = lmmax * nr * (num_mag_dims__ + 1);
+
+    mdarray<double, 4> fsym_glob({lmmax, nr, num_mag_dims__ + 1, na});
+
+    comm_a.allgather(sbuf, fsym_glob.at(memory_t::host), ld * spl_atoms.local_size(), ld * spl_atoms.global_offset());
+
+    /* copy back the result */
+    for (int i = 0; i < na; i++) {
+        int ia = atom_class__.atom_id(i);
+        for (int j = 0; j < num_mag_dims__ + 1; j++) {
+            for (int ir = 0; ir < nr; ir++) {
+                for (int lm = 0; lm < lmmax; lm++) {
+                    (*frlm__[j])[ia](lm, ir) = fsym_glob(lm, ir, j, i);
+                }
+            }
+        }
+    }
+}
+
 } // namespace sirius
 
 #endif

--- a/src/symmetry/symmetrize_mt_function.hpp
+++ b/src/symmetry/symmetrize_mt_function.hpp
@@ -19,108 +19,108 @@
 
 namespace sirius {
 
-template <typename Index_t>
-inline void
-symmetrize_mt_function(Crystal_symmetry const& sym__, mpi::Communicator const& comm__, int num_mag_dims__,
-                       std::vector<Spheric_function_set<double, Index_t>*> frlm__)
-{
-    PROFILE("sirius::symmetrize_mt_function");
-
-    /* first (scalar) component is always available */
-    auto& frlm = *frlm__[0];
-
-    /* compute maximum lm size */
-    int lmmax{0};
-    for (auto ia : frlm.atoms()) {
-        lmmax = std::max(lmmax, frlm[ia].angular_domain_size());
-    }
-    int lmax = sf::lmax(lmmax);
-
-    /* split atoms between MPI ranks */
-    splindex_block<Index_t> spl_atoms(frlm.atoms().size(), n_blocks(comm__.size()), block_id(comm__.rank()));
-
-    /* space for real Rlm rotation matrix */
-    mdarray<double, 2> rotm({lmmax, lmmax});
-
-    /* symmetry-transformed functions */
-    mdarray<double, 4> fsym_loc(
-            {lmmax, frlm.unit_cell().max_num_mt_points(), num_mag_dims__ + 1, spl_atoms.local_size()});
-    fsym_loc.zero();
-
-    mdarray<double, 3> ftmp({lmmax, frlm.unit_cell().max_num_mt_points(), num_mag_dims__ + 1});
-
-    double alpha = 1.0 / sym__.size();
-
-    /* loop over crystal symmetries */
-    for (int i = 0; i < sym__.size(); i++) {
-        /* full space-group symmetry operation is S{R|t} */
-        auto S = sym__[i].spin_rotation;
-        /* compute Rlm rotation matrix */
-        sht::rotation_matrix(lmax, sym__[i].spg_op.euler_angles, sym__[i].spg_op.proper, rotm);
-
-        for (auto it : spl_atoms) {
-            /* get global index of the atom */
-            int ia       = frlm.atoms()[it.i];
-            int lmmax_ia = frlm[ia].angular_domain_size();
-            int nrmax_ia = frlm.unit_cell().atom(ia).num_mt_points();
-            int ja       = sym__[i].spg_op.inv_sym_atom[ia];
-            /* apply {R|t} part of symmetry operation to all components */
-            for (int j = 0; j < num_mag_dims__ + 1; j++) {
-                la::wrap(la::lib_t::blas)
-                        .gemm('N', 'N', lmmax_ia, nrmax_ia, lmmax_ia, &alpha, rotm.at(memory_t::host), rotm.ld(),
-                              (*frlm__[j])[ja].at(memory_t::host), (*frlm__[j])[ja].ld(), &la::constant<double>::zero(),
-                              ftmp.at(memory_t::host, 0, 0, j), ftmp.ld());
-            }
-            /* always symmetrize the scalar component */
-            for (int ir = 0; ir < nrmax_ia; ir++) {
-                for (int lm = 0; lm < lmmax_ia; lm++) {
-                    fsym_loc(lm, ir, 0, it.li) += ftmp(lm, ir, 0);
-                }
-            }
-            /* apply S part to [0, 0, z] collinear vector */
-            if (num_mag_dims__ == 1) {
-                for (int ir = 0; ir < nrmax_ia; ir++) {
-                    for (int lm = 0; lm < lmmax_ia; lm++) {
-                        fsym_loc(lm, ir, 1, it.li) += ftmp(lm, ir, 1) * S(2, 2);
-                    }
-                }
-            }
-            /* apply 3x3 S-matrix to [x, y, z] vector */
-            if (num_mag_dims__ == 3) {
-                for (int k : {0, 1, 2}) {
-                    for (int j : {0, 1, 2}) {
-                        for (int ir = 0; ir < nrmax_ia; ir++) {
-                            for (int lm = 0; lm < lmmax_ia; lm++) {
-                                fsym_loc(lm, ir, 1 + k, it.li) += ftmp(lm, ir, 1 + j) * S(k, j);
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /* gather full function */
-    double* sbuf = spl_atoms.local_size() ? fsym_loc.at(memory_t::host) : nullptr;
-    auto ld      = static_cast<int>(fsym_loc.size(0) * fsym_loc.size(1) * fsym_loc.size(2));
-
-    mdarray<double, 4> fsym_glob(
-            {lmmax, frlm.unit_cell().max_num_mt_points(), num_mag_dims__ + 1, frlm.atoms().size()});
-
-    comm__.allgather(sbuf, fsym_glob.at(memory_t::host), ld * spl_atoms.local_size(), ld * spl_atoms.global_offset());
-
-    /* copy back the result */
-    for (int i = 0; i < static_cast<int>(frlm.atoms().size()); i++) {
-        int ia = frlm.atoms()[i];
-        for (int j = 0; j < num_mag_dims__ + 1; j++) {
-            for (int ir = 0; ir < frlm.unit_cell().atom(ia).num_mt_points(); ir++) {
-                for (int lm = 0; lm < frlm[ia].angular_domain_size(); lm++) {
-                    (*frlm__[j])[ia](lm, ir) = fsym_glob(lm, ir, j, i);
-                }
-            }
-        }
-    }
-}
+//template <typename Index_t>
+//inline void
+//symmetrize_mt_function(Crystal_symmetry const& sym__, mpi::Communicator const& comm__, int num_mag_dims__,
+//                       std::vector<Spheric_function_set<double, Index_t>*> frlm__)
+//{
+//    PROFILE("sirius::symmetrize_mt_function");
+//
+//    /* first (scalar) component is always available */
+//    auto& frlm = *frlm__[0];
+//
+//    /* compute maximum lm size */
+//    int lmmax{0};
+//    for (auto ia : frlm.atoms()) {
+//        lmmax = std::max(lmmax, frlm[ia].angular_domain_size());
+//    }
+//    int lmax = sf::lmax(lmmax);
+//
+//    /* split atoms between MPI ranks */
+//    splindex_block<Index_t> spl_atoms(frlm.atoms().size(), n_blocks(comm__.size()), block_id(comm__.rank()));
+//
+//    /* space for real Rlm rotation matrix */
+//    mdarray<double, 2> rotm({lmmax, lmmax});
+//
+//    /* symmetry-transformed functions */
+//    mdarray<double, 4> fsym_loc(
+//            {lmmax, frlm.unit_cell().max_num_mt_points(), num_mag_dims__ + 1, spl_atoms.local_size()});
+//    fsym_loc.zero();
+//
+//    mdarray<double, 3> ftmp({lmmax, frlm.unit_cell().max_num_mt_points(), num_mag_dims__ + 1});
+//
+//    double alpha = 1.0 / sym__.size();
+//
+//    /* loop over crystal symmetries */
+//    for (int i = 0; i < sym__.size(); i++) {
+//        /* full space-group symmetry operation is S{R|t} */
+//        auto S = sym__[i].spin_rotation;
+//        /* compute Rlm rotation matrix */
+//        sht::rotation_matrix(lmax, sym__[i].spg_op.euler_angles, sym__[i].spg_op.proper, rotm);
+//
+//        for (auto it : spl_atoms) {
+//            /* get global index of the atom */
+//            int ia       = frlm.atoms()[it.i];
+//            int lmmax_ia = frlm[ia].angular_domain_size();
+//            int nrmax_ia = frlm.unit_cell().atom(ia).num_mt_points();
+//            int ja       = sym__[i].spg_op.inv_sym_atom[ia];
+//            /* apply {R|t} part of symmetry operation to all components */
+//            for (int j = 0; j < num_mag_dims__ + 1; j++) {
+//                la::wrap(la::lib_t::blas)
+//                        .gemm('N', 'N', lmmax_ia, nrmax_ia, lmmax_ia, &alpha, rotm.at(memory_t::host), rotm.ld(),
+//                              (*frlm__[j])[ja].at(memory_t::host), (*frlm__[j])[ja].ld(), &la::constant<double>::zero(),
+//                              ftmp.at(memory_t::host, 0, 0, j), ftmp.ld());
+//            }
+//            /* always symmetrize the scalar component */
+//            for (int ir = 0; ir < nrmax_ia; ir++) {
+//                for (int lm = 0; lm < lmmax_ia; lm++) {
+//                    fsym_loc(lm, ir, 0, it.li) += ftmp(lm, ir, 0);
+//                }
+//            }
+//            /* apply S part to [0, 0, z] collinear vector */
+//            if (num_mag_dims__ == 1) {
+//                for (int ir = 0; ir < nrmax_ia; ir++) {
+//                    for (int lm = 0; lm < lmmax_ia; lm++) {
+//                        fsym_loc(lm, ir, 1, it.li) += ftmp(lm, ir, 1) * S(2, 2);
+//                    }
+//                }
+//            }
+//            /* apply 3x3 S-matrix to [x, y, z] vector */
+//            if (num_mag_dims__ == 3) {
+//                for (int k : {0, 1, 2}) {
+//                    for (int j : {0, 1, 2}) {
+//                        for (int ir = 0; ir < nrmax_ia; ir++) {
+//                            for (int lm = 0; lm < lmmax_ia; lm++) {
+//                                fsym_loc(lm, ir, 1 + k, it.li) += ftmp(lm, ir, 1 + j) * S(k, j);
+//                            }
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//    }
+//
+//    /* gather full function */
+//    double* sbuf = spl_atoms.local_size() ? fsym_loc.at(memory_t::host) : nullptr;
+//    auto ld      = static_cast<int>(fsym_loc.size(0) * fsym_loc.size(1) * fsym_loc.size(2));
+//
+//    mdarray<double, 4> fsym_glob(
+//            {lmmax, frlm.unit_cell().max_num_mt_points(), num_mag_dims__ + 1, frlm.atoms().size()});
+//
+//    comm__.allgather(sbuf, fsym_glob.at(memory_t::host), ld * spl_atoms.local_size(), ld * spl_atoms.global_offset());
+//
+//    /* copy back the result */
+//    for (int i = 0; i < static_cast<int>(frlm.atoms().size()); i++) {
+//        int ia = frlm.atoms()[i];
+//        for (int j = 0; j < num_mag_dims__ + 1; j++) {
+//            for (int ir = 0; ir < frlm.unit_cell().atom(ia).num_mt_points(); ir++) {
+//                for (int lm = 0; lm < frlm[ia].angular_domain_size(); lm++) {
+//                    (*frlm__[j])[ia](lm, ir) = fsym_glob(lm, ir, j, i);
+//                }
+//            }
+//        }
+//    }
+//}
 
 /// Symmetrize spherical expansion coefficients of the scalar and vector function for atoms of the same symmetry class.
 template <typename Index_t>
@@ -238,6 +238,18 @@ symmetrize_mt_function(Crystal_symmetry const& sym__, std::vector<mdarray<double
                 }
             }
         }
+    }
+}
+
+template <typename Index_t>
+inline void
+symmetrize_mt_function(Unit_cell const& uc__, std::vector<mdarray<double, 2>> const& rotm__,
+                       std::vector<std::unique_ptr<mpi::Grid>> const& mpi_grid__, int num_mag_dims__,
+                       std::vector<Spheric_function_set<double, Index_t>*> frlm__)
+{
+    for (int ic = 0; ic < uc__.num_atom_symmetry_classes(); ic++) {
+        symmetrize_mt_function(uc__.symmetry(), rotm__, uc__.atom_symmetry_class(ic), *mpi_grid__[ic], num_mag_dims__,
+                frlm__);
     }
 }
 

--- a/src/symmetry/symmetrize_mt_function.hpp
+++ b/src/symmetry/symmetrize_mt_function.hpp
@@ -160,10 +160,11 @@ symmetrize_mt_function(Crystal_symmetry const& sym__, Atom_symmetry_class const&
     mdarray<double, 2> rotm({lmmax, lmmax});
 
     /* symmetry-transformed functions */
-    mdarray<double, 4> fsym_loc({lmmax, nr, num_mag_dims__ + 1, spl_atoms.local_size()});
+    mdarray<double, 4> fsym_loc({lmmax, nr, num_mag_dims__ + 1, spl_atoms.local_size()},
+            get_memory_pool(memory_t::host));
     fsym_loc.zero();
 
-    mdarray<double, 3> ftmp({lmmax, nr, num_mag_dims__ + 1});
+    mdarray<double, 3> ftmp({lmmax, nr, num_mag_dims__ + 1}, get_memory_pool(memory_t::host));
 
     double alpha = 1.0 / sym__.size();
 
@@ -219,7 +220,7 @@ symmetrize_mt_function(Crystal_symmetry const& sym__, Atom_symmetry_class const&
     /* gather radial grid points */
     for (int i = 0; i < spl_atoms.local_size(); i++) {
         for (int j = 0; j < num_mag_dims__ + 1; j++) {
-            double* sbuf = nr_loc ? fsym_loc.at(memory_t::host, 0, ir_loc, j, i) : nullptr;
+            double* sbuf = fsym_loc.at(memory_t::host, 0, 0, j, i);
             comm_r.allgather(sbuf, lmmax * nr_loc, lmmax * ir_loc);
         }
     }
@@ -228,7 +229,7 @@ symmetrize_mt_function(Crystal_symmetry const& sym__, Atom_symmetry_class const&
     double* sbuf = spl_atoms.local_size() ? fsym_loc.at(memory_t::host) : nullptr;
     auto ld      = lmmax * nr * (num_mag_dims__ + 1);
 
-    mdarray<double, 4> fsym_glob({lmmax, nr, num_mag_dims__ + 1, na});
+    mdarray<double, 4> fsym_glob({lmmax, nr, num_mag_dims__ + 1, na}, get_memory_pool(memory_t::host));
 
     comm_a.allgather(sbuf, fsym_glob.at(memory_t::host), ld * spl_atoms.local_size(), ld * spl_atoms.global_offset());
 

--- a/src/symmetry/symmetrize_mt_function.hpp
+++ b/src/symmetry/symmetrize_mt_function.hpp
@@ -19,109 +19,6 @@
 
 namespace sirius {
 
-//template <typename Index_t>
-//inline void
-//symmetrize_mt_function(Crystal_symmetry const& sym__, mpi::Communicator const& comm__, int num_mag_dims__,
-//                       std::vector<Spheric_function_set<double, Index_t>*> frlm__)
-//{
-//    PROFILE("sirius::symmetrize_mt_function");
-//
-//    /* first (scalar) component is always available */
-//    auto& frlm = *frlm__[0];
-//
-//    /* compute maximum lm size */
-//    int lmmax{0};
-//    for (auto ia : frlm.atoms()) {
-//        lmmax = std::max(lmmax, frlm[ia].angular_domain_size());
-//    }
-//    int lmax = sf::lmax(lmmax);
-//
-//    /* split atoms between MPI ranks */
-//    splindex_block<Index_t> spl_atoms(frlm.atoms().size(), n_blocks(comm__.size()), block_id(comm__.rank()));
-//
-//    /* space for real Rlm rotation matrix */
-//    mdarray<double, 2> rotm({lmmax, lmmax});
-//
-//    /* symmetry-transformed functions */
-//    mdarray<double, 4> fsym_loc(
-//            {lmmax, frlm.unit_cell().max_num_mt_points(), num_mag_dims__ + 1, spl_atoms.local_size()});
-//    fsym_loc.zero();
-//
-//    mdarray<double, 3> ftmp({lmmax, frlm.unit_cell().max_num_mt_points(), num_mag_dims__ + 1});
-//
-//    double alpha = 1.0 / sym__.size();
-//
-//    /* loop over crystal symmetries */
-//    for (int i = 0; i < sym__.size(); i++) {
-//        /* full space-group symmetry operation is S{R|t} */
-//        auto S = sym__[i].spin_rotation;
-//        /* compute Rlm rotation matrix */
-//        sht::rotation_matrix(lmax, sym__[i].spg_op.euler_angles, sym__[i].spg_op.proper, rotm);
-//
-//        for (auto it : spl_atoms) {
-//            /* get global index of the atom */
-//            int ia       = frlm.atoms()[it.i];
-//            int lmmax_ia = frlm[ia].angular_domain_size();
-//            int nrmax_ia = frlm.unit_cell().atom(ia).num_mt_points();
-//            int ja       = sym__[i].spg_op.inv_sym_atom[ia];
-//            /* apply {R|t} part of symmetry operation to all components */
-//            for (int j = 0; j < num_mag_dims__ + 1; j++) {
-//                la::wrap(la::lib_t::blas)
-//                        .gemm('N', 'N', lmmax_ia, nrmax_ia, lmmax_ia, &alpha, rotm.at(memory_t::host), rotm.ld(),
-//                              (*frlm__[j])[ja].at(memory_t::host), (*frlm__[j])[ja].ld(), &la::constant<double>::zero(),
-//                              ftmp.at(memory_t::host, 0, 0, j), ftmp.ld());
-//            }
-//            /* always symmetrize the scalar component */
-//            for (int ir = 0; ir < nrmax_ia; ir++) {
-//                for (int lm = 0; lm < lmmax_ia; lm++) {
-//                    fsym_loc(lm, ir, 0, it.li) += ftmp(lm, ir, 0);
-//                }
-//            }
-//            /* apply S part to [0, 0, z] collinear vector */
-//            if (num_mag_dims__ == 1) {
-//                for (int ir = 0; ir < nrmax_ia; ir++) {
-//                    for (int lm = 0; lm < lmmax_ia; lm++) {
-//                        fsym_loc(lm, ir, 1, it.li) += ftmp(lm, ir, 1) * S(2, 2);
-//                    }
-//                }
-//            }
-//            /* apply 3x3 S-matrix to [x, y, z] vector */
-//            if (num_mag_dims__ == 3) {
-//                for (int k : {0, 1, 2}) {
-//                    for (int j : {0, 1, 2}) {
-//                        for (int ir = 0; ir < nrmax_ia; ir++) {
-//                            for (int lm = 0; lm < lmmax_ia; lm++) {
-//                                fsym_loc(lm, ir, 1 + k, it.li) += ftmp(lm, ir, 1 + j) * S(k, j);
-//                            }
-//                        }
-//                    }
-//                }
-//            }
-//        }
-//    }
-//
-//    /* gather full function */
-//    double* sbuf = spl_atoms.local_size() ? fsym_loc.at(memory_t::host) : nullptr;
-//    auto ld      = static_cast<int>(fsym_loc.size(0) * fsym_loc.size(1) * fsym_loc.size(2));
-//
-//    mdarray<double, 4> fsym_glob(
-//            {lmmax, frlm.unit_cell().max_num_mt_points(), num_mag_dims__ + 1, frlm.atoms().size()});
-//
-//    comm__.allgather(sbuf, fsym_glob.at(memory_t::host), ld * spl_atoms.local_size(), ld * spl_atoms.global_offset());
-//
-//    /* copy back the result */
-//    for (int i = 0; i < static_cast<int>(frlm.atoms().size()); i++) {
-//        int ia = frlm.atoms()[i];
-//        for (int j = 0; j < num_mag_dims__ + 1; j++) {
-//            for (int ir = 0; ir < frlm.unit_cell().atom(ia).num_mt_points(); ir++) {
-//                for (int lm = 0; lm < frlm[ia].angular_domain_size(); lm++) {
-//                    (*frlm__[j])[ia](lm, ir) = fsym_glob(lm, ir, j, i);
-//                }
-//            }
-//        }
-//    }
-//}
-
 /// Symmetrize spherical expansion coefficients of the scalar and vector function for atoms of the same symmetry class.
 template <typename Index_t>
 inline void
@@ -249,8 +146,8 @@ symmetrize_mt_function(Unit_cell const& uc__, std::vector<mdarray<double, 2>> co
 {
     for (int ic = 0; ic < uc__.num_atom_symmetry_classes(); ic++) {
         if (mpi_grid__[ic]) {
-            symmetrize_mt_function(uc__.symmetry(), rotm__, uc__.atom_symmetry_class(ic), *mpi_grid__[ic], num_mag_dims__,
-                    frlm__);
+            symmetrize_mt_function(uc__.symmetry(), rotm__, uc__.atom_symmetry_class(ic), *mpi_grid__[ic],
+                                   num_mag_dims__, frlm__);
         }
     }
 }

--- a/src/symmetry/symmetrize_mt_function.hpp
+++ b/src/symmetry/symmetrize_mt_function.hpp
@@ -126,8 +126,8 @@ symmetrize_mt_function(Crystal_symmetry const& sym__, mpi::Communicator const& c
 template <typename Index_t>
 inline void
 symmetrize_mt_function(Crystal_symmetry const& sym__, std::vector<mdarray<double, 2>> const& rotm__,
-        Atom_symmetry_class const& atom_class__, mpi::Grid const& mpi_grid__, int num_mag_dims__,
-        std::vector<Spheric_function_set<double, Index_t>*> frlm__)
+                       Atom_symmetry_class const& atom_class__, mpi::Grid const& mpi_grid__, int num_mag_dims__,
+                       std::vector<Spheric_function_set<double, Index_t>*> frlm__)
 {
     PROFILE("sirius::symmetrize_mt_function");
 
@@ -159,7 +159,7 @@ symmetrize_mt_function(Crystal_symmetry const& sym__, std::vector<mdarray<double
 
     /* symmetry-transformed functions */
     mdarray<double, 4> fsym_loc({lmmax, nr, num_mag_dims__ + 1, spl_atoms.local_size()},
-            get_memory_pool(memory_t::host));
+                                get_memory_pool(memory_t::host));
     fsym_loc.zero();
 
     double alpha = 1.0 / sym__.size();

--- a/src/symmetry/symmetrize_mt_function.hpp
+++ b/src/symmetry/symmetrize_mt_function.hpp
@@ -248,8 +248,10 @@ symmetrize_mt_function(Unit_cell const& uc__, std::vector<mdarray<double, 2>> co
                        std::vector<Spheric_function_set<double, Index_t>*> frlm__)
 {
     for (int ic = 0; ic < uc__.num_atom_symmetry_classes(); ic++) {
-        symmetrize_mt_function(uc__.symmetry(), rotm__, uc__.atom_symmetry_class(ic), *mpi_grid__[ic], num_mag_dims__,
-                frlm__);
+        if (mpi_grid__[ic]) {
+            symmetrize_mt_function(uc__.symmetry(), rotm__, uc__.atom_symmetry_class(ic), *mpi_grid__[ic], num_mag_dims__,
+                    frlm__);
+        }
     }
 }
 

--- a/src/unit_cell/atom_symmetry_class.hpp
+++ b/src/unit_cell/atom_symmetry_class.hpp
@@ -33,7 +33,7 @@ class Atom_symmetry_class
     /// List of atoms of this class.
     std::vector<int> atom_id_;
 
-    /// Pointer to atom type.
+    /// Reference to atom type.
     Atom_type const& atom_type_;
 
     /// Spherical part of the effective potential.


### PR DESCRIPTION
Optimise symmetrization of muffin-tin functions. The following steps are taken:

- Rlm rotation matrices are cached in simulation contexts. They were somehow expensive to generate each time
- symmstrizaion is now performed for each atom class independently on an optimal 2D MPI grid. First dimension is used to parallelize atoms of the given symmetry class, second dimension is used to parallelize radial grid points. As such, all MPI rank are involved in symmetrization
- minor fix in initializing muffin-tin magnetization - it was not synchronised between all MPI ranks