### PR TITLE
Fix compilation with clang 19

### DIFF
--- a/src/core/la/dmatrix.cpp
+++ b/src/core/la/dmatrix.cpp
@@ -237,7 +237,7 @@ dmatrix<T>::get_diag(int n__)
             }
         }
     }
-    blacs_grid_->comm().allreduce(d.template at(memory_t::host), n__);
+    blacs_grid_->comm().allreduce(d.at(memory_t::host), n__);
     return d;
 }
 
@@ -255,7 +255,7 @@ dmatrix<T>::save_to_hdf5(std::string name__, int m__, int n__)
             }
         }
     }
-    this->comm().allreduce(full_mtrx.template at(memory_t::host), static_cast<int>(full_mtrx.size()));
+    this->comm().allreduce(full_mtrx.at(memory_t::host), static_cast<int>(full_mtrx.size()));
 
     if (this->blacs_grid().comm().rank() == 0) {
         sirius::HDF5_tree h5(name__, sirius::hdf5_access_t::truncate);

--- a/src/hamiltonian/hamiltonian.cpp
+++ b/src/hamiltonian/hamiltonian.cpp
@@ -13,6 +13,7 @@
 
 #include "potential/potential.hpp"
 #include "local_operator.hpp"
+#include <memory>
 #include "hamiltonian.hpp"
 
 namespace sirius {
@@ -28,8 +29,8 @@ Hamiltonian0<T>::Hamiltonian0(Potential& potential__, bool precompute_lapw__, bo
 {
     PROFILE("sirius::Hamiltonian0");
 
-    local_op_ = std::unique_ptr<Local_operator<T>>(
-            new Local_operator<T>(ctx_, ctx_.spfft_coarse<T>(), ctx_.gvec_coarse_fft_sptr(), &potential__));
+    local_op_ = std::make_unique<Local_operator<T>>(ctx_, ctx_.spfft_coarse<T>(), ctx_.gvec_coarse_fft_sptr(),
+                                                    &potential__);
 
     if (!ctx_.full_potential()) {
         d_op_ = std::unique_ptr<D_operator<T>>(new D_operator<T>(potential__));
@@ -156,8 +157,8 @@ Hamiltonian0<T>::apply_bmt(wf::Wave_functions<T>& psi__, std::vector<wf::Wave_fu
 
         zm.zero();
 
-        /* only upper triangular part of zm is computed because it is a hermitian matrix */
-        #pragma omp parallel for default(shared)
+/* only upper triangular part of zm is computed because it is a hermitian matrix */
+#pragma omp parallel for default(shared)
         for (int xi2 = 0; xi2 < mt_basis_size; xi2++) {
             int lm2    = atom.type().indexb(xi2).lm;
             int idxrf2 = atom.type().indexb(xi2).idxrf;

--- a/src/hamiltonian/hamiltonian.cpp
+++ b/src/hamiltonian/hamiltonian.cpp
@@ -157,8 +157,8 @@ Hamiltonian0<T>::apply_bmt(wf::Wave_functions<T>& psi__, std::vector<wf::Wave_fu
 
         zm.zero();
 
-/* only upper triangular part of zm is computed because it is a hermitian matrix */
-#pragma omp parallel for default(shared)
+        /* only upper triangular part of zm is computed because it is a hermitian matrix */
+        #pragma omp parallel for default(shared)
         for (int xi2 = 0; xi2 < mt_basis_size; xi2++) {
             int lm2    = atom.type().indexb(xi2).lm;
             int idxrf2 = atom.type().indexb(xi2).idxrf;


### PR DESCRIPTION
- fix compilation with clang19
- use `std::make_unique` instead of `std::unique_ptr<..>(new..)`