### PR TITLE
Remove hard-coded printing of pika bindings

### DIFF
--- a/src/core/la/eigenproblem.cpp
+++ b/src/core/la/eigenproblem.cpp
@@ -331,9 +331,9 @@ Eigensolver_elpa::solve(ftn_int matrix_size__, la::dmatrix<std::complex<double>>
 void
 Eigensolver_dlaf::initialize()
 {
-    const char* pika_argv[] = {"sirius", "--pika:print-bind"};
+    const char* pika_argv[] = {"sirius"};
     const char* dlaf_argv[] = {"sirius"};
-    dlaf_initialize(2, pika_argv, 1, dlaf_argv);
+    dlaf_initialize(1, pika_argv, 1, dlaf_argv);
 }
 
 void


### PR DESCRIPTION
Printing pika bindings was hard-coded. It is too verbose with many ranks (and many cores) to force it to the user. This PR removes the printing. It can be enabled by the user by exporting the `PIKA_PRINT_BIND` variable.