### PR TITLE
[feature] proper I/O from/to hdf5

### DIFF
--- a/apps/mini_app/sirius.scf.cpp
+++ b/apps/mini_app/sirius.scf.cpp
@@ -82,16 +82,15 @@ preprocess_json_input(std::string fname__)
 std::unique_ptr<Simulation_context>
 create_sim_ctx(std::string fname__, cmd_args const& args__)
 {
-    std::string json_string;
+    std::string config_string;
     if (isHDF5(fname__)) {
-        HDF5_tree fin(fname__, hdf5_access_t::read_only);
-        fin.read("config", json_string);
+        config_string = fname__;
     } else {
         auto json = preprocess_json_input(fname__);
-        json_string = json.dump();
+        config_string = json.dump();
     }
 
-    auto ctx = std::make_unique<Simulation_context>(json_string, mpi::Communicator::world());
+    auto ctx = std::make_unique<Simulation_context>(config_string);
 
     auto& inp = ctx->cfg().parameters();
     if (inp.gamma_point() && !(inp.ngridk()[0] * inp.ngridk()[1] * inp.ngridk()[2] == 1)) {

--- a/apps/mini_app/sirius.scf.cpp
+++ b/apps/mini_app/sirius.scf.cpp
@@ -85,16 +85,7 @@ create_sim_ctx(std::string fname__, cmd_args const& args__)
     std::string json_string;
     if (isHDF5(fname__)) {
         HDF5_tree fin(fname__, hdf5_access_t::read_only);
-        auto dims = fin.dims("config");
-        if (dims.size() != 1) {
-            RTE_THROW("wrong size of config dataset");
-        }
-        std::vector<uint8_t> s_char(dims[0]);
-        fin.read("config", s_char);
-        json_string = std::string(dims[0], ' ');
-        for (int i = 0; i < dims[0]; i++) {
-            json_string[i] = s_char[i];
-        }
+        fin.read("config", json_string);
     } else {
         auto json = preprocess_json_input(fname__);
         json_string = json.dump();

--- a/apps/mini_app/sirius.scf.cpp
+++ b/apps/mini_app/sirius.scf.cpp
@@ -171,8 +171,8 @@ ground_state(Simulation_context& ctx, int task_id, cmd_args const& args, int wri
             RTE_THROW("storage file is not found");
         }
         density.load(storage_file_name);
-        //potential.load(storage_file_name);
-        potential.generate(density, ctx.use_symmetry(), true);
+        potential.load(storage_file_name);
+        //potential.generate(density, ctx.use_symmetry(), true);
         Hamiltonian0<double> H0(potential, true);
         initialize_subspace(kset, H0);
     } else {

--- a/apps/mini_app/sirius.scf.cpp
+++ b/apps/mini_app/sirius.scf.cpp
@@ -100,17 +100,16 @@ create_sim_ctx(std::string fname__, cmd_args const& args__)
         json_string = json.dump();
     }
 
-    auto ctx_ptr            = std::make_unique<Simulation_context>(json_string, mpi::Communicator::world());
-    Simulation_context& ctx = *ctx_ptr;
+    auto ctx = std::make_unique<Simulation_context>(json_string, mpi::Communicator::world());
 
-    auto& inp = ctx.cfg().parameters();
+    auto& inp = ctx->cfg().parameters();
     if (inp.gamma_point() && !(inp.ngridk()[0] * inp.ngridk()[1] * inp.ngridk()[2] == 1)) {
         RTE_THROW("this is not a Gamma-point calculation")
     }
 
-    ctx.import(args__);
+    ctx->import(args__);
 
-    return ctx_ptr;
+    return ctx;
 }
 
 auto

--- a/apps/mini_app/sirius.scf.cpp
+++ b/apps/mini_app/sirius.scf.cpp
@@ -86,7 +86,7 @@ create_sim_ctx(std::string fname__, cmd_args const& args__)
     if (isHDF5(fname__)) {
         config_string = fname__;
     } else {
-        auto json = preprocess_json_input(fname__);
+        auto json     = preprocess_json_input(fname__);
         config_string = json.dump();
     }
 
@@ -165,7 +165,6 @@ ground_state(Simulation_context& ctx, int task_id, cmd_args const& args, int wri
         }
         density.load(fname);
         density.generate_paw_density();
-        //potential.load(fname);
         potential.generate(density, ctx.use_symmetry(), true);
         Hamiltonian0<double> H0(potential, true);
         initialize_subspace(kset, H0);

--- a/apps/utils/unit_cell_tools.cpp
+++ b/apps/utils/unit_cell_tools.cpp
@@ -34,7 +34,7 @@ create_supercell(cmd_args const& args__)
         std::cout << std::endl;
     }
 
-    Simulation_context ctx("sirius.json", mpi::Communicator::self());
+    Simulation_context ctx(std::string("sirius.json"), mpi::Communicator::self());
 
     auto scell_lattice_vectors = dot(ctx.unit_cell().lattice_vectors(), r3::matrix<double>(scell));
 
@@ -113,7 +113,7 @@ create_supercell(cmd_args const& args__)
 void
 find_primitive()
 {
-    Simulation_context ctx("sirius.json", mpi::Communicator::self());
+    Simulation_context ctx(std::string("sirius.json"), mpi::Communicator::self());
 
     double lattice[3][3];
     for (int i : {0, 1, 2}) {

--- a/examples/pp-pw/Si7Ge/sirius.json
+++ b/examples/pp-pw/Si7Ge/sirius.json
@@ -16,7 +16,7 @@
         "gk_cutoff" : 5.0,
         "pw_cutoff" : 20.00,
 
-        "energy_tol" : 1e-8,
+        "energy_tol" : 1e-7,
         "density_tol" : 1e-7,
 
         "num_dft_iter" : 100,
@@ -33,7 +33,8 @@
     "mixer" : {
       "beta" : 0.8,
       "type" : "anderson",
-      "max_history" : 8
+      "max_history" : 8,
+      "use_hartree" : true
     },
 
     "unit_cell": {

--- a/python_module/py_sirius.cpp
+++ b/python_module/py_sirius.cpp
@@ -301,8 +301,6 @@ PYBIND11_MODULE(py_sirius, m)
             .def(py::init<Simulation_context&>(), py::keep_alive<1, 2>(), "ctx"_a)
             .def("generate", &Potential::generate, "density"_a, "use_sym"_a, "transform_to_rg"_a)
             .def("fft_transform", &Potential::fft_transform)
-            .def("save", &Potential::save)
-            .def("load", &Potential::load)
             .def_property("vxc", py::overload_cast<>(&Potential::xc_potential),
                           py::overload_cast<>(&Potential::xc_potential), py::return_value_policy::reference_internal)
             .def_property("exc", py::overload_cast<>(&Potential::xc_energy_density),

--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -2819,7 +2819,7 @@ sirius_generate_effective_potential(void* const* gs_handler__, int* error_code__
     call_sirius(
             [&]() {
                 auto& gs = get_gs(gs_handler__);
-                gs.potential().generate(gs.density(), gs.ctx().use_symmetry(), false);
+                gs.potential().generate(gs.density(), gs.ctx().use_symmetry(), true);
             },
             error_code__);
 }
@@ -6454,7 +6454,6 @@ sirius_save_state(void** gs_handler__, const char* file_name__, int* error_code_
                 auto& gs = get_gs(gs_handler__);
                 std::string file_name(file_name__);
                 gs.ctx().create_storage_file(file_name);
-                gs.potential().save(file_name);
                 gs.density().save(file_name);
             },
             error_code__);
@@ -6486,7 +6485,6 @@ sirius_load_state(void** gs_handler__, const char* file_name__, int* error_code_
             [&]() {
                 auto& gs = get_gs(gs_handler__);
                 std::string file_name(file_name__);
-                gs.potential().load(file_name);
                 gs.density().load(file_name);
             },
             error_code__);

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -1206,13 +1206,8 @@ Simulation_context::create_storage_file(std::string name__) const
             fout["unit_cell"]["atoms"].create_node(j);
             fout["unit_cell"]["atoms"][j].write("mt_basis_size", unit_cell().atom(j).mt_basis_size());
         }
-
-        auto s = this->serialize()["config"].dump();
-        mdarray<uint8_t, 1> s_char({s.size()});
-        for (size_t i = 0; i < s.size(); i++) {
-            s_char[i] = s[i];
-        }
-        fout.write("config", s_char);
+        auto dict = this->serialize()["config"];
+        fout.write("config", this->serialize()["config"].dump());
     }
     comm_.barrier();
 }

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -1172,7 +1172,13 @@ Simulation_context::create_storage_file(std::string name__) const
         fout.create_node("parameters");
         fout.create_node("effective_potential");
         fout.create_node("effective_magnetic_field");
