### PR TITLE
Fix direct reading of UPF files for tiny floats

### DIFF
--- a/src/unit_cell/atom_type.cpp
+++ b/src/unit_cell/atom_type.cpp
@@ -758,20 +758,12 @@ template <typename T>
 std::vector<T>
 vec_from_str(std::string const& str__, identity_t<T> scaling = T{1})
 {
-    std::string s;
-    std::istringstream ss(str__);
     std::vector<T> data;
-    while (ss >> s) {
-        if constexpr (std::is_same_v<T, double>) {
-            data.push_back(std::stod(s) * scaling);
-        } else if constexpr (std::is_same_v<T, int>) {
-            data.push_back(std::stoi(s) * scaling);
-        } else if constexpr (std::is_same_v<T, float>) {
-            data.push_back(std::stof(s) * scaling);
-        } else {
-            static_assert(!std::is_same_v<T, T>, "type not implemented");
-        }
-    }
+    std::istringstream iss(str__);
+
+    std::copy(std::istream_iterator<T>(iss), std::istream_iterator<T>(), std::back_inserter(data));
+    std::transform(data.begin(), data.end(), data.begin(), [&scaling](T val) { return val * scaling; });
+
     return data;
 }
 


### PR DESCRIPTION
The simplification of the `vec_from_string` function that happened in PR #983 leads to a loss of robustness. Indeed, the usage of `std::stod` instead of `std::istringstream`  leads to crashes when very small floats are present in the PP file (see  [last element of this line](https://github.com/JuliaMolSim/PseudoLibrary/blob/7c4b71a3b9d70a229d757aa6d546ef22b83a85a9/pseudos/hgh_pbe_upf/C.pbe-hgh.UPF#L1094) for an example). It seems that any number below `std::numeric_limits::min()` cannot be converted from a string to a double with `std::stod` (source: https://stackoverflow.com/questions/48086830/stdstod-throws-out-of-range-error-for-a-string-that-should-be-valid).

This PR reverses back some of the changes made in #983 to use `std::istringstream` again for string to double conversion. Note that this version of the function is still more general and elegant than the original one. If there is any better way of dealing with this issue, I am happy to hear it.

