### PR TITLE
fix rocm include for rocm v6

### DIFF
--- a/ci/baseimage.rocm.Dockerfile
+++ b/ci/baseimage.rocm.Dockerfile
@@ -23,7 +23,7 @@ RUN wget https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cm
     tar zxvf cmake.tar.gz --strip-components=1 -C /usr
 
 # get latest version of spack
-RUN git clone -b v0.21.2 https://github.com/spack/spack.git
+RUN git clone -b v0.22.2 https://github.com/spack/spack.git
 
 # add local repo to spack
 COPY ./spack /opt/spack

--- a/src/core/acc/acc_blas.hpp
+++ b/src/core/acc/acc_blas.hpp
@@ -262,14 +262,8 @@ strmm(char side__, char uplo__, char transa__, char diag__, int m__, int n__, fl
     acc::blas_api::operation_t transa = get_gpublasOperation_t(transa__);
     acc::blas_api::diagonal_t diag    = get_gpublasDiagonal_t(diag__);
     // acc::set_device();
-#ifdef SIRIUS_CUDA
     CALL_GPU_BLAS(acc::blas_api::strmm, (stream_handle(stream_id), side, uplo, transa, diag, m__, n__, alpha__, A__,
                                          lda__, B__, ldb__, B__, ldb__));
-#else
-    // rocblas trmm function does not take three matrices
-    CALL_GPU_BLAS(acc::blas_api::strmm,
-                  (stream_handle(stream_id), side, uplo, transa, diag, m__, n__, alpha__, A__, lda__, B__, ldb__));
-#endif
 }
 
 inline void
@@ -281,14 +275,8 @@ dtrmm(char side__, char uplo__, char transa__, char diag__, int m__, int n__, do
     acc::blas_api::operation_t transa = get_gpublasOperation_t(transa__);
     acc::blas_api::diagonal_t diag    = get_gpublasDiagonal_t(diag__);
     // acc::set_device();
-#ifdef SIRIUS_CUDA
     CALL_GPU_BLAS(acc::blas_api::dtrmm, (stream_handle(stream_id), side, uplo, transa, diag, m__, n__, alpha__, A__,
                                          lda__, B__, ldb__, B__, ldb__));
-#else
-    // rocblas trmm function does not take three matrices
-    CALL_GPU_BLAS(acc::blas_api::dtrmm,
-                  (stream_handle(stream_id), side, uplo, transa, diag, m__, n__, alpha__, A__, lda__, B__, ldb__));
-#endif
 }
 
 inline void
@@ -300,19 +288,11 @@ ctrmm(char side__, char uplo__, char transa__, char diag__, int m__, int n__, ac
     acc::blas_api::operation_t transa = get_gpublasOperation_t(transa__);
     acc::blas_api::diagonal_t diag    = get_gpublasDiagonal_t(diag__);
     // acc::set_device();
-#ifdef SIRIUS_CUDA
     CALL_GPU_BLAS(acc::blas_api::ctrmm, (stream_handle(stream_id), side, uplo, transa, diag, m__, n__,
                                          reinterpret_cast<const acc::blas_api::complex_float_t*>(alpha__),
                                          reinterpret_cast<const acc::blas_api::complex_float_t*>(A__), lda__,
                                          reinterpret_cast<acc::blas_api::complex_float_t*>(B__), ldb__,
                                          reinterpret_cast<acc::blas_api::complex_float_t*>(B__), ldb__));
-#else
-    // rocblas trmm function does not take three matrices
-    CALL_GPU_BLAS(acc::blas_api::ctrmm, (stream_handle(stream_id), side, uplo, transa, diag, m__, n__,
-                                         reinterpret_cast<const acc::blas_api::complex_float_t*>(alpha__),
-                                         reinterpret_cast<const acc::blas_api::complex_float_t*>(A__), lda__,
-                                         reinterpret_cast<acc::blas_api::complex_float_t*>(B__), ldb__));
-#endif
 }
 
 inline void
@@ -324,19 +304,11 @@ ztrmm(char side__, char uplo__, char transa__, char diag__, int m__, int n__, ac
     acc::blas_api::operation_t transa = get_gpublasOperation_t(transa__);
     acc::blas_api::diagonal_t diag    = get_gpublasDiagonal_t(diag__);
     // acc::set_device();
-#ifdef SIRIUS_CUDA
     CALL_GPU_BLAS(acc::blas_api::ztrmm, (stream_handle(stream_id), side, uplo, transa, diag, m__, n__,
                                          reinterpret_cast<const acc::blas_api::complex_double_t*>(alpha__),
                                          reinterpret_cast<const acc::blas_api::complex_double_t*>(A__), lda__,
                                          reinterpret_cast<acc::blas_api::complex_double_t*>(B__), ldb__,
                                          reinterpret_cast<acc::blas_api::complex_double_t*>(B__), ldb__));
-#else
-    // rocblas trmm function does not take three matrices
-    CALL_GPU_BLAS(acc::blas_api::ztrmm, (stream_handle(stream_id), side, uplo, transa, diag, m__, n__,
-                                         reinterpret_cast<const acc::blas_api::complex_double_t*>(alpha__),
-                                         reinterpret_cast<const acc::blas_api::complex_double_t*>(A__), lda__,
-                                         reinterpret_cast<acc::blas_api::complex_double_t*>(B__), ldb__));
-#endif
 }
 
 inline void

--- a/src/core/acc/acc_blas_api.hpp
+++ b/src/core/acc/acc_blas_api.hpp
@@ -20,7 +20,7 @@
 #include <cublas_v2.h>
 
 #elif defined(SIRIUS_ROCM)
-#include <rocblas.h>
+#include <rocblas/rocblas.h>
 
 #else
 #error Either SIRIUS_CUDA or SIRIUS_ROCM must be defined!


### PR DESCRIPTION
rocblas has changed the interface for `trmm` in v6.0.0. 

**TODO** either make the change backward compatible, or upgrade rocm to 6.0.0 in the base container too.