### PR TITLE
[API] pass data back to QE

### DIFF
--- a/src/api/sirius.f90
+++ b/src/api/sirius.f90
@@ -6303,32 +6303,37 @@ deallocate(file_name_c_type)
 end subroutine sirius_load_state
 
 !
-!> @brief Set density matrix.
+!> @brief Access (get or set) density matrix.
 !> @param [in] gs_handler Ground-state handler.
+!> @param [in] access_type Access type ("get" or "set").
 !> @param [in] ia Index of atom.
-!> @param [in] dm Input density matrix.
+!> @param [inout] dm Input density matrix.
 !> @param [in] ld Leading dimension of the density matrix.
 !> @param [out] error_code Error code.
-subroutine sirius_set_density_matrix(gs_handler,ia,dm,ld,error_code)
+subroutine sirius_access_density_matrix(gs_handler,access_type,ia,dm,ld,error_code)
 implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: gs_handler
+character(*), target, intent(in) :: access_type
 integer, target, intent(in) :: ia
-complex(8), target, intent(in) :: dm(ld, ld, 3)
+complex(8), target, intent(inout) :: dm(ld, ld, 3)
 integer, target, intent(in) :: ld
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: gs_handler_ptr
+type(C_PTR) :: access_type_ptr
+character(C_CHAR), target, allocatable :: access_type_c_type(:)
 type(C_PTR) :: ia_ptr
 type(C_PTR) :: dm_ptr
 type(C_PTR) :: ld_ptr
 type(C_PTR) :: error_code_ptr
 !
 interface
-subroutine sirius_set_density_matrix_aux(gs_handler,ia,dm,ld,error_code)&
-&bind(C, name="sirius_set_density_matrix")
+subroutine sirius_access_density_matrix_aux(gs_handler,access_type,ia,dm,ld,error_code)&
+&bind(C, name="sirius_access_density_matrix")
 use, intrinsic :: ISO_C_BINDING
 type(C_PTR), value :: gs_handler
+type(C_PTR), value :: access_type
 type(C_PTR), value :: ia
 type(C_PTR), value :: dm
 type(C_PTR), value :: ld
@@ -6338,6 +6343,10 @@ end interface
 !
 gs_handler_ptr = C_NULL_PTR
 gs_handler_ptr = C_LOC(gs_handler%handler_ptr_)
+access_type_ptr = C_NULL_PTR
+allocate(access_type_c_type(len(access_type)+1))
+access_type_c_type = string_f2c(access_type)
+access_type_ptr = C_LOC(access_type_c_type)
 ia_ptr = C_NULL_PTR
 ia_ptr = C_LOC(ia)
 dm_ptr = C_NULL_PTR
@@ -6348,81 +6357,39 @@ error_code_ptr = C_NULL_PTR
 if (present(error_code)) then
 error_code_ptr = C_LOC(error_code)
 endif
-call sirius_set_density_matrix_aux(gs_handler_ptr,ia_ptr,dm_ptr,ld_ptr,error_code_ptr)
-end subroutine sirius_set_density_matrix
+call sirius_access_density_matrix_aux(gs_handler_ptr,access_type_ptr,ia_ptr,dm_ptr,&
+&ld_ptr,error_code_ptr)
+deallocate(access_type_c_type)
+end subroutine sirius_access_density_matrix
 
 !
-!> @brief Get density matrix.
-!> @param [in] gs_handler Ground-state handler.
-!> @param [in] ia Index of atom.
-!> @param [out] dm Input density matrix.
-!> @param [in] ld Leading dimension of the density matrix.
-!> @param [out] error_code Error code.
-subroutine sirius_get_density_matrix(gs_handler,ia,dm,ld,error_code)
-implicit none
-!
-type(sirius_ground_state_handler), target, intent(in) :: gs_handler
-integer, target, intent(in) :: ia
-complex(8), target, intent(out) :: dm(ld, ld, 3)
-integer, target, intent(in) :: ld
-integer, optional, target, intent(out) :: error_code
-!
-type(C_PTR) :: gs_handler_ptr
-type(C_PTR) :: ia_ptr
-type(C_PTR) :: dm_ptr
-type(C_PTR) :: ld_ptr
-type(C_PTR) :: error_code_ptr
-!
-interface
-subroutine sirius_get_density_matrix_aux(gs_handler,ia,dm,ld,error_code)&
-&bind(C, name="sirius_get_density_matrix")
-use, intrinsic :: ISO_C_BINDING
-type(C_PTR), value :: gs_handler
-type(C_PTR), value :: ia
-type(C_PTR), value :: dm
-type(C_PTR), value :: ld
-type(C_PTR), value :: error_code
-end subroutine
-end interface
-!
-gs_handler_ptr = C_NULL_PTR
-gs_handler_ptr = C_LOC(gs_handler%handler_ptr_)
-ia_ptr = C_NULL_PTR
-ia_ptr = C_LOC(ia)
-dm_ptr = C_NULL_PTR
-dm_ptr = C_LOC(dm)
-ld_ptr = C_NULL_PTR
-ld_ptr = C_LOC(ld)
-error_code_ptr = C_NULL_PTR
-if (present(error_code)) then
-error_code_ptr = C_LOC(error_code)
-endif
-call sirius_get_density_matrix_aux(gs_handler_ptr,ia_ptr,dm_ptr,ld_ptr,error_code_ptr)
-end subroutine sirius_get_density_matrix
-
-!
-!> @brief Set local occupation matrix of LDA+U+V method.
+!> @brief Access (get or set) local occupation matrix of LDA+U+V method.
 !> @param [in] handler Ground-state handler.
