### PR TITLE
fix compilation with clang

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,6 +129,7 @@ target_link_libraries(sirius_cxx PUBLIC ${GSL_LIBRARY}
   $<$<BOOL:${SIRIUS_USE_ROCM}>:roc::rocblas>
   $<$<BOOL:${SIRIUS_USE_ROCM}>:hip::host>
   $<TARGET_NAME_IF_EXISTS:OpenMP::OpenMP_CXX>
+  fmt::fmt
 )
 
 target_include_directories(sirius_cxx PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>

--- a/src/core/fft/fft.hpp
+++ b/src/core/fft/fft.hpp
@@ -107,7 +107,7 @@ const std::map<SpfftProcessingUnitType, memory_t> spfft_memory_t = {{SPFFT_PU_HO
 
 template <typename F, typename T, typename... Args>
 using enable_return =
-        typename std::enable_if<std::is_same<typename std::invoke_result_t<F(Args...)>, T>::value, void>::type;
+typename std::enable_if<std::is_same<typename std::invoke_result_t<F, Args...>, T>::value, void>::type;
 
 /// Load data from real-valued lambda.
 template <typename T, typename F>

--- a/src/core/fft/fft.hpp
+++ b/src/core/fft/fft.hpp
@@ -107,7 +107,7 @@ const std::map<SpfftProcessingUnitType, memory_t> spfft_memory_t = {{SPFFT_PU_HO
 
 template <typename F, typename T, typename... Args>
 using enable_return =
-typename std::enable_if<std::is_same<typename std::invoke_result_t<F, Args...>, T>::value, void>::type;
+        typename std::enable_if<std::is_same<typename std::invoke_result_t<F, Args...>, T>::value, void>::type;
 
 /// Load data from real-valued lambda.
 template <typename T, typename F>

--- a/src/dft/dft_ground_state.cpp
+++ b/src/dft/dft_ground_state.cpp
@@ -19,7 +19,6 @@
 #include "hamiltonian/initialize_subspace.hpp"
 #include "hamiltonian/diagonalize.hpp"
 
-
 namespace sirius {
 
 void

--- a/src/dft/dft_ground_state.cpp
+++ b/src/dft/dft_ground_state.cpp
@@ -12,11 +12,13 @@
  */
 
 #include <iomanip>
+#include <fmt/format.h>
 #include "dft_ground_state.hpp"
 #include "core/profiler.hpp"
 #include "core/rte/rte.hpp"
 #include "hamiltonian/initialize_subspace.hpp"
 #include "hamiltonian/diagonalize.hpp"
+
 
 namespace sirius {
 

--- a/src/k_point/k_point_set.cpp
+++ b/src/k_point/k_point_set.cpp
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#include <fmt/base.h>
+#include <fmt/format.h>
 #include <limits>
 #include "core/rte/rte.hpp"
 #include "dft/smearing.hpp"


### PR DESCRIPTION
there was a typo in the previous PR, it was merged before cscs ci passed.

Also fix fmt includes and target in cmake.