### PR TITLE
Fortran: Add default initializers and make member variables private

### DIFF
--- a/src/api/sirius.f90
+++ b/src/api/sirius.f90
@@ -22,17 +22,17 @@ INTEGER, PARAMETER, PUBLIC :: SIRIUS_ARRAY_ARRAY_TYPE = 12
 
 !> @brief Opaque wrapper for simulation context handler.
 type sirius_context_handler
-    type(C_PTR) :: handler_ptr_
+    type(C_PTR) :: handler_ptr_ = C_NULL_PTR
 end type
 
 !> @brief Opaque wrapper for DFT ground statee handler.
 type sirius_ground_state_handler
-    type(C_PTR) :: handler_ptr_
+    type(C_PTR) :: handler_ptr_ = C_NULL_PTR
 end type
 
 !> @brief Opaque wrapper for K-point set handler.
 type sirius_kpoint_set_handler
-    type(C_PTR) :: handler_ptr_
+    type(C_PTR) :: handler_ptr_ = C_NULL_PTR
 end type
 
 !> @brief Free any of the SIRIUS handlers (context, ground state or k-points).

--- a/src/api/sirius.f90
+++ b/src/api/sirius.f90
@@ -22,16 +22,19 @@ INTEGER, PARAMETER, PUBLIC :: SIRIUS_ARRAY_ARRAY_TYPE = 12
 
 !> @brief Opaque wrapper for simulation context handler.
 type sirius_context_handler
+    private
     type(C_PTR) :: handler_ptr_ = C_NULL_PTR
 end type
 
 !> @brief Opaque wrapper for DFT ground statee handler.
 type sirius_ground_state_handler
+    private
     type(C_PTR) :: handler_ptr_ = C_NULL_PTR
 end type
 
 !> @brief Opaque wrapper for K-point set handler.
 type sirius_kpoint_set_handler
+    private
     type(C_PTR) :: handler_ptr_ = C_NULL_PTR
 end type
 


### PR DESCRIPTION
This PR adds default initializers to the Fortran API for all types to allow default initialization of these variables in codes using SIRIUS' Fortran interface.
Turning the member variables private prevent accident changes on the user side.