### PR TITLE
Add timers for Hubbard symmetrization

### DIFF
--- a/apps/unit_tests/test_rot_ylm.cpp
+++ b/apps/unit_tests/test_rot_ylm.cpp
@@ -67,16 +67,17 @@ run_test_impl(cmd_args& args)
             sf::spherical_harmonics(lmax, scoord2[1], scoord2[2], &ylm2(0));
 
             /* generate rotation matrices; they are block-diagonal in l- index */
-            mdarray<T, 2> ylm_rot_mtrx({sf::lmmax(lmax), sf::lmmax(lmax)});
-            sht::rotation_matrix(lmax, ang, proper_rotation, ylm_rot_mtrx);
+            auto ylm_rot_mtrx = sht::rotation_matrix<T>(lmax, ang, proper_rotation);
 
             mdarray<T, 1> ylm1({sf::lmmax(lmax)});
             ylm1.zero();
 
             /* rotate original sperical harmonics with P^{-1} */
-            for (int i = 0; i < sf::lmmax(lmax); i++) {
-                for (int j = 0; j < sf::lmmax(lmax); j++) {
-                    ylm1(i) += conj(ylm_rot_mtrx(i, j)) * ylm(j);
+            for (int l = 0; l <= lmax; l++) {
+                for (int i = 0; i < 2 * l + 1; i++) {
+                    for (int j = 0; j < 2 * l + 1; j++) {
+                        ylm1(l * l + i) += conj(ylm_rot_mtrx[l](i, j)) * ylm(l * l + j);
+                    }
                 }
             }
 

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -823,16 +823,15 @@ Simulation_context::update()
     unit_cell().update();
 
     /* cache rotation symmetry matrices */
-    int lmax  = this->full_potential() ? std::max(this->lmax_pot(), this->lmax_rho()) : 2 * this->unit_cell().lmax();
-    int lmmax = sf::lmmax(lmax);
+    int lmax = this->full_potential() ? std::max(this->lmax_pot(), this->lmax_rho())
+                                      : std::max(2 * this->unit_cell().lmax(), 4);
     rotm_.resize(this->unit_cell().symmetry().size());
     /* loop over crystal symmetries */
     #pragma omp parallel for
     for (int i = 0; i < this->unit_cell().symmetry().size(); i++) {
-        rotm_[i] = mdarray<double, 2>({lmmax, lmmax});
         /* compute Rlm rotation matrix */
-        sht::rotation_matrix(lmax, this->unit_cell().symmetry()[i].spg_op.euler_angles,
-                             this->unit_cell().symmetry()[i].spg_op.proper, rotm_[i]);
+        rotm_[i] = sht::rotation_matrix<double>(lmax, this->unit_cell().symmetry()[i].spg_op.euler_angles,
+                                                this->unit_cell().symmetry()[i].spg_op.proper);
     }
 
     /* get new reciprocal vector */

--- a/src/context/simulation_context.hpp
+++ b/src/context/simulation_context.hpp
@@ -290,7 +290,7 @@ class Simulation_context : public Simulation_parameters
     std::vector<std::unique_ptr<mpi::Grid>> mpi_grid_mt_sym_;
 
     /// Rotation matrices for real spherical harmonics.
-    std::vector<mdarray<double, 2>> rotm_;
+    std::vector<std::vector<mdarray<double, 2>>> rotm_;
 
     mutable double evp_work_count_{0};
     mutable int num_loc_op_applied_{0};

--- a/src/core/sht/sht.cpp
+++ b/src/core/sht/sht.cpp
@@ -13,6 +13,7 @@ namespace sirius {
 
 namespace sht { // TODO: move most of this to special functions
 
+/// Generate Wigner-D matrix.
 mdarray<double, 2>
 wigner_d_matrix(int l, double beta)
 {
@@ -41,6 +42,7 @@ wigner_d_matrix(int l, double beta)
     return d_mtrx;
 }
 
+/// Rotation of a set of complex spherical harmonics with l orbital quantum number.
 template <>
 mdarray<std::complex<double>, 2>
 rotation_matrix_l<std::complex<double>>(int l, r3::vector<double> euler_angles, int proper_rotation)
@@ -59,6 +61,7 @@ rotation_matrix_l<std::complex<double>>(int l, r3::vector<double> euler_angles, 
     return rot_mtrx;
 }
 
+/// Rotation of a set of real spherical harmonics with l orbital quantum number.
 template <>
 mdarray<double, 2>
 rotation_matrix_l<double>(int l, r3::vector<double> euler_angles, int proper_rotation)
@@ -85,31 +88,7 @@ rotation_matrix_l<double>(int l, r3::vector<double> euler_angles, int proper_rot
     return rot_mtrx;
 }
 
-// TODO: this is used in rotatin rlm spherical functions, but this is wrong.
-// the rotation must happen inside l-shells
-template <typename T>
-void
-rotation_matrix(int lmax, r3::vector<double> euler_angles, int proper_rotation, mdarray<T, 2>& rotm)
-{
-    rotm.zero();
-
-    for (int l = 0; l <= lmax; l++) {
-        auto rl = rotation_matrix_l<T>(l, euler_angles, proper_rotation);
-        for (int m = 0; m < 2 * l + 1; m++) {
-            for (int mp = 0; mp < 2 * l + 1; mp++) {
-                rotm(l * l + m, l * l + mp) = rl(m, mp);
-            }
-        }
-    }
-}
-
-template void
-rotation_matrix<double>(int lmax, r3::vector<double> euler_angles, int proper_rotation, mdarray<double, 2>& rotm);
-
-template void
-rotation_matrix<std::complex<double>>(int lmax, r3::vector<double> euler_angles, int proper_rotation,
-                                      mdarray<std::complex<double>, 2>& rotm);
-
+/// Return vector of rotation matrices for each of the l-shells.
 template <typename T>
 std::vector<mdarray<T, 2>>
 rotation_matrix(int lmax, r3::vector<double> euler_angles, int proper_rotation)
@@ -122,9 +101,11 @@ rotation_matrix(int lmax, r3::vector<double> euler_angles, int proper_rotation)
     return result;
 }
 
+/// Instantiation for real spherical harmonics.
 template std::vector<mdarray<double, 2>>
 rotation_matrix<double>(int lmax, r3::vector<double> euler_angles, int proper_rotation);
 
+/// Instantiation for complex spherical harmonics.
 template std::vector<mdarray<std::complex<double>, 2>>
 rotation_matrix<std::complex<double>>(int lmax, r3::vector<double> euler_angles, int proper_rotation);
 

--- a/src/core/sht/sht.hpp
+++ b/src/core/sht/sht.hpp
@@ -41,10 +41,6 @@ mdarray<T, 2>
 rotation_matrix_l(int l, r3::vector<double> euler_angles, int proper_rotation);
 
 template <typename T>
-void
-rotation_matrix(int lmax, r3::vector<double> euler_angles, int proper_rotation, mdarray<T, 2>& rotm);
-
-template <typename T>
 std::vector<mdarray<T, 2>>
 rotation_matrix(int lmax, r3::vector<double> euler_angles, int proper_rotation);
 

--- a/src/density/density.cpp
+++ b/src/density/density.cpp
@@ -1111,7 +1111,7 @@ Density::generate(K_point_set const& ks__, bool symmetrize__, bool add_core__, b
 
             /* symmetrize density matrix (used in standard uspp case) */
             if (unit_cell_.max_mt_basis_size() != 0) {
-                sirius::symmetrize_density_matrix(unit_cell_, *density_matrix_, ctx_.num_mag_comp());
+                sirius::symmetrize_density_matrix(unit_cell_, ctx_.rotm(), *density_matrix_, ctx_.num_mag_comp());
             }
 
             if (occupation_matrix_) {

--- a/src/density/density.cpp
+++ b/src/density/density.cpp
@@ -1116,7 +1116,7 @@ Density::generate(K_point_set const& ks__, bool symmetrize__, bool add_core__, b
 
             if (occupation_matrix_) {
                 /* all symmetrization is done in the occupation_matrix class */
-                symmetrize_occupation_matrix(*occupation_matrix_, ctx_.rotm());
+                symmetrize_occupation_matrix(*occupation_matrix_);
             }
 
             /* compare with reference density matrix */

--- a/src/density/density.cpp
+++ b/src/density/density.cpp
@@ -1116,7 +1116,7 @@ Density::generate(K_point_set const& ks__, bool symmetrize__, bool add_core__, b
 
             if (occupation_matrix_) {
                 /* all symmetrization is done in the occupation_matrix class */
-                symmetrize_occupation_matrix(*occupation_matrix_);
+                symmetrize_occupation_matrix(*occupation_matrix_, ctx_.rotm());
             }
 
             /* compare with reference density matrix */

--- a/src/hubbard/hubbard_matrix.hpp
+++ b/src/hubbard/hubbard_matrix.hpp
@@ -240,6 +240,7 @@ class Hubbard_matrix
     auto
     find_orbital_index(const int ia__, const int n__, const int l__) const
     {
+        PROFILE("Hubbard_matrix::find_orbital_index");
         for (int at_lvl = 0; at_lvl < static_cast<int>(atomic_orbitals_.size()); at_lvl++) {
             int lo_ind = atomic_orbitals_[at_lvl].second;
 

--- a/src/hubbard/hubbard_matrix.hpp
+++ b/src/hubbard/hubbard_matrix.hpp
@@ -240,7 +240,6 @@ class Hubbard_matrix
     auto
     find_orbital_index(const int ia__, const int n__, const int l__) const
     {
-        PROFILE("Hubbard_matrix::find_orbital_index");
         for (int at_lvl = 0; at_lvl < static_cast<int>(atomic_orbitals_.size()); at_lvl++) {
             int lo_ind = atomic_orbitals_[at_lvl].second;
 

--- a/src/symmetry/symmetrize_density_matrix.hpp
+++ b/src/symmetry/symmetrize_density_matrix.hpp
@@ -244,7 +244,8 @@ apply_symmetry_to_density_matrix(mdarray<std::complex<double>, 3> const& dm_ia__
  *
  */
 inline void
-symmetrize_density_matrix(Unit_cell const& uc__, density_matrix_t& dm__, int num_mag_comp__)
+symmetrize_density_matrix(Unit_cell const& uc__, std::vector<std::vector<mdarray<double, 2>>> const& rotm__,
+                          density_matrix_t& dm__, int num_mag_comp__)
 {
     PROFILE("sirius::symmetrize_density_matrix");
 
@@ -257,18 +258,13 @@ symmetrize_density_matrix(Unit_cell const& uc__, density_matrix_t& dm__, int num
 
     density_matrix_t dm_sym(uc__, num_mag_comp__);
 
-    int lmax = uc__.lmax();
-
     for (int i = 0; i < sym.size(); i++) {
-        int pr             = sym[i].spg_op.proper;
-        auto eang          = sym[i].spg_op.euler_angles;
-        auto rotm          = sht::rotation_matrix<double>(lmax, eang, pr);
         auto& spin_rot_su2 = sym[i].spin_rotation_su2;
 
         for (int ia = 0; ia < uc__.num_atoms(); ia++) {
             int ja = sym[i].spg_op.sym_atom[ia];
 
-            sirius::apply_symmetry_to_density_matrix(dm__[ia], uc__.atom(ia).type().indexb(), num_mag_comp__, rotm,
+            sirius::apply_symmetry_to_density_matrix(dm__[ia], uc__.atom(ia).type().indexb(), num_mag_comp__, rotm__[i],
                                                      spin_rot_su2, dm_sym[ja]);
         }
     }

--- a/src/symmetry/symmetrize_occupation_matrix.hpp
+++ b/src/symmetry/symmetrize_occupation_matrix.hpp
@@ -49,11 +49,11 @@ symmetrize_occupation_matrix(Occupation_matrix& om__)
     }
 
     std::vector<std::vector<mdarray<double, 2>>> rotms(sym.size());
-    for(int isym = 0; isym < sym.size(); ++isym) {
-        int pr    = sym[isym].spg_op.proper;
-        auto eang = sym[isym].spg_op.euler_angles;
-        auto tmp = sht::rotation_matrix<double>(4, eang, pr);
-        rotms[isym] = std::vector<mdarray<double,2>>(tmp.size());
+    for (int isym = 0; isym < sym.size(); ++isym) {
+        int pr      = sym[isym].spg_op.proper;
+        auto eang   = sym[isym].spg_op.euler_angles;
+        auto tmp    = sht::rotation_matrix<double>(4, eang, pr);
+        rotms[isym] = std::vector<mdarray<double, 2>>(tmp.size());
         for (int l = 0; l < static_cast<int>(tmp.size()); ++l) {
             rotms[isym][l] = mdarray<double, 2>({tmp[l].size(0), tmp[l].size(1)});
             auto_copy(rotms[isym][l], tmp[l]);
@@ -72,7 +72,7 @@ symmetrize_occupation_matrix(Occupation_matrix& om__)
             // local_[at_lvl].zero();
             mdarray<std::complex<double>, 3> dm_ia({lmmax_at, lmmax_at, 4});
             for (int isym = 0; isym < sym.size(); isym++) {
-                auto& rotm         = rotms[isym];
+                auto& rotm        = rotms[isym];
                 auto spin_rot_su2 = rotation_matrix_su2(sym[isym].spin_rotation);
 
                 int iap = sym[isym].spg_op.inv_sym_atom[ia];

--- a/src/symmetry/symmetrize_occupation_matrix.hpp
+++ b/src/symmetry/symmetrize_occupation_matrix.hpp
@@ -49,6 +49,7 @@ symmetrize_occupation_matrix(Occupation_matrix& om__)
     }
 
     std::vector<std::vector<mdarray<double, 2>>> rotms(sym.size());
+    #pragma omp parllel for
     for (int isym = 0; isym < sym.size(); ++isym) {
         int pr      = sym[isym].spg_op.proper;
         auto eang   = sym[isym].spg_op.euler_angles;

--- a/src/symmetry/symmetrize_occupation_matrix.hpp
+++ b/src/symmetry/symmetrize_occupation_matrix.hpp
@@ -21,6 +21,7 @@ namespace sirius {
 inline void
 symmetrize_occupation_matrix(Occupation_matrix& om__)
 {
+    PROFILE("sirius::symmetrize_occupation_matrix");
     auto& ctx = om__.ctx();
     auto& uc  = ctx.unit_cell();
 

--- a/src/symmetry/symmetrize_occupation_matrix.hpp
+++ b/src/symmetry/symmetrize_occupation_matrix.hpp
@@ -183,7 +183,7 @@ symmetrize_occupation_matrix(Occupation_matrix& om__)
         for (int isym = 0; isym < sym.size(); isym++) {
             int pr            = sym[isym].spg_op.proper;
             auto eang         = sym[isym].spg_op.euler_angles;
-            auto rotm         = sht::rotation_matrix<double>(4, eang, pr);
+            auto& rotm        = rotms[isym];
             auto spin_rot_su2 = rotation_matrix_su2(sym[isym].spin_rotation);
 
             int iap = sym[isym].spg_op.inv_sym_atom[ia];

--- a/src/symmetry/symmetrize_occupation_matrix.hpp
+++ b/src/symmetry/symmetrize_occupation_matrix.hpp
@@ -19,7 +19,7 @@
 namespace sirius {
 
 inline void
-symmetrize_occupation_matrix(Occupation_matrix& om__, std::vector<mdarray<double, 2>> const& rotm__)
+symmetrize_occupation_matrix(Occupation_matrix& om__)
 {
     PROFILE("sirius::symmetrize_occupation_matrix");
     auto& ctx = om__.ctx();
@@ -61,7 +61,7 @@ symmetrize_occupation_matrix(Occupation_matrix& om__, std::vector<mdarray<double
             for (int isym = 0; isym < sym.size(); isym++) {
                 int pr            = sym[isym].spg_op.proper;
                 auto eang         = sym[isym].spg_op.euler_angles;
-                auto& rotm        = rotm__[isym];
+                auto rotm         = sht::rotation_matrix<double>(4, eang, pr);
                 auto spin_rot_su2 = rotation_matrix_su2(sym[isym].spin_rotation);
 
                 int iap = sym[isym].spg_op.inv_sym_atom[ia];

--- a/src/symmetry/symmetrize_occupation_matrix.hpp
+++ b/src/symmetry/symmetrize_occupation_matrix.hpp
@@ -19,7 +19,7 @@
 namespace sirius {
 
 inline void
-symmetrize_occupation_matrix(Occupation_matrix& om__)
+symmetrize_occupation_matrix(Occupation_matrix& om__, std::vector<mdarray<double, 2>> const& rotm__)
 {
     PROFILE("sirius::symmetrize_occupation_matrix");
     auto& ctx = om__.ctx();
@@ -61,7 +61,7 @@ symmetrize_occupation_matrix(Occupation_matrix& om__)
             for (int isym = 0; isym < sym.size(); isym++) {
                 int pr            = sym[isym].spg_op.proper;
                 auto eang         = sym[isym].spg_op.euler_angles;
-                auto rotm         = sht::rotation_matrix<double>(4, eang, pr);
+                auto& rotm        = rotm__[isym];
                 auto spin_rot_su2 = rotation_matrix_su2(sym[isym].spin_rotation);
 
                 int iap = sym[isym].spg_op.inv_sym_atom[ia];

--- a/src/symmetry/symmetrize_occupation_matrix.hpp
+++ b/src/symmetry/symmetrize_occupation_matrix.hpp
@@ -14,6 +14,7 @@
 #ifndef __SYMMETRIZE_OCCUPATION_MATRIX_HPP__
 #define __SYMMETRIZE_OCCUPATION_MATRIX_HPP__
 
+#include "core/memory.hpp"
 #include "density/occupation_matrix.hpp"
 
 namespace sirius {
@@ -47,6 +48,18 @@ symmetrize_occupation_matrix(Occupation_matrix& om__)
         }
     }
 
+    std::vector<std::vector<mdarray<double, 2>>> rotms(sym.size());
+    for(int isym = 0; isym < sym.size(); ++isym) {
+        int pr    = sym[isym].spg_op.proper;
+        auto eang = sym[isym].spg_op.euler_angles;
+        auto tmp = sht::rotation_matrix<double>(4, eang, pr);
+        rotms[isym] = std::vector<mdarray<double,2>>(tmp.size());
+        for (int l = 0; l < static_cast<int>(tmp.size()); ++l) {
+            rotms[isym][l] = mdarray<double, 2>({tmp[l].size(0), tmp[l].size(1)});
+            auto_copy(rotms[isym][l], tmp[l]);
+        }
+    }
+
     for (int at_lvl = 0; at_lvl < static_cast<int>(om__.local().size()); at_lvl++) {
         const int ia     = om__.atomic_orbitals(at_lvl).first;
         const auto& atom = uc.atom(ia);
@@ -59,9 +72,7 @@ symmetrize_occupation_matrix(Occupation_matrix& om__)
             // local_[at_lvl].zero();
             mdarray<std::complex<double>, 3> dm_ia({lmmax_at, lmmax_at, 4});
             for (int isym = 0; isym < sym.size(); isym++) {
-                int pr            = sym[isym].spg_op.proper;
-                auto eang         = sym[isym].spg_op.euler_angles;
-                auto rotm         = sht::rotation_matrix<double>(4, eang, pr);
+                auto& rotm         = rotms[isym];
                 auto spin_rot_su2 = rotation_matrix_su2(sym[isym].spin_rotation);
 
                 int iap = sym[isym].spg_op.inv_sym_atom[ia];

--- a/src/symmetry/symmetrize_occupation_matrix.hpp
+++ b/src/symmetry/symmetrize_occupation_matrix.hpp
@@ -48,22 +48,11 @@ symmetrize_occupation_matrix(Occupation_matrix& om__)
         }
     }
 
-    std::vector<std::vector<mdarray<double, 2>>> rotms(sym.size());
-    #pragma omp parllel for
-    for (int isym = 0; isym < sym.size(); ++isym) {
-        int pr      = sym[isym].spg_op.proper;
-        auto eang   = sym[isym].spg_op.euler_angles;
-        auto tmp    = sht::rotation_matrix<double>(4, eang, pr);
-        rotms[isym] = std::vector<mdarray<double, 2>>(tmp.size());
-        for (int l = 0; l < static_cast<int>(tmp.size()); ++l) {
-            rotms[isym][l] = mdarray<double, 2>({tmp[l].size(0), tmp[l].size(1)});
-            auto_copy(rotms[isym][l], tmp[l]);
-        }
-    }
+    auto const& rotms = ctx.rotm();
 
     for (int at_lvl = 0; at_lvl < static_cast<int>(om__.local().size()); at_lvl++) {
-        const int ia     = om__.atomic_orbitals(at_lvl).first;
-        const auto& atom = uc.atom(ia);
+        int const ia     = om__.atomic_orbitals(at_lvl).first;
+        auto const& atom = uc.atom(ia);
         om__.local(at_lvl).zero();
         /* We can skip the symmetrization for this atomic level since it does not contribute
          * to the Hubbard correction (or U = 0) */
@@ -73,7 +62,7 @@ symmetrize_occupation_matrix(Occupation_matrix& om__)
             // local_[at_lvl].zero();
             mdarray<std::complex<double>, 3> dm_ia({lmmax_at, lmmax_at, 4});
             for (int isym = 0; isym < sym.size(); isym++) {
-                auto& rotm        = rotms[isym];
+                auto const& rotm  = rotms[isym];
                 auto spin_rot_su2 = rotation_matrix_su2(sym[isym].spin_rotation);
 
                 int iap = sym[isym].spg_op.inv_sym_atom[ia];
@@ -181,8 +170,6 @@ symmetrize_occupation_matrix(Occupation_matrix& om__)
         auto T  = nl.T();
         om__.nonlocal(i).zero();
         for (int isym = 0; isym < sym.size(); isym++) {
-            int pr            = sym[isym].spg_op.proper;
-            auto eang         = sym[isym].spg_op.euler_angles;
             auto& rotm        = rotms[isym];
             auto spin_rot_su2 = rotation_matrix_su2(sym[isym].spin_rotation);
 


### PR DESCRIPTION
Add `sirus::symmetrize_occupation_matrix`. 

@gsavva encountered a SCF+U calculation which spent the bulk of the time in `symmetrize_occupation_matrix` in `Density::generate`.