### PR TITLE
[enhancement] more printout

### DIFF
--- a/src/core/acc/acc.hpp
+++ b/src/core/acc/acc.hpp
@@ -338,6 +338,10 @@ get_uuid(int device_id__)
         }
         s << std::hex << std::setw(2) << std::setfill('0') << (int)devprop.uuid.bytes[i];
     }
+#elif defined(SIRIUS_ROCM)
+    for (int i = 0; i < 16; ++i) {
+        s << std::hex << devprop.uuid.bytes[i];
+    }
 #endif
     return s.str();
 }

--- a/src/hubbard/hubbard_matrix.cpp
+++ b/src/hubbard/hubbard_matrix.cpp
@@ -181,7 +181,7 @@ Hubbard_matrix::print_local(int at_lvl__, std::ostream& out__) const
 
     auto print_number = [&](double x) { out__ << std::setw(width) << std::setprecision(prec) << std::fixed << x; };
     auto const& atom  = ctx_.unit_cell().atom(atomic_orbitals_[at_lvl__].first);
-    auto solver = la::Eigensolver_factory("lapack");
+    auto solver       = la::Eigensolver_factory("lapack");
 
     out__ << "atom : " << atom.type().label();
     out__ << " level : " << atom.type().lo_descriptor_hub(atomic_orbitals_[at_lvl__].second).n();

--- a/src/hubbard/hubbard_matrix.cpp
+++ b/src/hubbard/hubbard_matrix.cpp
@@ -199,7 +199,12 @@ Hubbard_matrix::print_local(int at_lvl__, std::ostream& out__) const
                 }
             }
             solver->solve(mmax, A, &eigenvals[0], eigenvecs);
-            out__ << hbar(width * mmax, '-') << " SPIN: " << is + 1 << std::endl;
+            // don't print "SPIN: 1" for non-magnetic case
+            if (ctx_.num_spins() == 1) {
+                out__ << hbar(width * mmax, '-') << std::endl;
+            } else {
+                out__ << hbar(width * mmax, '-') << " SPIN: " << is + 1 << std::endl;
+            }
             // print eigenvalues
             for (const auto& val : eigenvals) {
                 print_number(val);

--- a/src/hubbard/hubbard_matrix.cpp
+++ b/src/hubbard/hubbard_matrix.cpp
@@ -181,6 +181,7 @@ Hubbard_matrix::print_local(int at_lvl__, std::ostream& out__) const
 
     auto print_number = [&](double x) { out__ << std::setw(width) << std::setprecision(prec) << std::fixed << x; };
     auto const& atom  = ctx_.unit_cell().atom(atomic_orbitals_[at_lvl__].first);
+    auto solver = la::Eigensolver_factory("lapack");
 
     out__ << "atom : " << atom.type().label();
     out__ << " level : " << atom.type().lo_descriptor_hub(atomic_orbitals_[at_lvl__].second).n();
@@ -188,8 +189,22 @@ Hubbard_matrix::print_local(int at_lvl__, std::ostream& out__) const
     const int l = atom.type().lo_descriptor_hub(atomic_orbitals_[at_lvl__].second).l();
     if (ctx_.num_mag_dims() != 3) {
         int mmax = 2 * l + 1;
+        std::vector<double> eigenvals(mmax);
+        la::dmatrix<double> eigenvecs(mmax, mmax);
+        la::dmatrix<double> A(mmax, mmax);
         for (int is = 0; is < ctx_.num_spins(); is++) {
+            for (int m = 0; m < mmax; m++) {
+                for (int mp = 0; mp < mmax; mp++) {
+                    A(m, mp) = std::real(this->local(at_lvl__)(m, mp, is));
+                }
+            }
+            solver->solve(mmax, A, &eigenvals[0], eigenvecs);
             out__ << hbar(width * mmax, '-') << " SPIN: " << is + 1 << std::endl;
+            // print eigenvalues
+            for (const auto& val : eigenvals) {
+                print_number(val);
+            }
+            out__ << std::endl << hbar(width * mmax, '-') << std::endl;
             bool has_imag{false};
             for (int m = 0; m < mmax; m++) {
                 for (int mp = 0; mp < mmax; mp++) {

--- a/src/hubbard/hubbard_matrix.cpp
+++ b/src/hubbard/hubbard_matrix.cpp
@@ -182,13 +182,14 @@ Hubbard_matrix::print_local(int at_lvl__, std::ostream& out__) const
     auto print_number = [&](double x) { out__ << std::setw(width) << std::setprecision(prec) << std::fixed << x; };
     auto const& atom  = ctx_.unit_cell().atom(atomic_orbitals_[at_lvl__].first);
 
-    out__ << "level : " << atom.type().lo_descriptor_hub(atomic_orbitals_[at_lvl__].second).n();
+    out__ << "atom : " << atom.type().label();
+    out__ << " level : " << atom.type().lo_descriptor_hub(atomic_orbitals_[at_lvl__].second).n();
     out__ << " l: " << atom.type().lo_descriptor_hub(atomic_orbitals_[at_lvl__].second).l() << std::endl;
     const int l = atom.type().lo_descriptor_hub(atomic_orbitals_[at_lvl__].second).l();
     if (ctx_.num_mag_dims() != 3) {
         int mmax = 2 * l + 1;
         for (int is = 0; is < ctx_.num_spins(); is++) {
-            out__ << hbar(width * mmax, '-') << std::endl;
+            out__ << hbar(width * mmax, '-') << " SPIN: " << is + 1 << std::endl;
             bool has_imag{false};
             for (int m = 0; m < mmax; m++) {
                 for (int mp = 0; mp < mmax; mp++) {


### PR DESCRIPTION
Adding more printout.
- [x] UUID for AMD GPUs
- [x] more info for occupation matrices: atom label and spin channel
- [x] Calculate and print the eigenvalues of the occupation matrices

QE prints the eigenvalues of the occupation matrices by default (which would be very useful for quick comparison)