### PR TITLE
[fix] number of mpi grids created

### DIFF
--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -848,7 +848,7 @@ Simulation_context::update()
         namax = std::max(namax, unit_cell().atom_symmetry_class(ic).num_atoms());
     }
 
-    mpi_grid_mt_sym_ = std::vector<std::unique_ptr<mpi::Grid>>(namax);
+    mpi_grid_mt_sym_ = std::vector<std::unique_ptr<mpi::Grid>>(namax + 1);
     for (int ic = 0; ic < unit_cell().num_atom_symmetry_classes(); ic++) {
         if (this->full_potential() || unit_cell().atom_symmetry_class(ic).atom_type().is_paw()) {
             int na = unit_cell().atom_symmetry_class(ic).num_atoms();

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -843,19 +843,23 @@ Simulation_context::update()
         return result;
     };
 
-    int namax{0};
+    int max_na{0};
     for (int ic = 0; ic < unit_cell().num_atom_symmetry_classes(); ic++) {
-        namax = std::max(namax, unit_cell().atom_symmetry_class(ic).num_atoms());
+        max_na = std::max(max_na, unit_cell().atom_symmetry_class(ic).num_atoms());
     }
 
-    mpi_grid_mt_sym_ = std::vector<std::unique_ptr<mpi::Grid>>(namax + 1);
+    std::vector<std::shared_ptr<mpi::Grid>> mpi_grid_tmp(max_na + 1);
+
+    mpi_grid_mt_sym_ = std::vector<std::shared_ptr<mpi::Grid>>(unit_cell().num_atom_symmetry_classes());
+
     for (int ic = 0; ic < unit_cell().num_atom_symmetry_classes(); ic++) {
         if (this->full_potential() || unit_cell().atom_symmetry_class(ic).atom_type().is_paw()) {
             int na = unit_cell().atom_symmetry_class(ic).num_atoms();
-            if (mpi_grid_mt_sym_[na] == nullptr) {
-                auto r               = make_mpi_grid_mt_sym(na, this->comm().size());
-                mpi_grid_mt_sym_[na] = std::make_unique<mpi::Grid>(r, this->comm());
+            if (mpi_grid_tmp[na] == nullptr) {
+                auto r           = make_mpi_grid_mt_sym(na, this->comm().size());
+                mpi_grid_tmp[na] = std::make_shared<mpi::Grid>(r, this->comm());
             }
+            mpi_grid_mt_sym_[ic] = mpi_grid_tmp[na];
         }
     }
 

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -853,7 +853,7 @@ Simulation_context::update()
         if (this->full_potential() || unit_cell().atom_symmetry_class(ic).atom_type().is_paw()) {
             int na = unit_cell().atom_symmetry_class(ic).num_atoms();
             if (mpi_grid_mt_sym_[na] == nullptr) {
-                auto r = make_mpi_grid_mt_sym(na, this->comm().size());
+                auto r               = make_mpi_grid_mt_sym(na, this->comm().size());
                 mpi_grid_mt_sym_[na] = std::make_unique<mpi::Grid>(r, this->comm());
             }
         }

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -843,13 +843,19 @@ Simulation_context::update()
         return result;
     };
 
-    mpi_grid_mt_sym_.clear();
+    int namax{0};
+    for (int ic = 0; ic < unit_cell().num_atom_symmetry_classes(); ic++) {
+        namax = std::max(namax, unit_cell().atom_symmetry_class(ic).num_atoms());
+    }
+
+    mpi_grid_mt_sym_ = std::vector<std::unique_ptr<mpi::Grid>>(namax);
     for (int ic = 0; ic < unit_cell().num_atom_symmetry_classes(); ic++) {
         if (this->full_potential() || unit_cell().atom_symmetry_class(ic).atom_type().is_paw()) {
-            auto r = make_mpi_grid_mt_sym(unit_cell().atom_symmetry_class(ic).num_atoms(), this->comm().size());
-            mpi_grid_mt_sym_.push_back(std::make_unique<mpi::Grid>(r, this->comm()));
-        } else {
-            mpi_grid_mt_sym_.push_back(nullptr);
+            int na = unit_cell().atom_symmetry_class(ic).num_atoms();
+            if (mpi_grid_mt_sym_[na] == nullptr) {
+                auto r = make_mpi_grid_mt_sym(na, this->comm().size());
+                mpi_grid_mt_sym_[na] = std::make_unique<mpi::Grid>(r, this->comm());
+            }
         }
     }
 

--- a/src/context/simulation_context.hpp
+++ b/src/context/simulation_context.hpp
@@ -269,7 +269,7 @@ class Simulation_context : public Simulation_parameters
     radial_integrals_t ri_;
 
     /// MPI grid for muffin-tin symmetrization.
-    /** MPI grid is defined for each atom symmetry class */
+    /** MPI grid is defined for each number of atoms belonging to symmetry classes. */
     std::vector<std::unique_ptr<mpi::Grid>> mpi_grid_mt_sym_;
 
     /// Rotation matrices for real spherical harmonics.

--- a/src/context/simulation_context.hpp
+++ b/src/context/simulation_context.hpp
@@ -269,8 +269,10 @@ class Simulation_context : public Simulation_parameters
     radial_integrals_t ri_;
 
     /// MPI grid for muffin-tin symmetrization.
-    /** MPI grid is defined for each number of atoms belonging to symmetry classes. */
-    std::vector<std::unique_ptr<mpi::Grid>> mpi_grid_mt_sym_;
+    /** MPI grid is defined for each atom symmetry class. MT symmetrization function is checking
+     *  this value, and if grid is not null, symmetrization for the given atom symmetry class is
+     *  performed. */
+    std::vector<std::shared_ptr<mpi::Grid>> mpi_grid_mt_sym_;
 
     /// Rotation matrices for real spherical harmonics.
     std::vector<std::vector<mdarray<double, 2>>> rotm_;

--- a/src/hubbard/hubbard_potential_energy.cpp
+++ b/src/hubbard/hubbard_potential_energy.cpp
@@ -71,8 +71,6 @@ generate_potential_collinear_local(Simulation_context const& ctx__, Atom_type co
     /* single orbital implementation */
     auto& hub_wf = atom_type__.lo_descriptor_hub(idx_hub_wf__);
 
-    hub_wf.print_info(RTE_OUT(ctx__.out()));
-
     if (!hub_wf.use_for_calculation()) {
         return;
     }

--- a/src/symmetry/symmetrize_mt_function.hpp
+++ b/src/symmetry/symmetrize_mt_function.hpp
@@ -144,13 +144,12 @@ symmetrize_mt_function(Crystal_symmetry const& sym__, std::vector<std::vector<md
 template <typename Index_t>
 inline void
 symmetrize_mt_function(Unit_cell const& uc__, std::vector<std::vector<mdarray<double, 2>>> const& rotm__,
-                       std::vector<std::unique_ptr<mpi::Grid>> const& mpi_grid__, int num_mag_dims__,
+                       std::vector<std::shared_ptr<mpi::Grid>> const& mpi_grid__, int num_mag_dims__,
                        std::vector<Spheric_function_set<double, Index_t>*> frlm__)
 {
     for (int ic = 0; ic < uc__.num_atom_symmetry_classes(); ic++) {
-        int na = uc__.atom_symmetry_class(ic).num_atoms();
-        if (mpi_grid__[na]) {
-            symmetrize_mt_function(uc__.symmetry(), rotm__, uc__.atom_symmetry_class(ic), *mpi_grid__[na],
+        if (mpi_grid__[ic]) {
+            symmetrize_mt_function(uc__.symmetry(), rotm__, uc__.atom_symmetry_class(ic), *mpi_grid__[ic],
                                    num_mag_dims__, frlm__);
         }
     }

--- a/src/symmetry/symmetrize_mt_function.hpp
+++ b/src/symmetry/symmetrize_mt_function.hpp
@@ -148,8 +148,9 @@ symmetrize_mt_function(Unit_cell const& uc__, std::vector<std::vector<mdarray<do
                        std::vector<Spheric_function_set<double, Index_t>*> frlm__)
 {
     for (int ic = 0; ic < uc__.num_atom_symmetry_classes(); ic++) {
-        if (mpi_grid__[ic]) {
-            symmetrize_mt_function(uc__.symmetry(), rotm__, uc__.atom_symmetry_class(ic), *mpi_grid__[ic],
+        int na = uc__.atom_symmetry_class(ic).num_atoms();
+        if (mpi_grid__[na]) {
+            symmetrize_mt_function(uc__.symmetry(), rotm__, uc__.atom_symmetry_class(ic), *mpi_grid__[na],
                                    num_mag_dims__, frlm__);
         }
     }


### PR DESCRIPTION
`mpi grid <-> atom class index` is a redundant mapping. The minimal and sufficient mapping is between mpi grid and number of atoms in the symmetry class. 