+        fout.create_node("xc_energy_density");
+        fout.create_node("xc_potential");
         fout.create_node("density");
+        fout.create_node("density_matrix");
+        for (int ia = 0; ia < this->unit_cell().num_atoms(); ia++) {
+            fout["density_matrix"].create_node(ia);
+        }
         fout.create_node("magnetization");
 
         for (int j = 0; j < num_mag_dims(); j++) {

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -1173,16 +1173,16 @@ Simulation_context::create_storage_file(std::string name__) const
         /* create new hdf5 file */
         HDF5_tree fout(name__, hdf5_access_t::truncate);
         fout.create_node("parameters");
-        fout.create_node("effective_potential");
-        fout.create_node("effective_magnetic_field");
-        fout.create_node("xc_energy_density");
-        fout.create_node("xc_potential");
+        //fout.create_node("effective_potential");
+        //fout.create_node("effective_magnetic_field");
+        //fout.create_node("xc_energy_density");
+        //fout.create_node("xc_potential");
         fout.create_node("density");
         fout.create_node("magnetization");
 
         for (int j = 0; j < num_mag_dims(); j++) {
             fout["magnetization"].create_node(j);
-            fout["effective_magnetic_field"].create_node(j);
+            //fout["effective_magnetic_field"].create_node(j);
         }
 
         fout["parameters"].write("num_spins", num_spins());
@@ -1210,7 +1210,10 @@ Simulation_context::create_storage_file(std::string name__) const
             fout["unit_cell"]["atom_types"].create_node(iat);
             fout["unit_cell"]["atom_types"][iat].write("config", unit_cell().atom_type(iat).serialize().dump());
         }
-        fout.write("config", this->serialize()["config"].dump());
+        auto config = this->serialize()["config"];
+        config.erase("locked");
+        config["control"].erase("mpi_grid_dims");
+        fout.write("config", config.dump());
     }
     comm_.barrier();
 }

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -1178,10 +1178,6 @@ Simulation_context::create_storage_file(std::string name__) const
         fout.create_node("xc_energy_density");
         fout.create_node("xc_potential");
         fout.create_node("density");
-        fout.create_node("density_matrix");
-        for (int ia = 0; ia < this->unit_cell().num_atoms(); ia++) {
-            fout["density_matrix"].create_node(ia);
-        }
         fout.create_node("magnetization");
 
         for (int j = 0; j < num_mag_dims(); j++) {

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -1173,16 +1173,11 @@ Simulation_context::create_storage_file(std::string name__) const
         /* create new hdf5 file */
         HDF5_tree fout(name__, hdf5_access_t::truncate);
         fout.create_node("parameters");
-        //fout.create_node("effective_potential");
-        //fout.create_node("effective_magnetic_field");
-        //fout.create_node("xc_energy_density");
-        //fout.create_node("xc_potential");
         fout.create_node("density");
         fout.create_node("magnetization");
 
         for (int j = 0; j < num_mag_dims(); j++) {
             fout["magnetization"].create_node(j);
-            //fout["effective_magnetic_field"].create_node(j);
         }
 
         fout["parameters"].write("num_spins", num_spins());

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -1200,6 +1200,13 @@ Simulation_context::create_storage_file(std::string name__) const
             fout["unit_cell"]["atoms"].create_node(j);
             fout["unit_cell"]["atoms"][j].write("mt_basis_size", unit_cell().atom(j).mt_basis_size());
         }
+
+        auto s = this->serialize()["config"].dump();
+        mdarray<uint8_t, 1> s_char({s.size()});
+        for (size_t i = 0; i < s.size(); i++) {
+            s_char[i] = s[i];
+        }
+        fout.write("config", s_char);
     }
     comm_.barrier();
 }

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -1208,6 +1208,10 @@ Simulation_context::create_storage_file(std::string name__) const
         auto config = this->serialize()["config"];
         config.erase("locked");
         config["control"].erase("mpi_grid_dims");
+        config["control"].erase("fft_mode");
+        config["control"].erase("gen_evp_solver_name");
+        config["control"].erase("std_evp_solver_name");
+        config["settings"].erase("fft_grid_size");
         fout.write("config", config.dump());
     }
     comm_.barrier();

--- a/src/context/simulation_context.hpp
+++ b/src/context/simulation_context.hpp
@@ -330,7 +330,7 @@ class Simulation_context : public Simulation_parameters
     }
 
     /// Create a simulation context with world communicator and load parameters from JSON string or a file.
