### PR TITLE
Update to clang format 18

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,6 +26,7 @@ UseTab: Never
 AllowShortFunctionsOnASingleLine: 'None'
 AllowShortIfStatementsOnASingleLine : 'false'
 AllowShortLoopsOnASingleLine: 'false'
+AllowShortLambdasOnASingleLine: 'true'
 KeepEmptyLinesAtTheStartOfBlocks: 'true'
 AlwaysBreakTemplateDeclarations: 'Yes'
 PointerAlignment: Left
@@ -39,7 +40,6 @@ MaxEmptyLinesToKeep: 1
 BreakConstructorInitializersBeforeComma: 'true'
 ConstructorInitializerIndentWidth: 4
 Cpp11BracedListStyle: 'true'
-
 AlwaysBreakAfterReturnType: All
 #AlwaysBreakAfterReturnType: 'TopLevelDefinitions'
 

--- a/.clang-format
+++ b/.clang-format
@@ -26,7 +26,6 @@ UseTab: Never
 AllowShortFunctionsOnASingleLine: 'None'
 AllowShortIfStatementsOnASingleLine : 'false'
 AllowShortLoopsOnASingleLine: 'false'
-AllowShortLambdasOnASingleLine: 'true'
 KeepEmptyLinesAtTheStartOfBlocks: 'true'
 AlwaysBreakTemplateDeclarations: 'Yes'
 PointerAlignment: Left
@@ -40,6 +39,7 @@ MaxEmptyLinesToKeep: 1
 BreakConstructorInitializersBeforeComma: 'true'
 ConstructorInitializerIndentWidth: 4
 Cpp11BracedListStyle: 'true'
+
 AlwaysBreakAfterReturnType: All
 #AlwaysBreakAfterReturnType: 'TopLevelDefinitions'
 

--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    container: zhongruoyu/llvm-ports:17.0.4-slim-focal
+    container: zhongruoyu/llvm-ports:18.1.8-slim-bullseye
     steps:
       - uses: actions/checkout@v4
       - name: Check .cpp and .hpp files

--- a/python_module/py_sirius.cpp
+++ b/python_module/py_sirius.cpp
@@ -468,9 +468,8 @@ PYBIND11_MODULE(py_sirius, m)
 
     py::class_<fft::Grid>(m, "FFT3D_grid")
             .def_property_readonly("num_points", py::overload_cast<>(&fft::Grid::num_points, py::const_))
-            .def_property_readonly("shape", [](const fft::Grid& obj) -> std::array<int, 3> {
-                return {obj[0], obj[1], obj[2]};
-            });
+            .def_property_readonly("shape",
+                                   [](const fft::Grid& obj) -> std::array<int, 3> { return {obj[0], obj[1], obj[2]}; });
 
     py::class_<mdarray<complex_double, 1>>(m, "mdarray1c")
             .def("on_device", &mdarray<complex_double, 1>::on_device)

