### PR TITLE
Elpa api change

### DIFF
--- a/cmake/modules/FindElpa.cmake
+++ b/cmake/modules/FindElpa.cmake
@@ -23,16 +23,12 @@ find_library(SIRIUS_ELPA_LIBRARIES
   DOC "elpa libraries list")
 
 find_path(SIRIUS_ELPA_INCLUDE_DIR
-  NAMES elpa/elpa.h elpa/elpa_constants.h
-  PATH_SUFFIXES include/elpa_openmp-$ENV{EBVERSIONELPA} include/elpa-$ENV{EBVERSIONELPA}
-  HINTS
-  ${_ELPA_INCLUDE_DIRS}
+  NAMES elpa/elpa.h
+  HINTS ${_ELPA_INCLUDE_DIRS}
   ENV ELPAROOT
-  ENV EBROOTELPA)
+  NO_CACHE)
 
 find_package_handle_standard_args(Elpa "DEFAULT_MSG" SIRIUS_ELPA_LIBRARIES SIRIUS_ELPA_INCLUDE_DIR)
-
-message("ELPA_INCLUDE_DIR: ${SIRIUS_ELPA_INCLUDE_DIR}")
 
 if(Elpa_FOUND AND NOT TARGET sirius::elpa)
   add_library(sirius::elpa INTERFACE IMPORTED)

--- a/src/core/la/eigenproblem.cpp
+++ b/src/core/la/eigenproblem.cpp
@@ -104,8 +104,8 @@ Eigensolver_elpa::solve(ftn_int matrix_size__, ftn_int nev__, la::dmatrix<double
 
     auto w = mph.get_unique_ptr<double>(matrix_size__);
 
-    elpa_generalized_eigenvectors_d(handle, A__.at(memory_t::host), B__.at(memory_t::host), w.get(),
-                                    Z__.at(memory_t::host), 0, &error);
+    elpa_generalized_eigenvectors(handle, A__.at(memory_t::host), B__.at(memory_t::host), w.get(),
+                                  Z__.at(memory_t::host), 0, &error);
 
     if (error != ELPA_OK) {
         elpa_deallocate(handle, &error);
@@ -168,8 +168,8 @@ Eigensolver_elpa::solve(ftn_int matrix_size__, ftn_int nev__, la::dmatrix<std::c
 
     auto w = mph.get_unique_ptr<double>(matrix_size__);
 
-    elpa_generalized_eigenvectors_dc(handle, A__.at(memory_t::host), B__.at(memory_t::host), w.get(),
-                                     Z__.at(memory_t::host), 0, &error);
+    elpa_generalized_eigenvectors(handle, A__.at(memory_t::host), B__.at(memory_t::host), w.get(),
+                                  Z__.at(memory_t::host), 0, &error);
 
     if (error != ELPA_OK) {
         elpa_deallocate(handle, &error);

--- a/src/core/la/eigenproblem.cpp
+++ b/src/core/la/eigenproblem.cpp
@@ -104,8 +104,13 @@ Eigensolver_elpa::solve(ftn_int matrix_size__, ftn_int nev__, la::dmatrix<double
 
     auto w = mph.get_unique_ptr<double>(matrix_size__);
 
+#if ELPA_API_VERSION < 20250131
+    elpa_generalized_eigenvectors_d(handle, A__.at(memory_t::host), B__.at(memory_t::host), w.get(),
+                                    Z__.at(memory_t::host), 0, &error);
+#else
     elpa_generalized_eigenvectors(handle, A__.at(memory_t::host), B__.at(memory_t::host), w.get(),
                                   Z__.at(memory_t::host), 0, &error);
+#endif
 
     if (error != ELPA_OK) {
         elpa_deallocate(handle, &error);
@@ -168,8 +173,13 @@ Eigensolver_elpa::solve(ftn_int matrix_size__, ftn_int nev__, la::dmatrix<std::c
 
     auto w = mph.get_unique_ptr<double>(matrix_size__);
 
+#if ELPA_API_VERSION < 20250131
+    elpa_generalized_eigenvectors_dc(handle, A__.at(memory_t::host), B__.at(memory_t::host), w.get(),
+                                     Z__.at(memory_t::host), 0, &error);
+#else
     elpa_generalized_eigenvectors(handle, A__.at(memory_t::host), B__.at(memory_t::host), w.get(),
                                   Z__.at(memory_t::host), 0, &error);
+#endif
 
     if (error != ELPA_OK) {
         elpa_deallocate(handle, &error);


### PR DESCRIPTION
Needs to be merged before CI update to spack v1.0 (which will use elpa 2025.1)

From the elpa manual (https://elpa.mpcdf.mpg.de/userguide/archive/elpa_userguide_2024_05.pdf, page 35)
>Important note for the GPU users
The overloaded convenience functions, like eigenvalues() can only be used if the data has
been allocated on the host. If the data has been allocated on the GPU device, an automatic
destinction of datatypes is not possible and one has to use the explicit functions specifying
the datatype, e.g. eigenvalues_double()

It appears to me one could have used the overloaded functions already pre 2025.