-    explicit Simulation_context(std::string const& str__, mpi::Communicator const& comm__ =  mpi::Communicator::world())
+    explicit Simulation_context(std::string const& str__, mpi::Communicator const& comm__ = mpi::Communicator::world())
         : comm_(comm__)
     {
         init_common();
@@ -339,8 +339,8 @@ class Simulation_context : public Simulation_parameters
             std::string json_string;
             fin.read("config", json_string);
             auto dict = read_json_from_file_or_string(json_string);
-            for (auto& e: dict["unit_cell"]["atom_types"]) {
-                auto label = e.get<std::string>();
+            for (auto& e : dict["unit_cell"]["atom_types"]) {
+                auto label                             = e.get<std::string>();
                 dict["unit_cell"]["atom_files"][label] = "";
             }
             import(dict);
@@ -359,7 +359,7 @@ class Simulation_context : public Simulation_parameters
     }
 
     explicit Simulation_context(nlohmann::json const& dict__,
-            mpi::Communicator const& comm__ =  mpi::Communicator::world())
+                                mpi::Communicator const& comm__ = mpi::Communicator::world())
         : comm_(comm__)
     {
         init_common();

--- a/src/context/simulation_context.hpp
+++ b/src/context/simulation_context.hpp
@@ -764,7 +764,7 @@ class Simulation_context : public Simulation_parameters
 
     /// Export parameters of simulation context as a JSON dictionary.
     nlohmann::json
-    serialize()
+    serialize() const
     {
         nlohmann::json dict;
         dict["config"] = cfg().dict();

--- a/src/context/simulation_parameters.cpp
+++ b/src/context/simulation_parameters.cpp
@@ -176,6 +176,8 @@ Simulation_parameters::import(cmd_args const& args__)
             args__.value("iterative_solver.early_restart", cfg_.iterative_solver().early_restart()));
     cfg_.iterative_solver().energy_tolerance(
             args__.value("iterative_solver.energy_tolerance", cfg_.iterative_solver().energy_tolerance()));
+    cfg_.iterative_solver().num_steps(
+            args__.value("iterative_solver.num_steps", cfg_.iterative_solver().num_steps()));
     cfg_.mixer().beta(args__.value("mixer.beta", cfg_.mixer().beta()));
     cfg_.mixer().type(args__.value("mixer.type", cfg_.mixer().type()));
 }

--- a/src/context/simulation_parameters.cpp
+++ b/src/context/simulation_parameters.cpp
@@ -174,6 +174,8 @@ Simulation_parameters::import(cmd_args const& args__)
 
     cfg_.iterative_solver().early_restart(
             args__.value("iterative_solver.early_restart", cfg_.iterative_solver().early_restart()));
+    cfg_.iterative_solver().energy_tolerance(
+            args__.value("iterative_solver.energy_tolerance", cfg_.iterative_solver().energy_tolerance()));
     cfg_.mixer().beta(args__.value("mixer.beta", cfg_.mixer().beta()));
     cfg_.mixer().type(args__.value("mixer.type", cfg_.mixer().type()));
 }

--- a/src/context/simulation_parameters.cpp
+++ b/src/context/simulation_parameters.cpp
@@ -142,16 +142,16 @@ get_section_options(std::string const& section__)
 }
 
 void
-Simulation_parameters::import(std::string const& str__)
-{
-    auto json = read_json_from_file_or_string(str__);
-    import(json);
-}
-
-void
 Simulation_parameters::import(nlohmann::json const& dict__)
 {
     cfg_.import(dict__);
+}
+
+void
+Simulation_parameters::import(std::string const& str__)
+{
+    auto dict = read_json_from_file_or_string(str__);
+    this->import(dict);
 }
 
 void

--- a/src/context/simulation_parameters.cpp
+++ b/src/context/simulation_parameters.cpp
@@ -176,8 +176,7 @@ Simulation_parameters::import(cmd_args const& args__)
             args__.value("iterative_solver.early_restart", cfg_.iterative_solver().early_restart()));
     cfg_.iterative_solver().energy_tolerance(
             args__.value("iterative_solver.energy_tolerance", cfg_.iterative_solver().energy_tolerance()));
-    cfg_.iterative_solver().num_steps(
-            args__.value("iterative_solver.num_steps", cfg_.iterative_solver().num_steps()));
+    cfg_.iterative_solver().num_steps(args__.value("iterative_solver.num_steps", cfg_.iterative_solver().num_steps()));
     cfg_.mixer().beta(args__.value("mixer.beta", cfg_.mixer().beta()));
     cfg_.mixer().type(args__.value("mixer.type", cfg_.mixer().type()));
 }

--- a/src/core/hdf5_tree.hpp
+++ b/src/core/hdf5_tree.hpp
@@ -70,6 +70,12 @@ struct hdf5_type_wrapper<uint8_t>
     };
 };
 
+inline bool
+isHDF5(std::string const& filename__)
+{
+    return H5Fis_hdf5(filename__.c_str()) > 0;
+}
+
 /// Interface to the HDF5 library.
 class HDF5_tree
 {

--- a/src/core/json.hpp
+++ b/src/core/json.hpp
@@ -39,6 +39,16 @@ try_parse(std::istream& is)
     return dict;
 }
 
+inline bool
+is_json_string(std::string const& str__) {
+    try {
+        auto json = nlohmann::json::parse(str__);
+        return true;
+    } catch (nlohmann::json::parse_error const&) {
+    }
+    return false;
+}
+
 inline nlohmann::json
 read_json_from_file(std::string const& filename)
 {

--- a/src/core/json.hpp
+++ b/src/core/json.hpp
@@ -40,7 +40,8 @@ try_parse(std::istream& is)
 }
 
 inline bool
-is_json_string(std::string const& str__) {
+is_json_string(std::string const& str__)
+{
     try {
         auto json = nlohmann::json::parse(str__);
         return true;

--- a/src/density/density.cpp
+++ b/src/density/density.cpp
@@ -2062,7 +2062,8 @@ Density::save(std::string name__) const
                 fout["occupation_matrix"]["local"].create_node(i).write("data", this->occupation_matrix().local(i));
             }
             for (size_t i = 0; i < this->occupation_matrix().nonlocal().size(); i++) {
-                fout["occupation_matrix"]["nonlocal"].create_node(i).write("data", this->occupation_matrix().nonlocal(i));
+                fout["occupation_matrix"]["nonlocal"].create_node(i).write("data",
+                                                                           this->occupation_matrix().nonlocal(i));
             }
         }
     }

--- a/src/density/density.hpp
+++ b/src/density/density.hpp
@@ -609,6 +609,12 @@ class Density : public Field4D
             mag(j).hdf5_write(name__, s.str());
         }
         ctx_.comm().barrier();
+        if (ctx_.comm().rank() == 0) {
+            HDF5_tree fout(name__, hdf5_access_t::read_write);
+            for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
+                fout["density_matrix"][ia].write("data", this->density_matrix(ia));
+            }
+        }
     }
 
     void
@@ -623,6 +629,10 @@ class Density : public Field4D
         }
         mdarray<int, 2> gv({3, ngv});
         fin.read("/parameters/gvec", gv);
+
+        for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
+            fin["density_matrix"][ia].read("data", this->density_matrix(ia));
+        }
 
         rho().hdf5_read(name__, "density", gv);
         rho().rg().fft_transform(1);

--- a/src/density/density.hpp
+++ b/src/density/density.hpp
@@ -600,47 +600,10 @@ class Density : public Field4D
     }
 
     void
-    save(std::string name__) const
-    {
-        rho().hdf5_write(name__, "density");
-        for (int j = 0; j < ctx_.num_mag_dims(); j++) {
-            std::stringstream s;
-            s << "magnetization/" << j;
-            mag(j).hdf5_write(name__, s.str());
-        }
-        ctx_.comm().barrier();
-        if (ctx_.comm().rank() == 0) {
-            HDF5_tree fout(name__, hdf5_access_t::read_write);
-            for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
-                fout["density_matrix"][ia].write("data", this->density_matrix(ia));
-            }
-        }
-    }
+    save(std::string name__) const;
 
     void