--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -6161,13 +6161,13 @@ sirius_linear_solver(void* const* gs_handler__, double const* vkq__, int const* 
                 mdarray<std::complex<double>, 3> dvpsi({*ld__, *num_spin_comp__, nbnd_occ_k}, dvpsi__);
 
                 auto dpsi_wf  = sirius::wave_function_factory<double>(sctx, kp, wf::num_bands(nbnd_occ_k),
-                                                                     wf::num_mag_dims(0), false);
+                                                                      wf::num_mag_dims(0), false);
                 auto psi_wf   = sirius::wave_function_factory<double>(sctx, kp, wf::num_bands(nbnd_occ_kq),
-                                                                    wf::num_mag_dims(0), false);
+                                                                      wf::num_mag_dims(0), false);
                 auto dvpsi_wf = sirius::wave_function_factory<double>(sctx, kp, wf::num_bands(nbnd_occ_k),
                                                                       wf::num_mag_dims(0), false);
                 auto tmp_wf   = sirius::wave_function_factory<double>(sctx, kp, wf::num_bands(nbnd_occ_k),
-                                                                    wf::num_mag_dims(0), false);
+                                                                      wf::num_mag_dims(0), false);
 
                 for (int ispn = 0; ispn < *num_spin_comp__; ispn++) {
                     for (int i = 0; i < nbnd_occ_kq; i++) {

--- a/src/core/ostream_tools.hpp
+++ b/src/core/ostream_tools.hpp
@@ -30,7 +30,7 @@ class null_stream_t : public std::ostream
     {
     }
     null_stream_t(null_stream_t&&)
-        : std::ostream(nullptr){};
+        : std::ostream(nullptr) {};
 };
 
 null_stream_t&

--- a/src/core/rt_graph.cpp
+++ b/src/core/rt_graph.cpp
@@ -352,8 +352,8 @@ max_node_identifier_length(const internal::TimingNode& node, const std::size_t r
 }
 
 auto
-export_node_json(const std::string& padding, const std::list<internal::TimingNode>& nodeList, std::ostream& stream)
-        -> void
+export_node_json(const std::string& padding, const std::list<internal::TimingNode>& nodeList,
+                 std::ostream& stream) -> void
 {
     stream << "{" << std::endl;
     const std::string nodePadding    = padding + "  ";
@@ -432,8 +432,8 @@ flatten_timings_nodes(std::list<TimingNode>& rootNodes, std::list<TimingNode>& n
 }
 
 auto
-flatten_timings_nodes_from_level(std::list<TimingNode>& nodes, std::size_t targetLevel, std::size_t currentLevel)
-        -> void
+flatten_timings_nodes_from_level(std::list<TimingNode>& nodes, std::size_t targetLevel,
+                                 std::size_t currentLevel) -> void
 {
     if (targetLevel > currentLevel) {
         for (auto& n : nodes) {

--- a/src/density/density.cpp
+++ b/src/density/density.cpp
@@ -734,7 +734,7 @@ Density::add_k_point_contribution_rg(K_point<T>* kp__, std::array<wf::Wave_funct
                 add_k_point_contribution_rg_collinear(kp__->spfft_transform(), ispn, w, inp_wf, nr, ctx_.gamma_point(),
                                                       density_rg);
             }
-        }    // ispn
+        } // ispn
     } else { /* non-collinear case */
         /* allocate on CPU or GPU */
         mdarray<std::complex<T>, 1> psi_r_up({nr}, get_memory_pool(memory_t::host));

--- a/src/dft/dft_ground_state.cpp
+++ b/src/dft/dft_ground_state.cpp
@@ -86,7 +86,7 @@ DFT_ground_state::energy_kin_sum_pw() const
             }
             ekin += 0.5 * d * kp->weight() * Gk.length2();
         } // igloc
-    }     // ikloc
+    } // ikloc
     ctx_.comm().allreduce(&ekin, 1);
     return ekin;
 }

--- a/src/geometry/non_local_functor.hpp
+++ b/src/geometry/non_local_functor.hpp
@@ -162,10 +162,10 @@ add_k_point_contribution_nonlocal(Simulation_context& ctx__, Beta_projectors_bas
                                 for_bnd(ibf, jbf, dij, 0.0, beta_phi_chunks[ispn + spin_factor]);
                             }
                         } // jbf
-                    }     // ibf
-                }         // ia_chunk
-            }             // ispn
-        }                 // x
+                    } // ibf
+                } // ia_chunk
+            } // ispn
+        } // x
     }
 
     // bp_base__.dismiss();

--- a/src/hamiltonian/non_local_operator.cpp
+++ b/src/hamiltonian/non_local_operator.cpp
@@ -545,7 +545,7 @@ apply_S_operator_strain_deriv(memory_t mem__, int comp__, Beta_projector_generat
         auto band_range_phi   = wf::band_range(0, phi__.num_wf().get());
         bool result_on_device = bp__.ctx().processing_unit() == device_t::GPU;
         auto dbeta_phi        = inner_prod_beta<complex_t>(spla_ctx, mem__, host_mem, result_on_device,
-                                                    bp_strain_deriv_coeffs__, phi__, wf::spin_index(0), band_range_phi);
+                                                           bp_strain_deriv_coeffs__, phi__, wf::spin_index(0), band_range_phi);
         auto beta_phi = inner_prod_beta<complex_t>(spla_ctx, mem__, host_mem, result_on_device, bp_coeffs__, phi__,
                                                    wf::spin_index(0), band_range_phi);
 

--- a/src/hubbard/hubbard_occupancies_derivatives.cpp
+++ b/src/hubbard/hubbard_occupancies_derivatives.cpp
@@ -358,9 +358,9 @@ Hubbard::compute_occupancies_derivatives(K_point<double>& kp__, Q_operator<doubl
                                                 phi_hub_s_psi_deriv, psi_s_phi_hub[ispn],
                                                 dn__.at(mt, 0, 0, ispn, x, ja), dn__.ld());
                 } // ispn