+!> @param [in] access_type Access type ("get" or "set").
 !> @param [in] ia Index of atom.
 !> @param [in] n Principal quantum number.
 !> @param [in] l Orbital quantum number.
 !> @param [in] spin Spin index.
-!> @param [in] occ_mtrx Local occupation matrix.
+!> @param [inout] occ_mtrx Local occupation matrix.
 !> @param [in] ld Leading dimension of the occupation matrix.
 !> @param [out] error_code Error code.
-subroutine sirius_set_local_occupation_matrix(handler,ia,n,l,spin,occ_mtrx,ld,error_code)
+subroutine sirius_access_local_occupation_matrix(handler,access_type,ia,n,l,spin,&
+&occ_mtrx,ld,error_code)
 implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
+character(*), target, intent(in) :: access_type
 integer, target, intent(in) :: ia
 integer, target, intent(in) :: n
 integer, target, intent(in) :: l
 integer, target, intent(in) :: spin
-complex(8), target, intent(in) :: occ_mtrx(ld, ld)
+complex(8), target, intent(inout) :: occ_mtrx(ld, ld)
 integer, target, intent(in) :: ld
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
+type(C_PTR) :: access_type_ptr
+character(C_CHAR), target, allocatable :: access_type_c_type(:)
 type(C_PTR) :: ia_ptr
 type(C_PTR) :: n_ptr
 type(C_PTR) :: l_ptr
@@ -6432,11 +6399,12 @@ type(C_PTR) :: ld_ptr
 type(C_PTR) :: error_code_ptr
 !
 interface
-subroutine sirius_set_local_occupation_matrix_aux(handler,ia,n,l,spin,occ_mtrx,ld,&
-&error_code)&
-&bind(C, name="sirius_set_local_occupation_matrix")
+subroutine sirius_access_local_occupation_matrix_aux(handler,access_type,ia,n,l,&
+&spin,occ_mtrx,ld,error_code)&
+&bind(C, name="sirius_access_local_occupation_matrix")
 use, intrinsic :: ISO_C_BINDING
 type(C_PTR), value :: handler
+type(C_PTR), value :: access_type
 type(C_PTR), value :: ia
 type(C_PTR), value :: n
 type(C_PTR), value :: l
@@ -6449,6 +6417,10 @@ end interface
 !
 handler_ptr = C_NULL_PTR
 handler_ptr = C_LOC(handler%handler_ptr_)
+access_type_ptr = C_NULL_PTR
+allocate(access_type_c_type(len(access_type)+1))
+access_type_c_type = string_f2c(access_type)
+access_type_ptr = C_LOC(access_type_c_type)
 ia_ptr = C_NULL_PTR
 ia_ptr = C_LOC(ia)
 n_ptr = C_NULL_PTR
@@ -6465,107 +6437,43 @@ error_code_ptr = C_NULL_PTR
 if (present(error_code)) then
 error_code_ptr = C_LOC(error_code)
 endif
-call sirius_set_local_occupation_matrix_aux(handler_ptr,ia_ptr,n_ptr,l_ptr,spin_ptr,&
-&occ_mtrx_ptr,ld_ptr,error_code_ptr)
-end subroutine sirius_set_local_occupation_matrix
+call sirius_access_local_occupation_matrix_aux(handler_ptr,access_type_ptr,ia_ptr,&
+&n_ptr,l_ptr,spin_ptr,occ_mtrx_ptr,ld_ptr,error_code_ptr)
+deallocate(access_type_c_type)
+end subroutine sirius_access_local_occupation_matrix
 
 !
-!> @brief Get local occupation matrix of LDA+U+V method.
+!> @brief Access (get or set) nonlocal part of LDA+U+V occupation matrix.
 !> @param [in] handler Ground-state handler.