-    load(std::string name__)
-    {
-        HDF5_tree fin(name__, hdf5_access_t::read_only);
-
-        int ngv;
-        fin.read("/parameters/num_gvec", &ngv, 1);
-        if (ngv != ctx_.gvec().num_gvec()) {
-            RTE_THROW("wrong number of G-vectors");
-        }
-        mdarray<int, 2> gv({3, ngv});
-        fin.read("/parameters/gvec", gv);
-
-        for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
-            fin["density_matrix"][ia].read("data", this->density_matrix(ia));
-        }
-
-        rho().hdf5_read(name__, "density", gv);
-        rho().rg().fft_transform(1);
-        for (int j = 0; j < ctx_.num_mag_dims(); j++) {
-            mag(j).hdf5_read(name__, "magnetization/" + std::to_string(j), gv);
-            mag(j).rg().fft_transform(1);
-        }
-    }
+    load(std::string name__);
 
     void
     save_to_xsf()

--- a/src/dft/dft_ground_state.cpp
+++ b/src/dft/dft_ground_state.cpp
@@ -348,7 +348,8 @@ DFT_ground_state::find(double density_tol__, double energy_tol__, double iter_so
         ctx_.message(2, __func__, out);
         /* check if the calculation has converged */
         bool converged{true};
-        converged = (std::abs(eold - etot) < energy_tol__) && result.converged && iter_solver_converged;
+        //converged = (std::abs(eold - etot) < energy_tol__) && result.converged && iter_solver_converged;
+        converged = (std::abs(eold - etot) < energy_tol__) && iter_solver_converged;
         if (ctx_.cfg().mixer().use_hartree()) {
             converged = converged && (eha_res < density_tol__);
         } else {
@@ -379,7 +380,7 @@ DFT_ground_state::find(double density_tol__, double energy_tol__, double iter_so
                 density_.mag(j).rg().fft_transform(-1);
             }
         }
-        potential_.save(storage_file_name);
+        //potential_.save(storage_file_name);
         density_.save(storage_file_name);
         // kset_.save(storage_file_name);
     }

--- a/src/dft/dft_ground_state.cpp
+++ b/src/dft/dft_ground_state.cpp
@@ -348,7 +348,7 @@ DFT_ground_state::find(double density_tol__, double energy_tol__, double iter_so
         ctx_.message(2, __func__, out);
         /* check if the calculation has converged */
         bool converged{true};
-        //converged = (std::abs(eold - etot) < energy_tol__) && result.converged && iter_solver_converged;
+        // converged = (std::abs(eold - etot) < energy_tol__) && result.converged && iter_solver_converged;
         converged = (std::abs(eold - etot) < energy_tol__) && iter_solver_converged;
         if (ctx_.cfg().mixer().use_hartree()) {
             converged = converged && (eha_res < density_tol__);
@@ -380,7 +380,7 @@ DFT_ground_state::find(double density_tol__, double energy_tol__, double iter_so
                 density_.mag(j).rg().fft_transform(-1);
             }
         }
-        //potential_.save(storage_file_name);
+        // potential_.save(storage_file_name);
         density_.save(storage_file_name);
         // kset_.save(storage_file_name);
     }

--- a/src/dft/dft_ground_state.hpp
+++ b/src/dft/dft_ground_state.hpp
@@ -89,7 +89,7 @@ class DFT_ground_state
         n = ctx_.num_itsol_steps();
         kset_.comm().allreduce(&n, 1);
         if (ctx_.verbosity() >= 2) {
-            RTE_OUT(ctx_.out()) << "numbef of iterative solver steps: " << n << std::endl;
+            RTE_OUT(ctx_.out()) << "number of iterative solver steps: " << n << std::endl;
         }
     }
 

--- a/src/hubbard/hubbard_matrix.cpp
+++ b/src/hubbard/hubbard_matrix.cpp
@@ -323,11 +323,11 @@ Hubbard_matrix::print_nonlocal(int idx__, std::ostream& out__) const
 void
 Hubbard_matrix::zero()
 {
-    for (int ia = 0; ia < static_cast<int>(local_.size()); ia++) {
-        local_[ia].zero();
+    for (int i = 0; i < static_cast<int>(local_.size()); i++) {
+        local_[i].zero();
     }
 
-    for (int i = 0; i < static_cast<int>(ctx_.cfg().hubbard().nonlocal().size()); i++) {
+    for (int i = 0; i < static_cast<int>(nonlocal_.size()); i++) {
         nonlocal_[i].zero();
     }
 
@@ -335,6 +335,18 @@ Hubbard_matrix::zero()
         if (apply_constraints(at_lvl)) {
             multipliers_constraints_[at_lvl].zero();
         }
+    }
+}
+
+void
+Hubbard_matrix::print(std::ostream& out__) const
+{
+    for (int i = 0; i < static_cast<int>(local_.size()); i++) {
+        this->print_local(i, out__);
+    }
+
+    for (int i = 0; i < static_cast<int>(nonlocal_.size()); i++) {
+        this->print_nonlocal(i, out__);
     }
 }
 

--- a/src/hubbard/hubbard_matrix.hpp
+++ b/src/hubbard/hubbard_matrix.hpp
@@ -63,10 +63,13 @@ class Hubbard_matrix
     access(std::string const& what__, std::complex<double>* ptr__, int ld__);
 
     void
-    print_local(int ia__, std::ostream& out__) const;
+    print_local(int idx__, std::ostream& out__) const;
 
     void
     print_nonlocal(int idx__, std::ostream& out__) const;
+
+    void
+    print(std::ostream& out__) const;
 
     void
     zero();

--- a/src/potential/potential.cpp
+++ b/src/potential/potential.cpp
@@ -372,62 +372,6 @@ Potential::generate(Density const& density__, bool use_symmetry__, bool transfor
     }
 }
 
