### PR TITLE
missing cstdint include (gcc14), remove static keyword

### DIFF
--- a/apps/tests/test_hloc.cpp
+++ b/apps/tests/test_hloc.cpp
@@ -33,7 +33,7 @@ test_hloc_impl(sirius::Simulation_context& ctx__, int num_bands__, int use_gpu__
     sirius::Local_operator<T> hloc(ctx__, fft, gvec_fft);
 
     wf::Wave_functions<T> phi(gvec, wf::num_mag_dims(0), wf::num_bands(4 * num_bands__), memory_t::host_pinned);
-    #pragma omp patallel for
+    #pragma omp parallel for
     for (int i = 0; i < 4 * num_bands__; i++) {
         for (int j = 0; j < phi.ld(); j++) {
             phi.pw_coeffs(j, wf::spin_index(0), wf::band_index(i)) = random<std::complex<T>>();

--- a/src/core/memory.hpp
+++ b/src/core/memory.hpp
@@ -154,7 +154,7 @@ get_device_t(std::string name__)
 /** Allocate a memory block of the memory_t type. Return a nullptr if this memory is not available, otherwise
  *  return a pointer to an allocated block. */
 template <typename T>
-static inline T*
+inline T*
 allocate(size_t n__, memory_t M__)
 {
     switch (M__) {
@@ -185,7 +185,7 @@ allocate(size_t n__, memory_t M__)
 }
 
 /// Deallocate pointer of a given memory type.
-static inline void
+inline void
 deallocate(void* ptr__, memory_t M__)
 {
     switch (M__) {
@@ -256,7 +256,7 @@ copy(memory_t from_mem__, T const* from_ptr__, memory_t to_mem__, T* to_ptr__, s
 
 /// Allocate n elements and return a unique pointer.
 template <typename T>
-static inline auto
+inline auto
 get_unique_ptr(size_t n__, memory_t M__)
 {
     return std::unique_ptr<T, std::function<void(void*)>>(allocate<T>(n__, M__),

--- a/src/core/mpi/communicator.hpp
+++ b/src/core/mpi/communicator.hpp
@@ -18,8 +18,7 @@
 #include <cassert>
 #include <vector>
 #include <complex>
-#include <cstdarg>
-#include <functional>
+#include <cstdint>
 #include <memory>
 #include <algorithm>
 #include <cstring>


### PR DESCRIPTION
I think the static keyword mentioned in #1073 isn't required.