### PR TITLE
[fix] Fixed bug in direct XML parsing of UPF v2 PPs

### DIFF
--- a/src/unit_cell/atom_type.cpp
+++ b/src/unit_cell/atom_type.cpp
@@ -796,7 +796,11 @@ Atom_type::read_pseudo_uspp(pugi::xml_node const& upf)
 
     local_potential(vec_from_str<double>(upf.child("PP_LOCAL").child_value(), 0.5));
 
-    ps_core_charge_density(vec_from_str<double>(upf.child("PP_NLCC").child_value()));
+    if (header.attribute("core_correction").as_bool()) {
+        ps_core_charge_density(vec_from_str<double>(upf.child("PP_NLCC").child_value()));
+    } else {
+        ps_core_charge_density(std::vector<double>(rgrid.size(), 0.0));
+    }
 
     ps_total_charge_density(vec_from_str<double>(upf.child("PP_RHOATOM").child_value()));
 


### PR DESCRIPTION
Fixed bug when parsing UPF files without NLCC. When there is no core correction, the default `json` behavior is to allocate an array for it filled with zeros. So far, the `pugixml` parser gave a size zero vector, leading to a crash. This PR fixes it.