-//void
-//Potential::save(std::string name__)
-//{
-//    effective_potential().hdf5_write(name__, "effective_potential");
-//    for (int j = 0; j < ctx_.num_mag_dims(); j++) {
-//        effective_magnetic_field(j).hdf5_write(name__, "effective_magnetic_field/" + std::to_string(j));
-//    }
-//    xc_energy_density().hdf5_write(name__, "xc_energy_density");
-//    xc_potential().hdf5_write(name__, "xc_potential");
-//    if (ctx_.comm().rank() == 0 && !ctx_.full_potential()) {
-//        HDF5_tree fout(name__, hdf5_access_t::read_write);
-//        for (int j = 0; j < ctx_.unit_cell().num_atoms(); j++) {
-//            if (ctx_.unit_cell().atom(j).mt_basis_size() != 0) {
-//                fout["unit_cell"]["atoms"][j].write("D_operator", ctx_.unit_cell().atom(j).d_mtrx());
-//            }
-//        }
-//    }
-//    comm_.barrier();
-//}
-//
-//void
-//Potential::load(std::string name__)
-//{
-//    HDF5_tree fin(name__, hdf5_access_t::read_only);
-//
-//    int ngv;
-//    fin.read("/parameters/num_gvec", &ngv, 1);
-//    if (ngv != ctx_.gvec().num_gvec()) {
-//        RTE_THROW("wrong number of G-vectors");
-//    }
-//    mdarray<int, 2> gv({3, ngv});
-//    fin.read("/parameters/gvec", gv);
-//
-//    effective_potential().hdf5_read(name__, "effective_potential", gv);
-//    effective_potential().rg().fft_transform(1);
-//
-//    for (int j = 0; j < ctx_.num_mag_dims(); j++) {
-//        effective_magnetic_field(j).hdf5_read(name__, "effective_magnetic_field/" + std::to_string(j), gv);
-//        effective_magnetic_field(j).rg().fft_transform(1);
-//    }
-//    xc_energy_density().hdf5_read(name__, "xc_energy_density", gv);
-//    xc_energy_density().rg().fft_transform(1);
-//    xc_potential().hdf5_read(name__, "xc_potential", gv);
-//    xc_potential().rg().fft_transform(1);
-//
-//    if (ctx_.full_potential()) {
-//        update_atomic_potential();
-//    }
-//
-//    if (!ctx_.full_potential()) {
-//        for (int j = 0; j < ctx_.unit_cell().num_atoms(); j++) {
-//            fin["unit_cell"]["atoms"][j].read("D_operator", ctx_.unit_cell().atom(j).d_mtrx());
-//        }
-//    }
-//}
-
 void
 Potential::update_atomic_potential()
 {

--- a/src/potential/potential.cpp
+++ b/src/potential/potential.cpp
@@ -379,6 +379,8 @@ Potential::save(std::string name__)
     for (int j = 0; j < ctx_.num_mag_dims(); j++) {
         effective_magnetic_field(j).hdf5_write(name__, "effective_magnetic_field/" + std::to_string(j));
     }
+    xc_energy_density().hdf5_write(name__, "xc_energy_density");
+    xc_potential().hdf5_write(name__, "xc_potential");
     if (ctx_.comm().rank() == 0 && !ctx_.full_potential()) {
         HDF5_tree fout(name__, hdf5_access_t::read_write);
         for (int j = 0; j < ctx_.unit_cell().num_atoms(); j++) {
@@ -404,10 +406,16 @@ Potential::load(std::string name__)
     fin.read("/parameters/gvec", gv);
 
     effective_potential().hdf5_read(name__, "effective_potential", gv);
+    effective_potential().rg().fft_transform(1);
 
     for (int j = 0; j < ctx_.num_mag_dims(); j++) {
         effective_magnetic_field(j).hdf5_read(name__, "effective_magnetic_field/" + std::to_string(j), gv);
+        effective_magnetic_field(j).rg().fft_transform(1);
     }
+    xc_energy_density().hdf5_read(name__, "xc_energy_density", gv);
+    xc_energy_density().rg().fft_transform(1);
+    xc_potential().hdf5_read(name__, "xc_potential", gv);
+    xc_potential().rg().fft_transform(1);
 
     if (ctx_.full_potential()) {
         update_atomic_potential();

--- a/src/potential/potential.cpp
+++ b/src/potential/potential.cpp
@@ -296,7 +296,7 @@ Potential::generate(Density const& density__, bool use_symmetry__, bool transfor
          *  1) compute D-matrix
          *  2) establish a mapping between fine and coarse FFT grid for the Hloc operator
          *  3) symmetrize effective potential */
-        fft_transform(-1);
+        this->fft_transform(-1);
     }
 
     if (use_symmetry__) {

--- a/src/potential/potential.cpp
+++ b/src/potential/potential.cpp
@@ -372,61 +372,61 @@ Potential::generate(Density const& density__, bool use_symmetry__, bool transfor
     }
 }
 
-void
-Potential::save(std::string name__)
-{
-    effective_potential().hdf5_write(name__, "effective_potential");
-    for (int j = 0; j < ctx_.num_mag_dims(); j++) {
-        effective_magnetic_field(j).hdf5_write(name__, "effective_magnetic_field/" + std::to_string(j));
-    }
-    xc_energy_density().hdf5_write(name__, "xc_energy_density");
-    xc_potential().hdf5_write(name__, "xc_potential");
-    if (ctx_.comm().rank() == 0 && !ctx_.full_potential()) {
-        HDF5_tree fout(name__, hdf5_access_t::read_write);
-        for (int j = 0; j < ctx_.unit_cell().num_atoms(); j++) {
-            if (ctx_.unit_cell().atom(j).mt_basis_size() != 0) {
-                fout["unit_cell"]["atoms"][j].write("D_operator", ctx_.unit_cell().atom(j).d_mtrx());
-            }
-        }
-    }
-    comm_.barrier();
-}
-
-void
-Potential::load(std::string name__)
-{
-    HDF5_tree fin(name__, hdf5_access_t::read_only);
-
-    int ngv;
-    fin.read("/parameters/num_gvec", &ngv, 1);
-    if (ngv != ctx_.gvec().num_gvec()) {
-        RTE_THROW("wrong number of G-vectors");
-    }
-    mdarray<int, 2> gv({3, ngv});
-    fin.read("/parameters/gvec", gv);
-
-    effective_potential().hdf5_read(name__, "effective_potential", gv);
-    effective_potential().rg().fft_transform(1);
-
-    for (int j = 0; j < ctx_.num_mag_dims(); j++) {
-        effective_magnetic_field(j).hdf5_read(name__, "effective_magnetic_field/" + std::to_string(j), gv);
-        effective_magnetic_field(j).rg().fft_transform(1);
-    }
-    xc_energy_density().hdf5_read(name__, "xc_energy_density", gv);
-    xc_energy_density().rg().fft_transform(1);
-    xc_potential().hdf5_read(name__, "xc_potential", gv);
-    xc_potential().rg().fft_transform(1);
-
-    if (ctx_.full_potential()) {
-        update_atomic_potential();
-    }
-
-    if (!ctx_.full_potential()) {
-        for (int j = 0; j < ctx_.unit_cell().num_atoms(); j++) {
-            fin["unit_cell"]["atoms"][j].read("D_operator", ctx_.unit_cell().atom(j).d_mtrx());
-        }
-    }
-}
+//void
+//Potential::save(std::string name__)
+//{
+//    effective_potential().hdf5_write(name__, "effective_potential");
+//    for (int j = 0; j < ctx_.num_mag_dims(); j++) {
+//        effective_magnetic_field(j).hdf5_write(name__, "effective_magnetic_field/" + std::to_string(j));
+//    }
+//    xc_energy_density().hdf5_write(name__, "xc_energy_density");
+//    xc_potential().hdf5_write(name__, "xc_potential");
+//    if (ctx_.comm().rank() == 0 && !ctx_.full_potential()) {
+//        HDF5_tree fout(name__, hdf5_access_t::read_write);
+//        for (int j = 0; j < ctx_.unit_cell().num_atoms(); j++) {
+//            if (ctx_.unit_cell().atom(j).mt_basis_size() != 0) {
+//                fout["unit_cell"]["atoms"][j].write("D_operator", ctx_.unit_cell().atom(j).d_mtrx());
+//            }
+//        }
+//    }
+//    comm_.barrier();
+//}
+//
+//void
+//Potential::load(std::string name__)
+//{
+//    HDF5_tree fin(name__, hdf5_access_t::read_only);
+//
+//    int ngv;
+//    fin.read("/parameters/num_gvec", &ngv, 1);
+//    if (ngv != ctx_.gvec().num_gvec()) {
+//        RTE_THROW("wrong number of G-vectors");
+//    }
+//    mdarray<int, 2> gv({3, ngv});
+//    fin.read("/parameters/gvec", gv);
+//
+//    effective_potential().hdf5_read(name__, "effective_potential", gv);
+//    effective_potential().rg().fft_transform(1);
+//
+//    for (int j = 0; j < ctx_.num_mag_dims(); j++) {
+//        effective_magnetic_field(j).hdf5_read(name__, "effective_magnetic_field/" + std::to_string(j), gv);
+//        effective_magnetic_field(j).rg().fft_transform(1);
+//    }
+//    xc_energy_density().hdf5_read(name__, "xc_energy_density", gv);
+//    xc_energy_density().rg().fft_transform(1);
+//    xc_potential().hdf5_read(name__, "xc_potential", gv);
+//    xc_potential().rg().fft_transform(1);
+//
+//    if (ctx_.full_potential()) {
+//        update_atomic_potential();
+//    }
+//
+//    if (!ctx_.full_potential()) {
+//        for (int j = 0; j < ctx_.unit_cell().num_atoms(); j++) {
+//            fin["unit_cell"]["atoms"][j].read("D_operator", ctx_.unit_cell().atom(j).d_mtrx());
+//        }
+//    }
+//}
 
 void
 Potential::update_atomic_potential()

--- a/src/potential/potential.hpp
+++ b/src/potential/potential.hpp
@@ -608,11 +608,11 @@ class Potential : public Field4D
     void
     generate(Density const& density__, bool use_sym__, bool transform_to_rg__);
 
-    void
-    save(std::string name__);
+    //void
+    //save(std::string name__);
 
-    void
-    load(std::string name__);
+    //void
+    //load(std::string name__);
 
     void
     update_atomic_potential();

--- a/src/potential/potential.hpp
+++ b/src/potential/potential.hpp
@@ -608,12 +608,6 @@ class Potential : public Field4D
     void
     generate(Density const& density__, bool use_sym__, bool transform_to_rg__);
 
-    //void
-    //save(std::string name__);
-
-    //void
-    //load(std::string name__);
-
     void
     update_atomic_potential();
 

--- a/src/unit_cell/atom_type.cpp
+++ b/src/unit_cell/atom_type.cpp
@@ -1348,4 +1348,144 @@ Atom_type::serialize() const
     return result;
 }
 