-!> @param [in] ia Index of atom.
-!> @param [in] n Principal quantum number.
-!> @param [in] l Orbital quantum number.
-!> @param [in] spin Spin index.
-!> @param [out] occ_mtrx Local occupation matrix.
-!> @param [in] ld Leading dimension of the occupation matrix.
-!> @param [out] error_code Error code.
-subroutine sirius_get_local_occupation_matrix(handler,ia,n,l,spin,occ_mtrx,ld,error_code)
-implicit none
-!
-type(sirius_ground_state_handler), target, intent(in) :: handler
-integer, target, intent(in) :: ia
-integer, target, intent(in) :: n
-integer, target, intent(in) :: l
-integer, target, intent(in) :: spin
-complex(8), target, intent(out) :: occ_mtrx(ld, ld)
-integer, target, intent(in) :: ld
-integer, optional, target, intent(out) :: error_code
-!
-type(C_PTR) :: handler_ptr
-type(C_PTR) :: ia_ptr
-type(C_PTR) :: n_ptr
-type(C_PTR) :: l_ptr
-type(C_PTR) :: spin_ptr
-type(C_PTR) :: occ_mtrx_ptr
-type(C_PTR) :: ld_ptr
-type(C_PTR) :: error_code_ptr
-!
-interface
-subroutine sirius_get_local_occupation_matrix_aux(handler,ia,n,l,spin,occ_mtrx,ld,&
-&error_code)&
-&bind(C, name="sirius_get_local_occupation_matrix")
-use, intrinsic :: ISO_C_BINDING
-type(C_PTR), value :: handler
-type(C_PTR), value :: ia
-type(C_PTR), value :: n
-type(C_PTR), value :: l
-type(C_PTR), value :: spin
-type(C_PTR), value :: occ_mtrx
-type(C_PTR), value :: ld
-type(C_PTR), value :: error_code
-end subroutine
-end interface
-!
-handler_ptr = C_NULL_PTR
-handler_ptr = C_LOC(handler%handler_ptr_)
-ia_ptr = C_NULL_PTR
-ia_ptr = C_LOC(ia)
-n_ptr = C_NULL_PTR
-n_ptr = C_LOC(n)
-l_ptr = C_NULL_PTR
-l_ptr = C_LOC(l)
-spin_ptr = C_NULL_PTR
-spin_ptr = C_LOC(spin)
-occ_mtrx_ptr = C_NULL_PTR
-occ_mtrx_ptr = C_LOC(occ_mtrx)
-ld_ptr = C_NULL_PTR
-ld_ptr = C_LOC(ld)
-error_code_ptr = C_NULL_PTR
-if (present(error_code)) then
-error_code_ptr = C_LOC(error_code)
-endif
-call sirius_get_local_occupation_matrix_aux(handler_ptr,ia_ptr,n_ptr,l_ptr,spin_ptr,&
-&occ_mtrx_ptr,ld_ptr,error_code_ptr)
-end subroutine sirius_get_local_occupation_matrix
-
-!
-!> @brief Set nonlocal part of LDA+U+V occupation matrix.
-!> @param [in] handler Ground-state handler.
+!> @param [in] access_type Access type ("get" or "set").
 !> @param [in] atom_pair Index of two atoms in the non-local V correction.
 !> @param [in] n Pair of principal quantum numbers.
 !> @param [in] l Pair of orbital quantum numbers.
 !> @param [in] spin Spin index.
 !> @param [in] T Translation vector that connects two atoms.
-!> @param [in] occ_mtrx Nonlocal occupation matrix.
+!> @param [inout] occ_mtrx Nonlocal occupation matrix.
 !> @param [in] ld1 Leading dimension of the occupation matrix.
 !> @param [in] ld2 Second dimension of the occupation matrix.
 !> @param [out] error_code Error code.
-subroutine sirius_set_nonlocal_occupation_matrix(handler,atom_pair,n,l,spin,T,occ_mtrx,&
-&ld1,ld2,error_code)
+subroutine sirius_access_nonlocal_occupation_matrix(handler,access_type,atom_pair,&
+&n,l,spin,T,occ_mtrx,ld1,ld2,error_code)
 implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: handler
+character(*), target, intent(in) :: access_type
 integer, target, intent(in) :: atom_pair(2)
 integer, target, intent(in) :: n(2)
 integer, target, intent(in) :: l(2)
 integer, target, intent(in) :: spin
 integer, target, intent(in) :: T(3)
-complex(8), target, intent(in) :: occ_mtrx(ld1, ld2)
+complex(8), target, intent(inout) :: occ_mtrx(ld1, ld2)
 integer, target, intent(in) :: ld1
 integer, target, intent(in) :: ld2
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: handler_ptr
+type(C_PTR) :: access_type_ptr
+character(C_CHAR), target, allocatable :: access_type_c_type(:)
 type(C_PTR) :: atom_pair_ptr
 type(C_PTR) :: n_ptr
 type(C_PTR) :: l_ptr
@@ -6577,11 +6485,12 @@ type(C_PTR) :: ld2_ptr
 type(C_PTR) :: error_code_ptr
 !
 interface
-subroutine sirius_set_nonlocal_occupation_matrix_aux(handler,atom_pair,n,l,spin,&
-&T,occ_mtrx,ld1,ld2,error_code)&
-&bind(C, name="sirius_set_nonlocal_occupation_matrix")
+subroutine sirius_access_nonlocal_occupation_matrix_aux(handler,access_type,atom_pair,&
+&n,l,spin,T,occ_mtrx,ld1,ld2,error_code)&
+&bind(C, name="sirius_access_nonlocal_occupation_matrix")
 use, intrinsic :: ISO_C_BINDING
 type(C_PTR), value :: handler
+type(C_PTR), value :: access_type
 type(C_PTR), value :: atom_pair
 type(C_PTR), value :: n
 type(C_PTR), value :: l
@@ -6596,6 +6505,10 @@ end interface
 !
 handler_ptr = C_NULL_PTR
 handler_ptr = C_LOC(handler%handler_ptr_)
