### PR TITLE
[feature] print occupation matrix at the end of Density instance

### DIFF
--- a/src/core/env/env.hpp
+++ b/src/core/env/env.hpp
@@ -91,6 +91,17 @@ print_timing()
     }
 }
 
+inline int
+print_occupation_matrix()
+{
+    auto val = get_value_ptr<int>("SIRIUS_PRINT_OCCUPATION_MATRIX");
+    if (val) {
+        return *val;
+    } else {
+        return 0;
+    }
+}
+
 inline std::string
 save_config()
 {

--- a/src/density/density.hpp
+++ b/src/density/density.hpp
@@ -344,6 +344,14 @@ class Density : public Field4D
     /// Constructor
     Density(Simulation_context& ctx__);
 
+    /// Destructor
+    ~Density()
+    {
+        if (env::print_occupation_matrix() && occupation_matrix_) {
+            occupation_matrix_->print_occupancies(0);
+        }
+    }
+
     /// Update internal parameters after a change of lattice vectors or atomic coordinates.
     void
     update();

--- a/src/density/occupation_matrix.cpp
+++ b/src/density/occupation_matrix.cpp
@@ -365,6 +365,7 @@ Occupation_matrix::print_occupancies(int verbosity__) const
                 auto const& atom = ctx_.unit_cell().atom(atomic_orbitals_[at_lvl].first);
                 int il           = atom.type().lo_descriptor_hub(atomic_orbitals_[at_lvl].second).l();
                 if (atom.type().lo_descriptor_hub(atomic_orbitals_[at_lvl].second).use_for_calculation()) {
+                    /* print local part */
                     Hubbard_matrix::print_local(at_lvl, s);
                     double occ[2] = {0, 0};
                     for (int ispn = 0; ispn < ctx_.num_spins(); ispn++) {
@@ -385,12 +386,11 @@ Occupation_matrix::print_occupancies(int verbosity__) const
         if (ctx_.cfg().hubbard().nonlocal().size() && (ctx_.verbosity() >= verbosity__ + 1)) {
             s << std::endl;
             for (int i = 0; i < static_cast<int>(ctx_.cfg().hubbard().nonlocal().size()); i++) {
+                /* print non-local part */
                 Hubbard_matrix::print_nonlocal(i, s);
             }
         }
-        if (ctx_.verbosity() >= verbosity__) {
-            ctx_.message(1, "occ.mtrx", s);
-        }
+        ctx_.message(verbosity__, "occ.mtrx", s);
     }
 }
 


### PR DESCRIPTION
```
export SIRIUS_PRINT_OCCUPATION_MATRIX=1
export SIRIUS_VERBOSITY=1
```
prints final values of the dft+u+v occupation matrix that was stored in the  Density class instance. This is intended for debug purposes.