+void
+Atom_type::init_aw_descriptors()
+{
+    RTE_ASSERT(this->lmax_apw() >= -1);
+
+    if (this->lmax_apw() >= 0 && aw_default_l_.size() == 0) {
+        RTE_THROW("default AW descriptor is empty");
+    }
+
+    aw_descriptors_.clear();
+    for (int l = 0; l <= this->lmax_apw(); l++) {
+        aw_descriptors_.push_back(aw_default_l_);
+        for (size_t ord = 0; ord < aw_descriptors_[l].size(); ord++) {
+            aw_descriptors_[l][ord].n = l + 1;
+            aw_descriptors_[l][ord].l = l;
+        }
+    }
+
+    for (size_t i = 0; i < aw_specific_l_.size(); i++) {
+        int l = aw_specific_l_[i][0].l;
+        if (l < this->lmax_apw()) {
+            aw_descriptors_[l] = aw_specific_l_[i];
+        }
+    }
+}
+
+void
+Atom_type::add_aw_descriptor(int n, int l, double enu, int dme, int auto_enu)
+{
+    if (static_cast<int>(aw_descriptors_.size()) < (l + 1)) {
+        aw_descriptors_.resize(l + 1, radial_solution_descriptor_set());
+    }
+
+    radial_solution_descriptor rsd;
+
+    rsd.n = n;
+    if (n == -1) {
+        /* default principal quantum number value for any l */
+        rsd.n = l + 1;
+        for (int ist = 0; ist < num_atomic_levels(); ist++) {
+            /* take next level after the core */
+            if (atomic_level(ist).core && atomic_level(ist).l == l) {
+                rsd.n = atomic_level(ist).n + 1;
+            }
+        }
+    }
+
+    rsd.l        = l;
+    rsd.dme      = dme;
+    rsd.enu      = enu;
+    rsd.auto_enu = auto_enu;
+    aw_descriptors_[l].push_back(rsd);
+}
+
+void
+Atom_type::add_lo_descriptor(int ilo, int n, int l, double enu, int dme, int auto_enu)
+{
+    if ((int)lo_descriptors_.size() == ilo) {
+        angular_momentum am(l);
+        lo_descriptors_.push_back(local_orbital_descriptor(am));
+    } else {
+        if (l != lo_descriptors_[ilo].am.l()) {
+            std::stringstream s;
+            s << "wrong angular quantum number" << std::endl
+              << "atom type id: " << id() << " (" << symbol_ << ")" << std::endl
+              << "idxlo: " << ilo << std::endl
+              << "n: " << l << std::endl
+              << "l: " << n << std::endl
+              << "expected l: " << lo_descriptors_[ilo].am.l() << std::endl;
+            RTE_THROW(s);
+        }
+    }
+
+    radial_solution_descriptor rsd;
+
+    rsd.n = n;
+    if (n == -1) {
+        /* default value for any l */
+        rsd.n = l + 1;
+        for (int ist = 0; ist < num_atomic_levels(); ist++) {
+            if (atomic_level(ist).core && atomic_level(ist).l == l) {
+                /* take next level after the core */
+                rsd.n = atomic_level(ist).n + 1;
+            }
+        }
+    }
+
+    rsd.l        = l;
+    rsd.dme      = dme;
+    rsd.enu      = enu;
+    rsd.auto_enu = auto_enu;
+    lo_descriptors_[ilo].rsd_set.push_back(rsd);
+}
+
+void
+Atom_type::add_ps_atomic_wf(int n__, angular_momentum am__, std::vector<double> f__, double occ__ = 0.0)
+{
+    Spline<double> rwf(radial_grid_, f__);
+    auto d = std::sqrt(inner(rwf, rwf, 0, radial_grid_.num_points()));
+    if (d < 1e-4) {
+        std::stringstream s;
+        s << "small norm (" << d << ") of radial atomic pseudo wave-function for n=" << n__
+          << " and j=" << am__.j();
+        RTE_THROW(s);
+    }
+
+    ps_atomic_wfs_.emplace_back(n__, am__, occ__, std::move(rwf));
+}
+
+void
+Atom_type::add_q_radial_function(int idxrf1__, int idxrf2__, int l__, std::vector<double> qrf__)
+{
+    /* sanity check */
+    if (l__ > 2 * lmax_beta()) {
+        std::stringstream s;
+        s << "wrong l for Q radial functions of atom type " << label_ << std::endl
+          << "current l: " << l__ << std::endl
+          << "lmax_beta: " << lmax_beta() << std::endl
+          << "maximum allowed l: " << 2 * lmax_beta();
+
+        RTE_THROW(s);
+    }
+
+    if (!augment_) {
+        /* once we add a Q-radial function, we need to augment the charge */
+        augment_ = true;
+        /* number of radial beta-functions */
+        int nbrf              = num_beta_radial_functions();
+        q_radial_functions_l_ = mdarray<Spline<double>, 2>({nbrf * (nbrf + 1) / 2, 2 * lmax_beta() + 1});
+
+        for (int l = 0; l <= 2 * lmax_beta(); l++) {
+            for (int idx = 0; idx < nbrf * (nbrf + 1) / 2; idx++) {
+                q_radial_functions_l_(idx, l) = Spline<double>(radial_grid_);
+            }
+        }
+    }
+
+    q_radial_functions_l_(packed_index(idxrf1__, idxrf2__), l__) = Spline<double>(radial_grid_, qrf__);
+}
+
 } // namespace sirius