-            }     // i
-        }         // x
-    }             // ichunk
+            } // i
+        } // x
+    } // ichunk
 
     if (ctx_.processing_unit() == device_t::GPU) {
         dn__.copy_to(memory_t::host);

--- a/src/k_point/k_point.cpp
+++ b/src/k_point/k_point.cpp
@@ -167,7 +167,7 @@ K_point<T>::initialize()
             hubbard_wave_functions_S_ = std::make_unique<wf::Wave_functions<T>>(
                     gkvec_, wf::num_mag_dims(0), wf::num_bands(nwfh), ctx_.host_memory_t());
             atomic_wave_functions_   = std::make_unique<wf::Wave_functions<T>>(gkvec_, wf::num_mag_dims(0),
-                                                                             wf::num_bands(nwf), ctx_.host_memory_t());
+                                                                               wf::num_bands(nwf), ctx_.host_memory_t());
             atomic_wave_functions_S_ = std::make_unique<wf::Wave_functions<T>>(
                     gkvec_, wf::num_mag_dims(0), wf::num_bands(nwf), ctx_.host_memory_t());
         }
@@ -231,7 +231,7 @@ K_point<T>::generate_hubbard_orbitals()
             /* save phi and sphi */
 
             wf_tmp  = std::make_unique<wf::Wave_functions<T>>(gkvec_, wf::num_mag_dims(0), wf::num_bands(nwf),
-                                                             ctx_.host_memory_t());
+                                                              ctx_.host_memory_t());
             swf_tmp = std::make_unique<wf::Wave_functions<T>>(gkvec_, wf::num_mag_dims(0), wf::num_bands(nwf),
                                                               ctx_.host_memory_t());
 

--- a/src/nlcglib/preconditioner/ultrasoft_precond_k.hpp
+++ b/src/nlcglib/preconditioner/ultrasoft_precond_k.hpp
@@ -28,7 +28,7 @@ class OperatorBase
 {
   public:
     OperatorBase(int n)
-        : n(n){};
+        : n(n) {};
     OperatorBase() = delete;
 
     int

--- a/src/potential/generate_d_operator_matrix.cpp
+++ b/src/potential/generate_d_operator_matrix.cpp
@@ -213,7 +213,7 @@ Potential::generate_D_operator_matrix()
                 }
             }
         } // iv
-    }     // iat
+    } // iat
 }
 
 } // namespace sirius

--- a/src/potential/xc.cpp
+++ b/src/potential/xc.cpp
@@ -134,7 +134,7 @@ Potential::xc_rg_nonmagnetic(Density const& density__, bool use_lapl__)
                                     exc.at(memory_t::host, spl_t.global_offset()));
                     }
                 } // omp parallel region
-            }     // num_points != 0
+            } // num_points != 0
         }
         PROFILE_STOP("sirius::Potential::xc_rg_nonmagnetic|libxc");
         if (ixc.is_gga()) { /* generic for gga and vdw */
@@ -307,7 +307,7 @@ Potential::xc_rg_magnetic(Density const& density__, bool use_lapl__)
                                     exc.at(memory_t::host, spl_t.global_offset()));
                     }
                 } // omp parallel region
-            }     // num_points != 0
+            } // num_points != 0
         }
         PROFILE_STOP("sirius::Potential::xc_rg_magnetic|libxc");
         if (ixc.is_gga()) {

--- a/src/radial/radial_integrals.hpp
+++ b/src/radial/radial_integrals.hpp
@@ -56,7 +56,7 @@ class Radial_integrals_base
 
         grid_q_ = Radial_grid_lin<double>(static_cast<int>(np__ * qmax_), 0, qmax_);
         spl_q_  = splindex_block<>(grid_q_.num_points(), n_blocks(unit_cell_.comm().size()),
-                                  block_id(unit_cell_.comm().rank()));
+                                   block_id(unit_cell_.comm().rank()));
     }
 
     /// Get starting index iq and delta dq for the q-point on the linear grid.


### PR DESCRIPTION
- Update `clang-format` in github actions from 17 to 18
- reformat the code (didn't manage to tweak the option such that there is no diff between the two versions)