### PR TITLE
cmake consistent with nvtx3 update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.23)
+cmake_minimum_required(VERSION 3.25)
 
 include(CMakePackageConfigHelpers)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -123,7 +123,7 @@ target_link_libraries(sirius_cxx PUBLIC ${GSL_LIBRARY}
   "${SIRIUS_LINALG_LIB}"
   $<$<BOOL:${SIRIUS_USE_PUGIXML}>:pugixml::pugixml>
   $<$<BOOL:${SIRIUS_USE_MEMORY_POOL}>:umpire>
-  $<$<BOOL:${SIRIUS_USE_NVTX}>:nvToolsExt>
+  $<$<BOOL:${SIRIUS_USE_NVTX}>:CUDA::nvtx3>
   $<TARGET_NAME_IF_EXISTS:sirius::cudalibs>
   $<$<BOOL:${SIRIUS_USE_ROCM}>:roc::rocsolver>
   $<$<BOOL:${SIRIUS_USE_ROCM}>:roc::rocblas>


### PR DESCRIPTION
nvtx3 include have been added in  #1075, add the correct target in cmake and require cmake>=3.25 (version which knows about nvtx3 target)