+access_type_ptr = C_NULL_PTR
+allocate(access_type_c_type(len(access_type)+1))
+access_type_c_type = string_f2c(access_type)
+access_type_ptr = C_LOC(access_type_c_type)
 atom_pair_ptr = C_NULL_PTR
 atom_pair_ptr = C_LOC(atom_pair)
 n_ptr = C_NULL_PTR
@@ -6616,9 +6529,10 @@ error_code_ptr = C_NULL_PTR
 if (present(error_code)) then
 error_code_ptr = C_LOC(error_code)
 endif
-call sirius_set_nonlocal_occupation_matrix_aux(handler_ptr,atom_pair_ptr,n_ptr,l_ptr,&
-&spin_ptr,T_ptr,occ_mtrx_ptr,ld1_ptr,ld2_ptr,error_code_ptr)
-end subroutine sirius_set_nonlocal_occupation_matrix
+call sirius_access_nonlocal_occupation_matrix_aux(handler_ptr,access_type_ptr,atom_pair_ptr,&
+&n_ptr,l_ptr,spin_ptr,T_ptr,occ_mtrx_ptr,ld1_ptr,ld2_ptr,error_code_ptr)
+deallocate(access_type_c_type)
+end subroutine sirius_access_nonlocal_occupation_matrix
 
 !
 !> @brief major version.

--- a/src/api/sirius.f90
+++ b/src/api/sirius.f90
@@ -6355,7 +6355,7 @@ end subroutine sirius_set_density_matrix
 !> @brief Get density matrix.
 !> @param [in] gs_handler Ground-state handler.
 !> @param [in] ia Index of atom.
-!> @param [in] dm Input density matrix.
+!> @param [out] dm Input density matrix.
 !> @param [in] ld Leading dimension of the density matrix.
 !> @param [out] error_code Error code.
 subroutine sirius_get_density_matrix(gs_handler,ia,dm,ld,error_code)
@@ -6363,7 +6363,7 @@ implicit none
 !
 type(sirius_ground_state_handler), target, intent(in) :: gs_handler
 integer, target, intent(in) :: ia
-complex(8), target, intent(in) :: dm(ld, ld, 3)
+complex(8), target, intent(out) :: dm(ld, ld, 3)
 integer, target, intent(in) :: ld
 integer, optional, target, intent(out) :: error_code
 !

