### PR TITLE
[fix] more robustness in Enu search

### DIFF
--- a/src/core/debug.hpp
+++ b/src/core/debug.hpp
@@ -1,0 +1,37 @@
+/* This file is part of SIRIUS electronic structure library.
+ *
+ * Copyright (c), ETH Zurich.  All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+/** \file debug.hpp
+ *
+ *  \brief Functions used for debug purposes.
+ */
+
+#ifndef __DEBUG_HPP__
+#define __DEBUG_HPP__
+
+#include <mpi.h>
+#include <fstream>
+
+/// Return individual ofstream for each MPI rank.
+inline std::ofstream
+local_output()
+{
+    std::ofstream result;
+    int i;
+    MPI_Initialized(&i);
+    if (i) {
+        MPI_Comm_rank(MPI_COMM_WORLD, &i);
+        result = std::ofstream("out" + std::to_string(i) + ".txt", std::ios::app);
+    } else {
+        result = std::ofstream("/dev/null");
+    }
+    return result;
+}
+
+#endif
+

--- a/src/core/debug.hpp
+++ b/src/core/debug.hpp
@@ -34,4 +34,3 @@ local_output()
 }
 
 #endif
-

--- a/src/hamiltonian/diagonalize.hpp
+++ b/src/hamiltonian/diagonalize.hpp
@@ -81,6 +81,9 @@ diagonalize(Hamiltonian0<T> const& H0__, K_point_set& kset__, double itsol_tol__
             }
         }
     }
+    /* wait for all */
+    ctx.comm().barrier();
+
     kset__.comm().allreduce(&num_dav_iter, 1);
     kset__.comm().allreduce<bool, mpi::op_t::land>(&converged, 1);
     ctx.num_itsol_steps(num_dav_iter);