--- a/src/unit_cell/atom_type.cpp
+++ b/src/unit_cell/atom_type.cpp
@@ -1265,9 +1265,7 @@ Atom_type::add_hubbard_orbital(int n__, int l__, double occ__, double U, double 
 nlohmann::json
 Atom_type::serialize() const
 {
-    nlohmann::json dict = {
-        {"header", nlohmann::json::object()}
-    };
+    nlohmann::json dict = {{"header", nlohmann::json::object()}};
 
     dict["header"]["z_valence"] = zn_;
     dict["header"]["mesh_size"] = this->num_mt_points();
@@ -1279,24 +1277,24 @@ Atom_type::serialize() const
         dict["header"]["pseudo_type"] = "NC";
     }
     dict["header"]["number_of_proj"] = num_beta_radial_functions();
-    dict["header"]["element"] = symbol_;
-    dict["radial_grid"] = radial_grid().values();
-    dict["local_potential"] = local_potential();
-    dict["core_charge_density"] = ps_core_charge_density();
-    dict["total_charge_density"] = ps_total_charge_density();
-    dict["atomic_wave_functions"] = nlohmann::json::array();
-    for (auto& e: ps_atomic_wfs_) {
-        auto o = nlohmann::json::object();
-        o["angular_momentum"] = e.am.l();
-        o["radial_function"] = e.f.values();
+    dict["header"]["element"]        = symbol_;
+    dict["radial_grid"]              = radial_grid().values();
+    dict["local_potential"]          = local_potential();
+    dict["core_charge_density"]      = ps_core_charge_density();
+    dict["total_charge_density"]     = ps_total_charge_density();
+    dict["atomic_wave_functions"]    = nlohmann::json::array();
+    for (auto& e : ps_atomic_wfs_) {
+        auto o                        = nlohmann::json::object();
+        o["angular_momentum"]         = e.am.l();
+        o["radial_function"]          = e.f.values();
         o["principal_quantum_number"] = e.n;
         dict["atomic_wave_functions"].push_back(o);
     }
     dict["beta_projectors"] = nlohmann::json::array();
-    for (auto& e: beta_radial_functions_) {
-        auto o = nlohmann::json::object();
+    for (auto& e : beta_radial_functions_) {
+        auto o                = nlohmann::json::object();
         o["angular_momentum"] = e.first.l();
-        o["radial_function"] = e.second.values();
+        o["radial_function"]  = e.second.values();
         dict["beta_projectors"].push_back(o);
     }
     int nbf = num_beta_radial_functions();
@@ -1312,38 +1310,36 @@ Atom_type::serialize() const
         for (int i = 0; i < nbf; i++) {
             for (int j = i; j < nbf; j++) {
                 for (int l = 0; l <= 2 * lmax_beta(); l++) {
-                    auto o = nlohmann::json::object();
-                    o["i"] = i;
-                    o["j"] = j;
+                    auto o                = nlohmann::json::object();
+                    o["i"]                = i;
+                    o["j"]                = j;
                     o["angular_momentum"] = l;
-                    o["radial_function"] = q_radial_function(i, j, l).values();
+                    o["radial_function"]  = q_radial_function(i, j, l).values();
                     dict["augmentation"].push_back(o);
                 }
             }
         }
     }
     if (is_paw()) {
-        auto paw = nlohmann::json::object();
+        auto paw                      = nlohmann::json::object();
         paw["ae_core_charge_density"] = paw_ae_core_charge_density();
-        paw["ae_wfc"] = nlohmann::json::array();
-        for (auto& e: ae_paw_wfs_) {
-            auto o = nlohmann::json::object();
+        paw["ae_wfc"]                 = nlohmann::json::array();
+        for (auto& e : ae_paw_wfs_) {
+            auto o               = nlohmann::json::object();
             o["radial_function"] = e;
             paw["ae_wfc"].push_back(o);
         }
         paw["pw_wfc"] = nlohmann::json::array();
-        for (auto& e: ps_paw_wfs_) {
-            auto o = nlohmann::json::object();
+        for (auto& e : ps_paw_wfs_) {
+            auto o               = nlohmann::json::object();
             o["radial_function"] = e;
             paw["ps_wfc"].push_back(o);
         }
         paw["occupations"] = paw_wf_occ_;
-        dict["paw_data"] = paw;
+        dict["paw_data"]   = paw;
     }
 
-    nlohmann::json result = {
-        {"pseudo_potential", dict}
-    };
+    nlohmann::json result = {{"pseudo_potential", dict}};
 
     return result;
 }
@@ -1449,8 +1445,7 @@ Atom_type::add_ps_atomic_wf(int n__, angular_momentum am__, std::vector<double> 
     auto d = std::sqrt(inner(rwf, rwf, 0, radial_grid_.num_points()));
     if (d < 1e-4) {
         std::stringstream s;
-        s << "small norm (" << d << ") of radial atomic pseudo wave-function for n=" << n__
-          << " and j=" << am__.j();
+        s << "small norm (" << d << ") of radial atomic pseudo wave-function for n=" << n__ << " and j=" << am__.j();
         RTE_THROW(s);
     }
 

--- a/src/unit_cell/atom_type.cpp
+++ b/src/unit_cell/atom_type.cpp
@@ -1439,7 +1439,7 @@ Atom_type::add_lo_descriptor(int ilo, int n, int l, double enu, int dme, int aut
 }
 
 void
-Atom_type::add_ps_atomic_wf(int n__, angular_momentum am__, std::vector<double> f__, double occ__ = 0.0)
+Atom_type::add_ps_atomic_wf(int n__, angular_momentum am__, std::vector<double> f__, double occ__)
 {
     Spline<double> rwf(radial_grid_, f__);
     auto d = std::sqrt(inner(rwf, rwf, 0, radial_grid_.num_points()));

--- a/src/unit_cell/atom_type.hpp
+++ b/src/unit_cell/atom_type.hpp
@@ -376,7 +376,7 @@ class Atom_type
     void
     print_info(std::ostream& out__) const;
 
-    /// Serialize atom type information to json 
+    /// Serialize atom type information to json
     nlohmann::json
     serialize() const;
 

--- a/src/unit_cell/atom_type.hpp
+++ b/src/unit_cell/atom_type.hpp
@@ -281,13 +281,6 @@ class Atom_type
     inline void
     read_pseudo_paw(nlohmann::json const& parser);
 
-    /// Read atomic parameters from json file.
-    inline void
-    read_input(std::string const& str__);
-
-    inline void
-    read_input(nlohmann::json const& parser);
-
     /// Read atomic parameters directly from UPF v2 files
 #ifdef SIRIUS_USE_PUGIXML
     inline void
@@ -302,7 +295,7 @@ class Atom_type
 
     /// Initialize descriptors of the augmented-wave radial functions.
     inline void
-    init_aw_descriptors()
+    init_aw_descriptors() //TODO: move to cpp
     {
         RTE_ASSERT(this->lmax_apw() >= -1);
 
@@ -376,6 +369,13 @@ class Atom_type
     /// Move constructor.
     Atom_type(Atom_type&& src) = default;
 
+    /// Read atomic parameters from json file.
+    void
+    read_input(std::string const& str__);
+
+    void
+    read_input(nlohmann::json const& parser);
+
     /// Initialize the atom type.
     /** Once the unit cell is populated with all atom types and atoms, each atom type can be initialized. */
     void
@@ -398,6 +398,10 @@ class Atom_type
     /// Print basic info to standard output.
     void
     print_info(std::ostream& out__) const;
+
+    /// Serialize atom type information to json 
+    nlohmann::json
+    serialize() const;
 
     /// Set the radial grid of the given type.
     inline void
@@ -444,7 +448,7 @@ class Atom_type
 
     /// Add augmented-wave descriptor.
     inline void
-    add_aw_descriptor(int n, int l, double enu, int dme, int auto_enu)
+    add_aw_descriptor(int n, int l, double enu, int dme, int auto_enu) // TODO: move to cpp
     {
         if (static_cast<int>(aw_descriptors_.size()) < (l + 1)) {
             aw_descriptors_.resize(l + 1, radial_solution_descriptor_set());
@@ -473,7 +477,7 @@ class Atom_type
 
     /// Add local orbital descriptor
     inline void
-    add_lo_descriptor(int ilo, int n, int l, double enu, int dme, int auto_enu)
+    add_lo_descriptor(int ilo, int n, int l, double enu, int dme, int auto_enu) // TODO: move to cpp
     {
         if ((int)lo_descriptors_.size() == ilo) {
             angular_momentum am(l);
@@ -521,7 +525,7 @@ class Atom_type
 
     /// Add atomic radial function to the list.
     inline void
-    add_ps_atomic_wf(int n__, angular_momentum am__, std::vector<double> f__, double occ__ = 0.0)
+    add_ps_atomic_wf(int n__, angular_momentum am__, std::vector<double> f__, double occ__ = 0.0) // TODO: move to cpp
     {
         Spline<double> rwf(radial_grid_, f__);
         auto d = std::sqrt(inner(rwf, rwf, 0, radial_grid_.num_points()));
@@ -548,7 +552,10 @@ class Atom_type
     add_beta_radial_function(angular_momentum am__, std::vector<double> beta__)
     {
         if (augment_) {
-            RTE_THROW("can't add more beta projectors");
+            std::stringstream s;
+            s << "augmentation charge has already been added" << std::endl
+              << "this fixes the number of beta projectors to " << this->num_beta_radial_functions() << std::endl
+              << "can't add more beta projectors" << std::endl;
         }
         Spline<double> s(radial_grid_, beta__);
         beta_radial_functions_.push_back(std::make_pair(am__, std::move(s)));
@@ -572,7 +579,7 @@ class Atom_type
     /** Radial functions of beta projectors must be added already. Their total number will be used to
         deterimine the storage size for the radial functions of the augmented charge. */
     inline void
-    add_q_radial_function(int idxrf1__, int idxrf2__, int l__, std::vector<double> qrf__)
+    add_q_radial_function(int idxrf1__, int idxrf2__, int l__, std::vector<double> qrf__) // TODO: move to cpp
     {
         /* sanity check */
         if (l__ > 2 * lmax_beta()) {

--- a/src/unit_cell/unit_cell.cpp
+++ b/src/unit_cell/unit_cell.cpp
@@ -596,7 +596,7 @@ Unit_cell::generate_radial_integrals()
 }
 
 std::string
-Unit_cell::chemical_formula()
+Unit_cell::chemical_formula() const
 {
     std::string name;
     for (int iat = 0; iat < num_atom_types(); iat++) {

--- a/src/unit_cell/unit_cell.cpp
+++ b/src/unit_cell/unit_cell.cpp
@@ -379,7 +379,8 @@ Unit_cell::serialize(bool cart_pos__) const
             if (cart_pos__) {
                 v = dot(lattice_vectors_, v);
             }
-            dict["atoms"][atom_type(iat).label()].push_back({v[0], v[1], v[2]});
+            auto f = atom(ia).vector_field();
+            dict["atoms"][atom_type(iat).label()].push_back({v[0], v[1], v[2], f[0], f[1], f[2]});
         }
     }
     return dict;

--- a/src/unit_cell/unit_cell.hpp
+++ b/src/unit_cell/unit_cell.hpp
@@ -242,7 +242,7 @@ class Unit_cell
     /// Get a simple simple chemical formula bases on the total unit cell.
     /** Atoms of each type are counted and packed in a string. For example, O2Ni2 or La2O4Cu */
     std::string
-    chemical_formula();
+    chemical_formula() const;
 
     /// Update the parameters that depend on atomic positions or lattice vectors.
     void


### PR DESCRIPTION
TODO

- [x] save config to hdf5
- [x] add hdf5 functionality to read the dimensions of dataset 
- [x] read json from hdf5 in the mini-app; this will eliminate the need to save json using environment variable
- [x] test restart
- [x] save and load Hubbard occupation matrix (@mtaillefumier volunteered to have a look)
- [x] save and load density matrix in case of PAW (@toxa81)
- [x] test restart from PAW species
- [ ] save and load wave-functions (@gcistaro)
- [ ] split mini-app into ground state solver and band structure plot; band structure mini-app should start from sirius.h5 file; k-point path should be provided as separate json file
- [ ]  test qe/sirius + h5 file + band structure plot in mini-app

@gcistaro ngridk can be passed from qe to sirius using static dictionary ("parameters") at the beginning of initialization