--- a/src/api/sirius.f90
+++ b/src/api/sirius.f90
@@ -6352,6 +6352,55 @@ call sirius_set_density_matrix_aux(gs_handler_ptr,ia_ptr,dm_ptr,ld_ptr,error_cod
 end subroutine sirius_set_density_matrix
 
 !
+!> @brief Get density matrix.
+!> @param [in] gs_handler Ground-state handler.
+!> @param [in] ia Index of atom.
+!> @param [in] dm Input density matrix.
+!> @param [in] ld Leading dimension of the density matrix.
+!> @param [out] error_code Error code.
+subroutine sirius_get_density_matrix(gs_handler,ia,dm,ld,error_code)
+implicit none
+!
+type(sirius_ground_state_handler), target, intent(in) :: gs_handler
+integer, target, intent(in) :: ia
+complex(8), target, intent(in) :: dm(ld, ld, 3)
+integer, target, intent(in) :: ld
+integer, optional, target, intent(out) :: error_code
+!
+type(C_PTR) :: gs_handler_ptr
+type(C_PTR) :: ia_ptr
+type(C_PTR) :: dm_ptr
+type(C_PTR) :: ld_ptr
+type(C_PTR) :: error_code_ptr
+!
+interface
+subroutine sirius_get_density_matrix_aux(gs_handler,ia,dm,ld,error_code)&
+&bind(C, name="sirius_get_density_matrix")
+use, intrinsic :: ISO_C_BINDING
+type(C_PTR), value :: gs_handler
+type(C_PTR), value :: ia
+type(C_PTR), value :: dm
+type(C_PTR), value :: ld
+type(C_PTR), value :: error_code
+end subroutine
+end interface
+!
+gs_handler_ptr = C_NULL_PTR
+gs_handler_ptr = C_LOC(gs_handler%handler_ptr_)
+ia_ptr = C_NULL_PTR
+ia_ptr = C_LOC(ia)
+dm_ptr = C_NULL_PTR
+dm_ptr = C_LOC(dm)
+ld_ptr = C_NULL_PTR
+ld_ptr = C_LOC(ld)
+error_code_ptr = C_NULL_PTR
+if (present(error_code)) then
+error_code_ptr = C_LOC(error_code)
+endif
+call sirius_get_density_matrix_aux(gs_handler_ptr,ia_ptr,dm_ptr,ld_ptr,error_code_ptr)
+end subroutine sirius_get_density_matrix
+
+!
 !> @brief Set local occupation matrix of LDA+U+V method.
 !> @param [in] handler Ground-state handler.
 !> @param [in] ia Index of atom.

--- a/src/api/sirius.f90
+++ b/src/api/sirius.f90
@@ -6470,6 +6470,75 @@ call sirius_set_local_occupation_matrix_aux(handler_ptr,ia_ptr,n_ptr,l_ptr,spin_
 end subroutine sirius_set_local_occupation_matrix
 
 !
+!> @brief Get local occupation matrix of LDA+U+V method.
+!> @param [in] handler Ground-state handler.
+!> @param [in] ia Index of atom.
+!> @param [in] n Principal quantum number.
+!> @param [in] l Orbital quantum number.
+!> @param [in] spin Spin index.
+!> @param [out] occ_mtrx Local occupation matrix.
+!> @param [in] ld Leading dimension of the occupation matrix.
+!> @param [out] error_code Error code.
+subroutine sirius_get_local_occupation_matrix(handler,ia,n,l,spin,occ_mtrx,ld,error_code)
+implicit none
+!
+type(sirius_ground_state_handler), target, intent(in) :: handler
+integer, target, intent(in) :: ia
+integer, target, intent(in) :: n
+integer, target, intent(in) :: l
+integer, target, intent(in) :: spin
+complex(8), target, intent(out) :: occ_mtrx(ld, ld)
+integer, target, intent(in) :: ld
+integer, optional, target, intent(out) :: error_code
+!
+type(C_PTR) :: handler_ptr
+type(C_PTR) :: ia_ptr
+type(C_PTR) :: n_ptr
+type(C_PTR) :: l_ptr
+type(C_PTR) :: spin_ptr
+type(C_PTR) :: occ_mtrx_ptr
+type(C_PTR) :: ld_ptr
+type(C_PTR) :: error_code_ptr
+!
+interface
+subroutine sirius_get_local_occupation_matrix_aux(handler,ia,n,l,spin,occ_mtrx,ld,&
+&error_code)&
+&bind(C, name="sirius_get_local_occupation_matrix")
+use, intrinsic :: ISO_C_BINDING
+type(C_PTR), value :: handler
+type(C_PTR), value :: ia
+type(C_PTR), value :: n
+type(C_PTR), value :: l
+type(C_PTR), value :: spin
+type(C_PTR), value :: occ_mtrx
+type(C_PTR), value :: ld
+type(C_PTR), value :: error_code
+end subroutine
+end interface
+!
+handler_ptr = C_NULL_PTR
+handler_ptr = C_LOC(handler%handler_ptr_)
+ia_ptr = C_NULL_PTR
+ia_ptr = C_LOC(ia)
+n_ptr = C_NULL_PTR
+n_ptr = C_LOC(n)
+l_ptr = C_NULL_PTR
+l_ptr = C_LOC(l)
+spin_ptr = C_NULL_PTR
+spin_ptr = C_LOC(spin)
+occ_mtrx_ptr = C_NULL_PTR
+occ_mtrx_ptr = C_LOC(occ_mtrx)
+ld_ptr = C_NULL_PTR
+ld_ptr = C_LOC(ld)
+error_code_ptr = C_NULL_PTR
+if (present(error_code)) then
+error_code_ptr = C_LOC(error_code)
+endif
+call sirius_get_local_occupation_matrix_aux(handler_ptr,ia_ptr,n_ptr,l_ptr,spin_ptr,&
+&occ_mtrx_ptr,ld_ptr,error_code_ptr)
+end subroutine sirius_get_local_occupation_matrix
+
+!
 !> @brief Set nonlocal part of LDA+U+V occupation matrix.
 !> @param [in] handler Ground-state handler.
 !> @param [in] atom_pair Index of two atoms in the non-local V correction.

--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -6549,6 +6549,60 @@ sirius_set_density_matrix(void** gs_handler__, int const* ia__, std::complex<dou
 
 /*
 @api begin
+sirius_get_density_matrix:
+  doc: Get density matrix.
+  arguments:
+    gs_handler:
+      type: gs_handler
+      attr: in, required
+      doc: Ground-state handler.
+    ia:
+      type: int
+      attr: in, required
+      doc: Index of atom.
+    dm:
+      type: complex
+      attr: in, required, dimension(ld, ld, 3)
+      doc: Input density matrix.
+    ld:
+      type: int
+      attr: in, required
+      doc: Leading dimension of the density matrix.
+    error_code:
+      type: int
+      attr: out, optional
+      doc: Error code.
+@api end
+*/
+void
+sirius_get_density_matrix(void** gs_handler__, int const* ia__, std::complex<double>* dm__, int const* ld__,
+                          int* error_code__)
+{
+    call_sirius(
+            [&]() {
+                auto& gs = get_gs(gs_handler__);
+                int ia   = *ia__ - 1;
+                auto& atom = gs.ctx().unit_cell().atom(ia);
+                auto idx_map = atomic_orbital_index_map_QE(atom.type());
+                int nbf = atom.mt_basis_size();
+                RTE_ASSERT(nbf <= *ld__);
+
+                for (int icomp = 0; icomp < gs.ctx().num_mag_comp(); icomp++) {
+                    for (int xi1 = 0; xi1 < nbf; xi1++) {
+                        int p1 = phase_Rlm_QE(atom.type(), xi1);
+                        for (int xi2 = 0; xi2 < nbf; xi2++) {
+                            int p2 = phase_Rlm_QE(atom.type(), xi2);
+                            dm__[idx_map[xi1], idx_map[xi2], icomp] =
+                                    gs.density().density_matrix(ia)(xi1, xi2, icomp) / static_cast<double>(p1 * p2);
+                        }
+                    }
+                }
+            },
+            error_code__);
+}
+
+/*
+@api begin
 sirius_set_local_occupation_matrix:
   doc: Set local occupation matrix of LDA+U+V method.
   arguments:

--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -6667,6 +6667,69 @@ sirius_set_local_occupation_matrix(void** handler__, int const* ia__, int const*
 
 /*
 @api begin
+sirius_get_local_occupation_matrix:
+  doc: Get local occupation matrix of LDA+U+V method.
+  arguments:
+    handler:
+      type: gs_handler
+      attr: in, required
+      doc: Ground-state handler.
+    ia:
+      type: int
+      attr: in, required
+      doc: Index of atom.
+    n:
+      type: int
+      attr: in, required
+      doc: Principal quantum number.
+    l:
+      type: int
+      attr: in, required
+      doc: Orbital quantum number.
+    spin:
+      type: int
+      attr: in, required
+      doc: Spin index.
+    occ_mtrx:
+      type: complex
+      attr: out, required, dimension(ld, ld)
+      doc: Local occupation matrix.
+    ld:
+      type: int
+      attr: in, required
+      doc: Leading dimension of the occupation matrix.
+    error_code:
+      type: int
+      attr: out, optional
+      doc: Error code.
+@api end
+*/
+void
+sirius_get_local_occupation_matrix(void** handler__, int const* ia__, int const* n__, int const* l__, int const* spin__,
+                                   std::complex<double>* occ_mtrx__, int const* ld__, int* error_code__)
+{
+    call_sirius(
+            [&]() {
+                auto& gs = get_gs(handler__);
+                int ia   = *ia__ - 1;
+                int n    = *n__;
+                int l    = *l__;
+                int spin = *spin__ - 1;
+                mdarray<std::complex<double>, 2> occ_mtrx({*ld__, *ld__}, occ_mtrx__);
+                auto idx      = gs.density().occupation_matrix().find_orbital_index(ia, n, l);
+                auto& local_m = gs.density().occupation_matrix().local(idx);
+                for (int m1 = 0; m1 < 2 * l + 1; m1++) {
+                    for (int m2 = 0; m2 < 2 * l + 1; m2++) {
+                        occ_mtrx(idx_m_qe(m1 - l), idx_m_qe(m2 - l)) =
+                                local_m(m1, m2, spin) / static_cast<double>(phase_m_qe(m1 - l) * phase_m_qe(m2 - l));
+                    }
+                }
+            },
+            error_code__);
+}
+
+/*
+@api begin
 sirius_set_nonlocal_occupation_matrix:
   doc: Set nonlocal part of LDA+U+V occupation matrix.
   arguments:

--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -6524,8 +6524,8 @@ sirius_access_density_matrix:
 @api end
 */
 void
-sirius_access_density_matrix(void** gs_handler__, const char* access_type__, int const* ia__, std::complex<double>* dm__, int const* ld__,
-                          int* error_code__)
+sirius_access_density_matrix(void** gs_handler__, const char* access_type__, int const* ia__,
+                             std::complex<double>* dm__, int const* ld__, int* error_code__)
 {
     call_sirius(
             [&]() {
@@ -6544,11 +6544,11 @@ sirius_access_density_matrix(void** gs_handler__, const char* access_type__, int
                         for (int xi2 = 0; xi2 < nbf; xi2++) {
                             int p2 = phase_Rlm_QE(atom.type(), xi2);
                             if (access == "get") { // QE <-- SIRIUS
-                              dm(idx_map[xi1], idx_map[xi2], icomp) =
-                                      gs.density().density_matrix(ia)(xi1, xi2, icomp) / static_cast<double>(p1 * p2);
+                                dm(idx_map[xi1], idx_map[xi2], icomp) =
+                                        gs.density().density_matrix(ia)(xi1, xi2, icomp) / static_cast<double>(p1 * p2);
                             } else { // access == "set", QE --> SIRIUS
-                              gs.density().density_matrix(ia)(xi1, xi2, icomp) =
-                                      dm(idx_map[xi1], idx_map[xi2], icomp) * static_cast<double>(p1 * p2);
+                                gs.density().density_matrix(ia)(xi1, xi2, icomp) =
+                                        dm(idx_map[xi1], idx_map[xi2], icomp) * static_cast<double>(p1 * p2);
                             }
                         }
                     }
@@ -6601,8 +6601,9 @@ sirius_access_local_occupation_matrix:
 @api end
 */
 void
-sirius_access_local_occupation_matrix(void** handler__, const char* access_type__, int const* ia__, int const* n__, int const* l__, int const* spin__,
-                                   std::complex<double>* occ_mtrx__, int const* ld__, int* error_code__)
+sirius_access_local_occupation_matrix(void** handler__, const char* access_type__, int const* ia__, int const* n__,
+                                      int const* l__, int const* spin__, std::complex<double>* occ_mtrx__,
+                                      int const* ld__, int* error_code__)
 {
     call_sirius(
             [&]() {
@@ -6619,7 +6620,8 @@ sirius_access_local_occupation_matrix(void** handler__, const char* access_type_
                     for (int m2 = 0; m2 < 2 * l + 1; m2++) {
                         if (access == "get") { // QE <-- SIRIUS
                             occ_mtrx(idx_m_qe(m1 - l), idx_m_qe(m2 - l)) =
-                                local_m(m1, m2, spin) / static_cast<double>(phase_m_qe(m1 - l) * phase_m_qe(m2 - l));
+                                    local_m(m1, m2, spin) /
+                                    static_cast<double>(phase_m_qe(m1 - l) * phase_m_qe(m2 - l));
                         } else { // access == "set", QE --> SIRIUS
                             local_m(m1, m2, spin) = occ_mtrx(idx_m_qe(m1 - l), idx_m_qe(m2 - l)) *
                                                     static_cast<double>(phase_m_qe(m1 - l) * phase_m_qe(m2 - l));
@@ -6682,9 +6684,10 @@ sirius_access_nonlocal_occupation_matrix:
 @api end
 */
 void
-sirius_access_nonlocal_occupation_matrix(void** handler__, const char* access_type__, int const* atom_pair__, int const* n__, int const* l__,
-                                      int const* spin__, int const* T__, std::complex<double>* occ_mtrx__,
-                                      int const* ld1__, int const* ld2__, int* error_code__)
+sirius_access_nonlocal_occupation_matrix(void** handler__, const char* access_type__, int const* atom_pair__,
+                                         int const* n__, int const* l__, int const* spin__, int const* T__,
+                                         std::complex<double>* occ_mtrx__, int const* ld1__, int const* ld2__,
+                                         int* error_code__)
 {
     call_sirius(
             [&]() {
@@ -6711,12 +6714,12 @@ sirius_access_nonlocal_occupation_matrix(void** handler__, const char* access_ty
                             for (int m2 = 0; m2 < 2 * l2 + 1; m2++) {
                                 if (access == "get") { // QE <-- SIRIUS
                                     occ_mtrx(idx_m_qe(m1 - l1), idx_m_qe(m2 - l2)) =
-                                        gs.density().occupation_matrix().nonlocal(i)(m1, m2, spin) /
-                                        static_cast<double>(phase_m_qe(m1 - l1) * phase_m_qe(m2 - l2));
+                                            gs.density().occupation_matrix().nonlocal(i)(m1, m2, spin) /
+                                            static_cast<double>(phase_m_qe(m1 - l1) * phase_m_qe(m2 - l2));
                                 } else { // access == "set", QE --> SIRIUS
-                                  gs.density().occupation_matrix().nonlocal(i)(m1, m2, spin) =
-                                          occ_mtrx(idx_m_qe(m1 - l1), idx_m_qe(m2 - l2)) *
-                                          static_cast<double>(phase_m_qe(m1 - l1) * phase_m_qe(m2 - l2));
+                                    gs.density().occupation_matrix().nonlocal(i)(m1, m2, spin) =
+                                            occ_mtrx(idx_m_qe(m1 - l1), idx_m_qe(m2 - l2)) *
+                                            static_cast<double>(phase_m_qe(m1 - l1) * phase_m_qe(m2 - l2));
                                 }
                             }
                         }

--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -6593,7 +6593,7 @@ sirius_get_density_matrix(void** gs_handler__, int const* ia__, std::complex<dou
                         int p1 = phase_Rlm_QE(atom.type(), xi1);
                         for (int xi2 = 0; xi2 < nbf; xi2++) {
                             int p2 = phase_Rlm_QE(atom.type(), xi2);
-                            dm[idx_map[xi1], idx_map[xi2], icomp] =
+                            dm(idx_map[xi1], idx_map[xi2], icomp) =
                                     gs.density().density_matrix(ia)(xi1, xi2, icomp) / static_cast<double>(p1 * p2);
                         }
                     }

--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -6562,7 +6562,7 @@ sirius_get_density_matrix:
       doc: Index of atom.
     dm:
       type: complex
-      attr: in, required, dimension(ld, ld, 3)
+      attr: out, required, dimension(ld, ld, 3)
       doc: Input density matrix.
     ld:
       type: int
@@ -6581,6 +6581,7 @@ sirius_get_density_matrix(void** gs_handler__, int const* ia__, std::complex<dou
     call_sirius(
             [&]() {
                 auto& gs     = get_gs(gs_handler__);
+                mdarray<std::complex<double>, 3> dm({*ld__, *ld__, 3}, dm__);
                 int ia       = *ia__ - 1;
                 auto& atom   = gs.ctx().unit_cell().atom(ia);
                 auto idx_map = atomic_orbital_index_map_QE(atom.type());
@@ -6592,7 +6593,7 @@ sirius_get_density_matrix(void** gs_handler__, int const* ia__, std::complex<dou
                         int p1 = phase_Rlm_QE(atom.type(), xi1);
                         for (int xi2 = 0; xi2 < nbf; xi2++) {
                             int p2 = phase_Rlm_QE(atom.type(), xi2);
-                            dm__[idx_map[xi1], idx_map[xi2], icomp] =
+                            dm[idx_map[xi1], idx_map[xi2], icomp] =
                                     gs.density().density_matrix(ia)(xi1, xi2, icomp) / static_cast<double>(p1 * p2);
                         }
                     }

--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -6580,11 +6580,11 @@ sirius_get_density_matrix(void** gs_handler__, int const* ia__, std::complex<dou
 {
     call_sirius(
             [&]() {
-                auto& gs = get_gs(gs_handler__);
-                int ia   = *ia__ - 1;
-                auto& atom = gs.ctx().unit_cell().atom(ia);
+                auto& gs     = get_gs(gs_handler__);
+                int ia       = *ia__ - 1;
+                auto& atom   = gs.ctx().unit_cell().atom(ia);
                 auto idx_map = atomic_orbital_index_map_QE(atom.type());
-                int nbf = atom.mt_basis_size();
+                int nbf      = atom.mt_basis_size();
                 RTE_ASSERT(nbf <= *ld__);
 
                 for (int icomp = 0; icomp < gs.ctx().num_mag_comp(); icomp++) {

--- a/src/api/sirius_c_headers.h
+++ b/src/api/sirius_c_headers.h
@@ -3233,20 +3233,24 @@ void
 sirius_load_state(void** gs_handler__, const char* file_name__, int* error_code__);
 
 /*
-sirius_set_density_matrix:
-  doc: Set density matrix.
+sirius_access_density_matrix:
+  doc: Access (get or set) density matrix.
   arguments:
     gs_handler:
       type: gs_handler
       attr: in, required
       doc: Ground-state handler.
+    access_type:
+      type: string
+      attr: in, required
+      doc: Access type ("get" or "set").
     ia:
       type: int
       attr: in, required
       doc: Index of atom.
     dm:
       type: complex
-      attr: in, required, dimension(ld, ld, 3)
+      attr: inout, required, dimension(ld, ld, 3)
       doc: Input density matrix.
     ld:
       type: int
@@ -3258,17 +3262,21 @@ sirius_set_density_matrix:
       doc: Error code.
 */
 void
-sirius_set_density_matrix(void** gs_handler__, int const* ia__, double complex* dm__, int const* ld__,
+sirius_access_density_matrix(void** gs_handler__, const char* access_type__, int const* ia__, double complex* dm__, int const* ld__,
                           int* error_code__);
 
 /*
-sirius_set_local_occupation_matrix:
-  doc: Set local occupation matrix of LDA+U+V method.
+sirius_access_local_occupation_matrix:
+  doc: Access (get or set) local occupation matrix of LDA+U+V method.
   arguments:
     handler:
       type: gs_handler
       attr: in, required
       doc: Ground-state handler.
+    access_type:
+      type: string
+      attr: in, required
+      doc: Access type ("get" or "set").
     ia:
       type: int
       attr: in, required
@@ -3287,7 +3295,7 @@ sirius_set_local_occupation_matrix:
       doc: Spin index.
     occ_mtrx:
       type: complex
-      attr: in, required, dimension(ld, ld)
+      attr: inout, required, dimension(ld, ld)
       doc: Local occupation matrix.
     ld:
       type: int
@@ -3299,17 +3307,21 @@ sirius_set_local_occupation_matrix:
       doc: Error code.
 */
 void
-sirius_set_local_occupation_matrix(void** handler__, int const* ia__, int const* n__, int const* l__, int const* spin__,
+sirius_access_local_occupation_matrix(void** handler__, const char* access_type__, int const* ia__, int const* n__, int const* l__, int const* spin__,
                                    double complex* occ_mtrx__, int const* ld__, int* error_code__);
 
 /*
-sirius_set_nonlocal_occupation_matrix:
-  doc: Set nonlocal part of LDA+U+V occupation matrix.
+sirius_access_nonlocal_occupation_matrix:
+  doc: Access (get or set) nonlocal part of LDA+U+V occupation matrix.
   arguments:
     handler:
       type: gs_handler
       attr: in, required
       doc: Ground-state handler.
+    access_type:
+      type: string
+      attr: in, required
+      doc: Access type ("get" or "set").
     atom_pair:
       type: int
       attr: in, required, dimension(2)
@@ -3332,7 +3344,7 @@ sirius_set_nonlocal_occupation_matrix:
       doc: Translation vector that connects two atoms.
     occ_mtrx:
       type: complex
-      attr: in, required, dimension(ld1, ld2)
+      attr: inout, required, dimension(ld1, ld2)
       doc: Nonlocal occupation matrix.
     ld1:
       type: int
@@ -3348,7 +3360,7 @@ sirius_set_nonlocal_occupation_matrix:
       doc: Error code.
 */
 void
-sirius_set_nonlocal_occupation_matrix(void** handler__, int const* atom_pair__, int const* n__, int const* l__,
+sirius_access_nonlocal_occupation_matrix(void** handler__, const char* access_type__, int const* atom_pair__, int const* n__, int const* l__,
                                       int const* spin__, int const* T__, double complex* occ_mtrx__,
                                       int const* ld1__, int const* ld2__, int* error_code__);
 


### PR DESCRIPTION
Implementation of more API functions to pass data from SIRIUS to QE:
- density matrix
- local and non-local occupation matrix

Linked to [PR#69](https://github.com/electronic-structure/q-e-sirius/pull/69) on the `q-e-sirius` side