--- a/src/hamiltonian/diagonalize_fp.hpp
+++ b/src/hamiltonian/diagonalize_fp.hpp
@@ -32,6 +32,8 @@ diagonalize_fp_fv_exact(Hamiltonian_k<double> const& Hk__, K_point<double>& kp__
 
     auto& ctx = Hk__.H0().ctx();
 
+    RTE_ASSERT(kp__.gklo_basis_size() > ctx.num_fv_states());
+
     auto& solver = ctx.gen_evp_solver();
 
     /* total eigen-value problem size */
@@ -61,14 +63,14 @@ diagonalize_fp_fv_exact(Hamiltonian_k<double> const& Hk__, K_point<double>& kp__
         double max_diff = check_hermitian(h, ngklo);
         if (max_diff > 1e-12) {
             std::stringstream s;
-            s << "H matrix is not hermitian" << std::endl << "max error: " << max_diff;
-            RTE_THROW(s);
+            s << "H matrix is not hermitian, max error: " << max_diff;
+            RTE_WARNING(s);
         }
         max_diff = check_hermitian(o, ngklo);
         if (max_diff > 1e-12) {
             std::stringstream s;
-            s << "O matrix is not hermitian" << std::endl << "max error: " << max_diff;
-            RTE_THROW(s);
+            s << "O matrix is not hermitian, max error: " << max_diff;
+            RTE_WARNING(s);
         }
     }
 
@@ -78,8 +80,6 @@ diagonalize_fp_fv_exact(Hamiltonian_k<double> const& Hk__, K_point<double>& kp__
         print_checksum("h_lapw", z1, ctx.out());
         print_checksum("o_lapw", z2, ctx.out());
     }
-
-    RTE_ASSERT(kp__.gklo_basis_size() > ctx.num_fv_states());
 
     std::vector<double> eval(ctx.num_fv_states());
 

--- a/src/radial/radial_solver.hpp
+++ b/src/radial/radial_solver.hpp
@@ -1208,8 +1208,7 @@ class Enu_finder : public Radial_solver
 
         std::stringstream sinfo;
 
-        auto compute_etop = [&]() -> int
-        {
+        auto compute_etop = [&]() -> int {
             /* We want to find enu such that the wave-function at the muffin-tin boundary is zero
              * and the number of nodes inside muffin-tin is equal to n-l-1. This will be the top
              * of the band. */
@@ -1290,24 +1289,22 @@ class Enu_finder : public Radial_solver
          * of the derivative. */
         double denu{1e-6};
         try {
-            sinfo << "find_enu(): find bottom energy" << std::endl
-                  << "  enu_start : " << etop_ << std::endl;
+            sinfo << "find_enu(): find bottom energy" << std::endl << "  enu_start : " << etop_ << std::endl;
             double sd = surface_deriv();
             double e1 = integrate_forward_until(rel__, etop_, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
-                                           [this, &denu, sd, &surface_deriv, &p](int iter, int nn, double& enu) {
-                                             if (surface_deriv() * sd < 0) {
-                                                 return true;
-                                             }
-                                             /* do not allow step in energy to grow too much */
-                                             denu = std::min(0.01, denu * 1.1);
-                                             enu -= denu;
-                                             return false;
-                                         });
+                                                [this, &denu, sd, &surface_deriv, &p](int iter, int nn, double& enu) {
+                                                    if (surface_deriv() * sd < 0) {
+                                                        return true;
+                                                    }
+                                                    /* do not allow step in energy to grow too much */
+                                                    denu = std::min(0.01, denu * 1.1);
+                                                    enu -= denu;
+                                                    return false;
+                                                });
 
             /* refine bottom energy */
-            double e2    = e1 + denu;
-            sinfo << "find_enu(): refine bottom energy" << std::endl
-                  << "  enu_start : " << (e1 + e2) / 2 << std::endl;
+            double e2 = e1 + denu;
+            sinfo << "find_enu(): refine bottom energy" << std::endl << "  enu_start : " << (e1 + e2) / 2 << std::endl;
             ebot_ = integrate_forward_until(rel__, (e1 + e2) / 2, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
                                             [this, &e1, &e2, sd, &surface_deriv](int iter, int nn, double& enu) {
                                                 if (surface_deriv() * sd > 0) {
@@ -1332,8 +1329,7 @@ class Enu_finder : public Radial_solver
                 }
             }
         } catch (std::exception const& e) {
-            sinfo << e.what() << std::endl
-                  << "denu : " << denu << std::endl;
+            sinfo << e.what() << std::endl << "denu : " << denu << std::endl;
         }
     }
 

--- a/src/radial/radial_solver.hpp
+++ b/src/radial/radial_solver.hpp
@@ -1035,12 +1035,6 @@ class Bound_state : public Radial_solver
             std::swap(e1, e2);
         }
 
-        int nn1 = integrate_forward_gsl<relativity_t::dirac>(e1, l_, k_, chi_p, chi_q, p, dpdr_, q, dqdr, true);
-        int nn2 = integrate_forward_gsl<relativity_t::dirac>(e2, l_, k_, chi_p, chi_q, p, dpdr_, q, dqdr, true);
-
-        sout << "firt pass: e_bottom = " << e1 << ", e_top = " << e2 << std::endl;
-        sout << "number of nodes: " << nn1 << " " << nn2 << std::endl;
-
         /* 2nd pass: refine by bisection */
         enu_ = integrate_forward_until(rel__, (e1 + e2) / 2, l_, k_, chi_p, chi_q, p, dpdr_, q, dqdr, true,
                                        [&e1, &e2, this](int iter, int nn, double& enu) {
@@ -1053,12 +1047,8 @@ class Bound_state : public Radial_solver
                                            return std::abs(e1 - e2) < enu_tolerance_;
                                        });
 
-        nn1 = integrate_forward_gsl<relativity_t::dirac>(e1, l_, k_, chi_p, chi_q, p, dpdr_, q, dqdr, true);
-        nn2 = integrate_forward_gsl<relativity_t::dirac>(e2, l_, k_, chi_p, chi_q, p, dpdr_, q, dqdr, true);
-        sout << "second pass: e_bottom = " << e1 << ", e_top = " << e2 << std::endl;
-        sout << "number of nodes: " << nn1 << " " << nn2 << std::endl;
-
         /* final choice for enu: bottom enery of the refined interval */
+        /* radial functions are also recomputed for the final time */
         enu_ = integrate_forward_until(rel__, e1, l_, k_, chi_p, chi_q, p, dpdr_, q, dqdr, true,
                                        [](int iter, int nn, double& enu) { return true; });
 
@@ -1216,148 +1206,135 @@ class Enu_finder : public Radial_solver
         std::vector<double> dpdr(np);
         std::vector<double> dqdr(np);
 
-        std::stringstream sout;
+        std::stringstream sinfo;
 
-        /* We want to find enu such that the wave-function at the muffin-tin boundary is zero
-         * and the number of nodes inside muffin-tin is equal to n-l-1. This will be the top
-         * of the band. */
-        int s{1};
-        int sp;
+        auto compute_etop = [&]() -> int
+        {
+            /* We want to find enu such that the wave-function at the muffin-tin boundary is zero
+             * and the number of nodes inside muffin-tin is equal to n-l-1. This will be the top
+             * of the band. */
+            int s{1};
+            int sp;
+            double denu{1e-6};
+            double e1;
+            sinfo << "find_enu(): find top enery" << std::endl
+                  << "  n         : " << n_ << ", l : " << l_ << std::endl
+                  << "  enu_start : " << enu_start__ << std::endl;
+            try {
+                /* 1st pass: estimate upper and lower boundaries of the etop */
+                e1 = integrate_forward_until(rel__, enu_start__, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
+                                             [&s, &sp, &denu, this](int iter, int nn, double& enu) {
+                                                 sp = s;
+                                                 s  = (nn > (n_ - l_ - 1)) ? -1 : 1;
+                                                 if (s != sp && iter > 0) {
+                                                     return true;
+                                                 }
+                                                 denu = std::min(0.1, denu * 2);
+                                                 enu += s * denu;
+                                                 return false;
+                                             });
+            } catch (std::exception const& e) {
+                sinfo << e.what() << std::endl << "denu : " << denu;
+                return 1;
+            }
+
+            double e2 = e1 - sp * denu;
+
+            /* e1 is bottom, e2 is top energy */
+            if (e1 > e2) {
+                std::swap(e1, e2);
+            }
+
+            sinfo << "find_enu(): refine top energy" << std::endl
+                  << "  e1 : " << e1 << ", e2 : " << e2 << std::endl
+                  << "  enu_start : " << (e1 + e2) / 2 << std::endl;
+
+            try {
+                /* 2nd pass: refine by bisection */
+                etop_ = integrate_forward_until(rel__, (e1 + e2) / 2, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
+                                                [&e1, &e2, this](int iter, int nn, double& enu) {
+                                                    if (nn > (n_ - l_ - 1)) {
+                                                        e2 = enu;
+                                                    } else {
+                                                        e1 = enu;
+                                                    }
+                                                    enu = (e1 + e2) / 2.0;
+                                                    return std::abs(e1 - e2) < 1e-9;
+                                                });
+            } catch (std::exception const& e) {
+                sinfo << e.what() << std::endl;
+                return 1;
+            }
+            return 0;
+        };
+
+        if (compute_etop() != 0) {
+            sinfo << "find_enu(): top of the linearization energy interval is not found";
+            RTE_THROW(sinfo);
+        }
+
+        enu_ = etop_;
+
+        auto surface_deriv = [this, &dpdr, &p]() {
+            if (true) {
+                /* return  p'(R) */
+                return dpdr.back();
+            } else {
+                /* return R*u'(R) */
+                return dpdr.back() - p.back() / radial_grid_.last();
+            }
+        };
+
+        /* Now we go down in energy and search for enu such that the wave-function derivative is zero
+         * at the muffin-tin boundary. This will be the bottom of the band. Here we look at a sign change
+         * of the derivative. */
         double denu{1e-6};
-        double e0;
-        sout << "find_enu(): find top enery" << std::endl
-             << "  n         : " << n_ << ", l : " << l_ << std::endl
-             << "  enu_start : " << enu_start__ << std::endl;
         try {
-            /* 1st pass: estimate upper and lower boundaries of the etop*/
-            e0 = integrate_forward_until(rel__, enu_start__, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
-                                         [&s, &sp, &denu, this](int iter, int nn, double& enu) {
-                                             sp = s;
-                                             s  = (nn > (n_ - l_ - 1)) ? -1 : 1;
-                                             if (s != sp && iter > 0) {
+            sinfo << "find_enu(): find bottom energy" << std::endl
+                  << "  enu_start : " << etop_ << std::endl;
+            double sd = surface_deriv();
+            double e1 = integrate_forward_until(rel__, etop_, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
+                                           [this, &denu, sd, &surface_deriv, &p](int iter, int nn, double& enu) {
+                                             if (surface_deriv() * sd < 0) {
                                                  return true;
                                              }
-                                             if (denu <= 1.0) {
-                                                 denu *= 4;
-                                             }
-                                             enu += s * denu;
+                                             /* do not allow step in energy to grow too much */
+                                             denu = std::min(0.01, denu * 1.1);
+                                             enu -= denu;
                                              return false;
                                          });
-        } catch (std::exception const& e) {
-            sout << e.what() << std::endl << "denu : " << denu;
-            RTE_THROW(sout);
-        }
 
-        double e1 = e0;
-        double e2 = e0 - sp * denu;
-
-        /* e1 is bottom, e2 is top energy */
-        if (e1 > e2) {
-            std::swap(e1, e2);
-        }
-
-        sout << "find_enu(): refine top energy" << std::endl
-             << "  e1 : " << e1 << ", e2 : " << e2 << std::endl
-             << "  enu_start : " << (e1 + e2) / 2 << std::endl;
-
-        try {
-            /* 2nd pass: refine by bisection */
-            etop_ = integrate_forward_until(rel__, (e1 + e2) / 2, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
-                                            [&e1, &e2, this](int iter, int nn, double& enu) {
-                                                if (nn > (n_ - l_ - 1)) {
+            /* refine bottom energy */
+            double e2    = e1 + denu;
+            sinfo << "find_enu(): refine bottom energy" << std::endl
+                  << "  enu_start : " << (e1 + e2) / 2 << std::endl;
+            ebot_ = integrate_forward_until(rel__, (e1 + e2) / 2, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
+                                            [this, &e1, &e2, sd, &surface_deriv](int iter, int nn, double& enu) {
+                                                if (surface_deriv() * sd > 0) {
                                                     e2 = enu;
                                                 } else {
                                                     e1 = enu;
                                                 }
                                                 enu = (e1 + e2) / 2.0;
-                                                return std::abs(e1 - e2) < 1e-9;
+                                                return std::abs(surface_deriv()) < 1e-8;
                                             });
+            switch (auto_enu__) {
+                case 1: {
+                    enu_ = (ebot_ + etop_) / 2.0;
+                    break;
+                }
+                case 2: {
+                    enu_ = ebot_;
+                    break;
+                }
+                default: {
+                    RTE_THROW("wrong type of auto_enu");
+                }
+            }
         } catch (std::exception const& e) {
-            sout << e.what() << std::endl;
-            RTE_THROW(sout);
+            sinfo << e.what() << std::endl
+                  << "denu : " << denu << std::endl;
         }
-
-        enu_ = etop_;
-        return;
-
-        //auto surface_deriv = [this, &dpdr, &p]() {
-        //    if (true) {
-        //        /* return  p'(R) */
-        //        return dpdr.back();
-        //    } else {
-        //        /* return R*u'(R) */
-        //        return dpdr.back() - p.back() / radial_grid_.last();
-        //    }
-        //};
-
-        //double sd = surface_deriv();
-
-        //sout << "find_enu(): find bottom energy" << std::endl
-        //     << "  enu_start : " << etop_ << std::endl;
-
-        ///* Now we go down in energy and search for enu such that the wave-function derivative is zero
-        // * at the muffin-tin boundary. This will be the bottom of the band. Here we look at a sign change
-        // * of the derivative. */
-        //denu = 1e-4;
-        //try {
-        //    e0   = integrate_forward_until(rel__, etop_, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
-        //                                   [&denu, sd, &surface_deriv, &p, this, &sout](int iter, int nn, double& enu) {
-        //                                     sout << "iter : " << iter << ", nn : " << nn << ", enu : " << enu << ", sd : " << sd << " " << surface_deriv() << std::endl;
-        //                                     if (surface_deriv() * sd < 0 || nn != (n_ - l_ - 1) || std::abs(p.back()) > 0.2) {
-        //                                         return true;
-        //                                     }
-        //                                     /* do not allow step in energy to grow too much */
-        //                                     if (denu <= 1.0) {
-        //                                         denu *= 1.5;
-        //                                     }
-        //                                     enu -= denu;
-        //                                     return false;
-        //                                 });
-        //} catch (std::exception const& e) {
-        //    sout << e.what() << std::endl
-        //         << "denu : " << denu << std::endl;
-        //    RTE_THROW(sout);
-        //}
-
-        //if (surface_deriv() * sd < 0) {
-        //    /* refine bottom energy */
-        //    e1    = e0;
-        //    e2    = e0 + denu;
-        //    sout << "find_enu(): refine bottom energy" << std::endl
-        //         << "  enu_start : " << (e1 + e2) / 2 << std::endl;
-        //    try {
-        //        ebot_ = integrate_forward_until(rel__, (e1 + e2) / 2, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
-        //                                        [&e1, &e2, sd, &surface_deriv, this](int iter, int nn, double& enu) {
-        //                                            if (surface_deriv() * sd > 0) {
-        //                                                e2 = enu;
-        //                                            } else {
-        //                                                e1 = enu;
-        //                                            }
-        //                                            enu = (e1 + e2) / 2.0;
-        //                                            return std::abs(surface_deriv()) < 1e-8;
-        //                                        });
-        //    } catch (std::exception const& e) {
-        //        sout << e.what() << std::endl
-        //             << "denu : " << denu << std::endl;
-        //        RTE_THROW(sout);
-        //    }
-        //} else {
-        //    ebot_ = e0;
-        //}
-
-        //switch (auto_enu__) {
-        //    case 1: {
-        //        enu_ = (ebot_ + etop_) / 2.0;
-        //        break;
-        //    }
-        //    case 2: {
-        //        enu_ = ebot_;
-        //        break;
-        //    }
-        //    default: {
-        //        RTE_THROW("wrong type of auto_enu");
-        //    }
-        //}
     }
 
   public:

--- a/src/radial/radial_solver.hpp
+++ b/src/radial/radial_solver.hpp
@@ -1216,6 +1216,8 @@ class Enu_finder : public Radial_solver
         std::vector<double> dpdr(np);
         std::vector<double> dqdr(np);
 
+        std::stringstream sout;
+
         /* We want to find enu such that the wave-function at the muffin-tin boundary is zero
          * and the number of nodes inside muffin-tin is equal to n-l-1. This will be the top
          * of the band. */
@@ -1223,20 +1225,29 @@ class Enu_finder : public Radial_solver
         int sp;
         double denu{1e-6};
         double e0;
-        /* 1st pass: estimate upper and lower boundaries of the etop*/
-        e0 = integrate_forward_until(rel__, enu_start__, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
-                                     [&s, &sp, &denu, this](int iter, int nn, double& enu) {
-                                         sp = s;
-                                         s  = (nn > (n_ - l_ - 1)) ? -1 : 1;
-                                         if (s != sp && iter > 0) {
-                                             return true;
-                                         }
-                                         if (denu <= 1.0) {
-                                             denu *= 4;
-                                         }
-                                         enu += s * denu;
-                                         return false;
-                                     });
+        sout << "find_enu(): find top enery" << std::endl
+             << "  n         : " << n_ << ", l : " << l_ << std::endl
+             << "  enu_start : " << enu_start__ << std::endl;
+        try {
+            /* 1st pass: estimate upper and lower boundaries of the etop*/
+            e0 = integrate_forward_until(rel__, enu_start__, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
+                                         [&s, &sp, &denu, this](int iter, int nn, double& enu) {
+                                             sp = s;
+                                             s  = (nn > (n_ - l_ - 1)) ? -1 : 1;
+                                             if (s != sp && iter > 0) {
+                                                 return true;
+                                             }
+                                             if (denu <= 1.0) {
+                                                 denu *= 4;
+                                             }
+                                             enu += s * denu;
+                                             return false;
+                                         });
+        } catch (std::exception const& e) {
+            sout << e.what() << std::endl
+                 << "denu : " << denu;
+            RTE_THROW(sout);
+        }
 
         double e1 = e0;
         double e2 = e0 - sp * denu;
@@ -1246,17 +1257,29 @@ class Enu_finder : public Radial_solver
             std::swap(e1, e2);
         }
 
-        /* 2nd pass: refine by bisection */
-        etop_ = integrate_forward_until(rel__, (e1 + e2) / 2, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
-                                        [&e1, &e2, this](int iter, int nn, double& enu) {
-                                            if (nn > (n_ - l_ - 1)) {
-                                                e2 = enu;
-                                            } else {
-                                                e1 = enu;
-                                            }
-                                            enu = (e1 + e2) / 2.0;
-                                            return std::abs(e1 - e2) < 1e-9;
-                                        });
+        sout << "find_enu(): refine top energy" << std::endl
+             << "  e1 : " << e1 << ", e2 : " << e2 << std::endl
+             << "  enu_start : " << (e1 + e2) / 2 << std::endl;
+
+        try {
+            /* 2nd pass: refine by bisection */
+            etop_ = integrate_forward_until(rel__, (e1 + e2) / 2, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
+                                            [&e1, &e2, this](int iter, int nn, double& enu) {
+                                                if (nn > (n_ - l_ - 1)) {
+                                                    e2 = enu;
+                                                } else {
+                                                    e1 = enu;
+                                                }
+                                                enu = (e1 + e2) / 2.0;
+                                                return std::abs(e1 - e2) < 1e-9;
+                                            });
+        } catch (std::exception const& e) {
+            sout << e.what() << std::endl;
+            RTE_THROW(sout);
+        }
+
+        enu_ = etop_;
+        return;
 
         auto surface_deriv = [this, &dpdr, &p]() {
             if (true) {
@@ -1270,36 +1293,59 @@ class Enu_finder : public Radial_solver
 
         double sd = surface_deriv();
 
+        sout << "find_enu(): find bottom energy" << std::endl
+             << "  enu_start : " << etop_ << std::endl;
+
         /* Now we go down in energy and search for enu such that the wave-function derivative is zero
          * at the muffin-tin boundary. This will be the bottom of the band. Here we look at a sign change
          * of the derivative. */
         denu = 1e-4;
-        e0   = integrate_forward_until(rel__, etop_, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
-                                       [&denu, sd, &surface_deriv, this](int iter, int nn, double& enu) {
-                                         if (surface_deriv() * sd < 0) {
-                                             return true;
-                                         }
-                                         /* do not allow step in energy to grow too much */
-                                         if (denu <= 1.0) {
-                                             denu *= 1.5;
-                                         }
-                                         enu -= denu;
-                                         return false;
-                                     });
+        try {
+            e0   = integrate_forward_until(rel__, etop_, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
+                                           [&denu, sd, &surface_deriv, &p, this, &sout](int iter, int nn, double& enu) {
+                                             sout << "iter : " << iter << ", nn : " << nn << ", enu : " << enu << ", sd : " << sd << " " << surface_deriv() << std::endl;
+                                             if (surface_deriv() * sd < 0 || nn != (n_ - l_ - 1) || std::abs(p.back()) > 0.2) {
+                                                 return true;
+                                             }
+                                             /* do not allow step in energy to grow too much */
+                                             if (denu <= 1.0) {
+                                                 denu *= 1.5;
+                                             }
+                                             enu -= denu;
+                                             return false;
+                                         });
+        } catch (std::exception const& e) {
+            sout << e.what() << std::endl
+                 << "denu : " << denu << std::endl;
+            RTE_THROW(sout);
+        }
 
-        /* refine bottom energy */
-        e1    = e0;
-        e2    = e0 + denu;
-        ebot_ = integrate_forward_until(rel__, (e1 + e2) / 2, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
-                                        [&e1, &e2, sd, &surface_deriv, this](int iter, int nn, double& enu) {
-                                            if (surface_deriv() * sd > 0) {
-                                                e2 = enu;
-                                            } else {
-                                                e1 = enu;
-                                            }
-                                            enu = (e1 + e2) / 2.0;
-                                            return std::abs(surface_deriv()) < 1e-8;
-                                        });
+        if (surface_deriv() * sd < 0) {
+            /* refine bottom energy */
+            e1    = e0;
+            e2    = e0 + denu;
+            sout << "find_enu(): refine bottom energy" << std::endl
+                 << "  enu_start : " << (e1 + e2) / 2 << std::endl;
+            try {
+                ebot_ = integrate_forward_until(rel__, (e1 + e2) / 2, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
+                                                [&e1, &e2, sd, &surface_deriv, this](int iter, int nn, double& enu) {
+                                                    if (surface_deriv() * sd > 0) {
+                                                        e2 = enu;
+                                                    } else {
+                                                        e1 = enu;
+                                                    }
+                                                    enu = (e1 + e2) / 2.0;
+                                                    return std::abs(surface_deriv()) < 1e-8;
+                                                });
+            } catch (std::exception const& e) {
+                sout << e.what() << std::endl
+                     << "denu : " << denu << std::endl;
+                RTE_THROW(sout);
+            }
+        } else {
+            ebot_ = e0;
+        }
+
 
         switch (auto_enu__) {
             case 1: {

--- a/src/radial/radial_solver.hpp
+++ b/src/radial/radial_solver.hpp
@@ -1244,8 +1244,7 @@ class Enu_finder : public Radial_solver
                                              return false;
                                          });
         } catch (std::exception const& e) {
-            sout << e.what() << std::endl
-                 << "denu : " << denu;
+            sout << e.what() << std::endl << "denu : " << denu;
             RTE_THROW(sout);
         }
 
@@ -1281,85 +1280,84 @@ class Enu_finder : public Radial_solver
         enu_ = etop_;
         return;
 
-        auto surface_deriv = [this, &dpdr, &p]() {
-            if (true) {
-                /* return  p'(R) */
-                return dpdr.back();
-            } else {
-                /* return R*u'(R) */
-                return dpdr.back() - p.back() / radial_grid_.last();
-            }
-        };
+        //auto surface_deriv = [this, &dpdr, &p]() {
+        //    if (true) {
+        //        /* return  p'(R) */
+        //        return dpdr.back();
+        //    } else {
+        //        /* return R*u'(R) */
+        //        return dpdr.back() - p.back() / radial_grid_.last();
+        //    }
+        //};
 
-        double sd = surface_deriv();
+        //double sd = surface_deriv();
 
-        sout << "find_enu(): find bottom energy" << std::endl
-             << "  enu_start : " << etop_ << std::endl;
+        //sout << "find_enu(): find bottom energy" << std::endl
+        //     << "  enu_start : " << etop_ << std::endl;
 
-        /* Now we go down in energy and search for enu such that the wave-function derivative is zero
-         * at the muffin-tin boundary. This will be the bottom of the band. Here we look at a sign change
-         * of the derivative. */
-        denu = 1e-4;
-        try {
-            e0   = integrate_forward_until(rel__, etop_, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
-                                           [&denu, sd, &surface_deriv, &p, this, &sout](int iter, int nn, double& enu) {
-                                             sout << "iter : " << iter << ", nn : " << nn << ", enu : " << enu << ", sd : " << sd << " " << surface_deriv() << std::endl;
-                                             if (surface_deriv() * sd < 0 || nn != (n_ - l_ - 1) || std::abs(p.back()) > 0.2) {
-                                                 return true;
-                                             }
-                                             /* do not allow step in energy to grow too much */
-                                             if (denu <= 1.0) {
-                                                 denu *= 1.5;
-                                             }
-                                             enu -= denu;
-                                             return false;
-                                         });
-        } catch (std::exception const& e) {
-            sout << e.what() << std::endl
-                 << "denu : " << denu << std::endl;
-            RTE_THROW(sout);
-        }
+        ///* Now we go down in energy and search for enu such that the wave-function derivative is zero
+        // * at the muffin-tin boundary. This will be the bottom of the band. Here we look at a sign change
+        // * of the derivative. */
+        //denu = 1e-4;
+        //try {
+        //    e0   = integrate_forward_until(rel__, etop_, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
+        //                                   [&denu, sd, &surface_deriv, &p, this, &sout](int iter, int nn, double& enu) {
+        //                                     sout << "iter : " << iter << ", nn : " << nn << ", enu : " << enu << ", sd : " << sd << " " << surface_deriv() << std::endl;
+        //                                     if (surface_deriv() * sd < 0 || nn != (n_ - l_ - 1) || std::abs(p.back()) > 0.2) {
+        //                                         return true;
+        //                                     }
+        //                                     /* do not allow step in energy to grow too much */
+        //                                     if (denu <= 1.0) {
+        //                                         denu *= 1.5;
+        //                                     }
+        //                                     enu -= denu;
+        //                                     return false;
+        //                                 });
+        //} catch (std::exception const& e) {
+        //    sout << e.what() << std::endl
+        //         << "denu : " << denu << std::endl;
+        //    RTE_THROW(sout);
+        //}
 
-        if (surface_deriv() * sd < 0) {
-            /* refine bottom energy */
-            e1    = e0;
-            e2    = e0 + denu;
-            sout << "find_enu(): refine bottom energy" << std::endl
-                 << "  enu_start : " << (e1 + e2) / 2 << std::endl;
-            try {
-                ebot_ = integrate_forward_until(rel__, (e1 + e2) / 2, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
-                                                [&e1, &e2, sd, &surface_deriv, this](int iter, int nn, double& enu) {
-                                                    if (surface_deriv() * sd > 0) {
-                                                        e2 = enu;
-                                                    } else {
-                                                        e1 = enu;
-                                                    }
-                                                    enu = (e1 + e2) / 2.0;
-                                                    return std::abs(surface_deriv()) < 1e-8;
-                                                });
-            } catch (std::exception const& e) {
-                sout << e.what() << std::endl
-                     << "denu : " << denu << std::endl;
-                RTE_THROW(sout);
-            }
-        } else {
-            ebot_ = e0;
-        }
+        //if (surface_deriv() * sd < 0) {
+        //    /* refine bottom energy */
+        //    e1    = e0;
+        //    e2    = e0 + denu;
+        //    sout << "find_enu(): refine bottom energy" << std::endl
+        //         << "  enu_start : " << (e1 + e2) / 2 << std::endl;
+        //    try {
+        //        ebot_ = integrate_forward_until(rel__, (e1 + e2) / 2, l_, 0, chi_p, chi_q, p, dpdr, q, dqdr, false,
+        //                                        [&e1, &e2, sd, &surface_deriv, this](int iter, int nn, double& enu) {
+        //                                            if (surface_deriv() * sd > 0) {
+        //                                                e2 = enu;
+        //                                            } else {
+        //                                                e1 = enu;
+        //                                            }
+        //                                            enu = (e1 + e2) / 2.0;
+        //                                            return std::abs(surface_deriv()) < 1e-8;
+        //                                        });
+        //    } catch (std::exception const& e) {
+        //        sout << e.what() << std::endl
+        //             << "denu : " << denu << std::endl;
+        //        RTE_THROW(sout);
+        //    }
+        //} else {
+        //    ebot_ = e0;
+        //}
 
-
-        switch (auto_enu__) {
-            case 1: {
-                enu_ = (ebot_ + etop_) / 2.0;
-                break;
-            }
-            case 2: {
-                enu_ = ebot_;
-                break;
-            }
-            default: {
-                RTE_THROW("wrong type of auto_enu");
-            }
-        }
+        //switch (auto_enu__) {
+        //    case 1: {
+        //        enu_ = (ebot_ + etop_) / 2.0;
+        //        break;
+        //    }
+        //    case 2: {
+        //        enu_ = ebot_;
+        //        break;
+        //    }
+        //    default: {
+        //        RTE_THROW("wrong type of auto_enu");
+        //    }
+        //}
     }
 
   public:

--- a/src/unit_cell/atom_symmetry_class.cpp
+++ b/src/unit_cell/atom_symmetry_class.cpp
@@ -120,6 +120,10 @@ Atom_symmetry_class::generate_aw_radial_functions(relativity_t rel__, mdarray<do
                 rf__(ir, idxrf, 0) *= norm;
                 rf__(ir, idxrf, 1) *= norm;
             }
+            /* aw radial function can't be zero at MT boundary */
+            if (std::abs(rf__(nmtp - 1 , idxrf, 0)) < 1e-2) {
+                return false;
+            }
             for (int i : {0, 1, 2}) {
                 sd__(i, idxrf) *= norm;
             }
@@ -135,7 +139,16 @@ Atom_symmetry_class::generate_aw_radial_functions(relativity_t rel__, mdarray<do
          * radial functions */
         bool success{false};
         for (int k = 0; k < 100; k++) {
-            if ((success = compute_all_orders(l, k * 0.5))) {
+            if (l <= 3) {
+                /* for low l numbers Enu finder will find the top of the band;
+                 * in this case we need to go down in energy to remove any degeneracy of radial functions */
+                success = compute_all_orders(l, -k * 0.1);
+            } else {
+                /* for high l values, Enu is typically set in the species files and is not searched;
+                 * in case of trouble with them we need to increase linearisation energies */
+                success = compute_all_orders(l, k * 0.25);
+            }
+            if (success) {
                 break;
             }
         }

--- a/src/unit_cell/atom_symmetry_class.cpp
+++ b/src/unit_cell/atom_symmetry_class.cpp
@@ -142,7 +142,7 @@ Atom_symmetry_class::generate_aw_radial_functions(relativity_t rel__, mdarray<do
             if (l <= 3) {
                 /* for low l numbers Enu finder will find the top of the band;
                  * in this case we need to go down in energy to remove any degeneracy of radial functions */
-                success = compute_all_orders(l, -k * 0.1);
+                success = compute_all_orders(l, -k * 0.05);
             } else {
                 /* for high l values, Enu is typically set in the species files and is not searched;
                  * in case of trouble with them we need to increase linearisation energies */

--- a/src/unit_cell/atom_symmetry_class.cpp
+++ b/src/unit_cell/atom_symmetry_class.cpp
@@ -121,7 +121,7 @@ Atom_symmetry_class::generate_aw_radial_functions(relativity_t rel__, mdarray<do
                 rf__(ir, idxrf, 1) *= norm;
             }
             /* aw radial function can't be zero at MT boundary */
-            if (std::abs(rf__(nmtp - 1 , idxrf, 0)) < 1e-2) {
+            if (std::abs(rf__(nmtp - 1, idxrf, 0)) < 1e-2) {
                 return false;
             }
             for (int i : {0, 1, 2}) {

--- a/src/unit_cell/atom_symmetry_class.cpp
+++ b/src/unit_cell/atom_symmetry_class.cpp
@@ -182,47 +182,43 @@ Atom_symmetry_class::generate_lo_radial_functions(relativity_t rel__, mdarray<do
         double a[3][3];
         double rderiv[3][3];
 
-        /* number of radial solutions */
-        int num_rs = static_cast<int>(lo_descriptor(idxlo).rsd_set.size());
-        RTE_ASSERT(num_rs <= 3);
+        /* number of radial functions */
+        int num_rf = static_cast<int>(lo_descriptor(idxlo).rsd_set.size());
+        RTE_ASSERT(num_rf <= 3);
 
-        std::vector<std::vector<double>> u(num_rs);
-        std::vector<std::vector<double>> rdudr(num_rs);
+        std::vector<std::vector<double>> u(num_rf);
+        std::vector<std::vector<double>> rdudr(num_rf);
 
-        for (int order = 0; order < num_rs; order++) {
-            auto rsd = lo_descriptor(idxlo).rsd_set[order];
+        for (int irf = 0; irf < num_rf; irf++) {
+            auto rsd = lo_descriptor(idxlo).rsd_set[irf];
 
             auto result = solver.solve(rel__, rsd.dme, rsd.l, rsd.enu);
 
-            u[order]     = result.p;
-            rdudr[order] = result.rdudr;
+            u[irf]     = result.p;
+            rdudr[irf] = result.rdudr;
 
             /* divide by r */
             for (int ir = 0; ir < nmtp; ir++) {
                 /* store u(r) = p(r)/r */
-                u[order][ir] *= atom_type_.radial_grid().x_inv(ir);
+                u[irf][ir] *= atom_type_.radial_grid().x_inv(ir);
             }
 
-            /* matrix of derivatives */
-            a[order][0] = result.uderiv[0];
-            a[order][1] = result.uderiv[1];
-            a[order][2] = result.uderiv[2];
-
-            for (int i : {0, 1, 2}) {
-                rderiv[order][i] = a[order][i];
+            for (int i = 0; i < num_rf; i++) {
+                /* matrix of derivatives */
+                a[irf][i] = rderiv[irf][i] = result.uderiv[i];
             }
         }
 
         double b[]    = {0, 0, 0};
-        b[num_rs - 1] = 1.0;
+        b[num_rf - 1] = 1.0;
 
-        int info = la::wrap(la::lib_t::lapack).gesv(num_rs, 1, &a[0][0], 3, b, 3);
+        int info = la::wrap(la::lib_t::lapack).gesv(num_rf, 1, &a[0][0], 3, b, 3);
 
         if (info) {
             std::stringstream s;
             s << "a[i][j] = ";
-            for (int i = 0; i < num_rs; i++) {
-                for (int j = 0; j < num_rs; j++) {
+            for (int i = 0; i < num_rf; i++) {
+                for (int j = 0; j < num_rf; j++) {
                     s << rderiv[i][j] << " ";
                 }
             }
@@ -237,7 +233,7 @@ Atom_symmetry_class::generate_lo_radial_functions(relativity_t rel__, mdarray<do
         /* index of local orbital radial function */
         auto idxrf = atom_type_.indexr().index_of(rf_lo_index(idxlo));
         /* take linear combination of radial solutions */
-        for (int order = 0; order < num_rs; order++) {
+        for (int order = 0; order < num_rf; order++) {
             for (int ir = 0; ir < nmtp; ir++) {
                 /* u(r) function */
                 rf__(ir, idxrf, 0) += b[order] * u[order][ir];
@@ -265,11 +261,27 @@ Atom_symmetry_class::generate_lo_radial_functions(relativity_t rel__, mdarray<do
               << "  value : " << radial_functions_(nmtp - 1, idxrf, 0) << std::endl
               << "  number of MT points: " << nmtp << std::endl
               << "  MT radius: " << atom_type_.radial_grid().last() << std::endl
-              << "  b_coeffs: ";
-            for (int j = 0; j < num_rs; j++) {
+              << "  matrix of derivatives:" << std::endl;
+            for (int i = 0; i < num_rf; i++) {
+                for (int j = 0; j < num_rf; j++) {
+                    s << rderiv[i][j] << " ";
+                }
+                s << std::endl;
+            }
+            s << "  b_coeffs: ";
+            for (int j = 0; j < num_rf; j++) {
                 s << b[j] << " ";
             }
             s << std::endl;
+            s << "  norm: " << norm << std::endl;
+            double d{0};
+            for (int i = 0; i < num_rf; i++) {
+                d += b[i] * rderiv[i][0];
+            }
+            s << "  expected value at MT boundary from the linear equations: " << d << std::endl;
+            for (int i = 0; i < num_rf; i++) {
+                s << " rderiv, u: " << rderiv[i][0] << " " << u[i][nmtp - 1] << std::endl;
+            }
             RTE_WARNING(s);
         }
     }


### PR DESCRIPTION
The idea is to search for the top of the band energy. This is always possible by checking for (n-l-1+1) number of nodes in the radial function. Then, to remove degeneracies of radial functions, Enu is adjusted further. 