### PR TITLE
[enhancement] use k-independent muffin-tin part of the Hamiltonian

### DIFF
--- a/src/core/typedefs.hpp
+++ b/src/core/typedefs.hpp
@@ -47,25 +47,6 @@ using real_type = typename Real<T>::type;
 template <class T>
 constexpr bool is_real_v = std::is_same<T, real_type<T>>::value;
 
-/// Spin-blocks of the Hamiltonian.
-enum class spin_block_t
-{
-    /// Non-magnetic case.
-    nm,
-
-    /// Up-up block.
-    uu,
-
-    /// Down-donw block.
-    dd,
-
-    /// Up-down block.
-    ud,
-
-    /// Down-up block.
-    du
-};
-
 /// Type of electronic structure methods.
 enum class electronic_structure_method_t
 {

--- a/src/geometry/force.cpp
+++ b/src/geometry/force.cpp
@@ -803,7 +803,7 @@ Force::add_ibs_force(K_point<double>* kp__, Hamiltonian_k<double>& Hk__, mdarray
         Hk__.set_fv_h_o_apw_lo(atom, ia, alm_row, alm_col, h, o);
 
         /* apply MT Hamiltonian to column coefficients */
-        Hk__.H0().apply_hmt_to_apw(atom, spin_block_t::nm, kp__->num_gkvec_col(), alm_col, halm_col);
+        Hk__.H0().apply_hmt_to_apw(ia, spin_block_t::nm, kp__->num_gkvec_col(), alm_col, halm_col);
 
         /* apw-apw block of the overlap matrix */
         la::wrap(la::lib_t::blas)

--- a/src/geometry/force.cpp
+++ b/src/geometry/force.cpp
@@ -803,7 +803,7 @@ Force::add_ibs_force(K_point<double>* kp__, Hamiltonian_k<double>& Hk__, mdarray
         Hk__.set_fv_h_o_apw_lo(atom, ia, alm_row, alm_col, h, o);
 
         /* apply MT Hamiltonian to column coefficients */
-        Hk__.H0().apply_hmt_to_apw(ia, spin_block_t::nm, kp__->num_gkvec_col(), alm_col, halm_col);
+        Hk__.H0().apply_hmt_to_apw(ia, 0, kp__->num_gkvec_col(), alm_col, halm_col);
 
         /* apw-apw block of the overlap matrix */
         la::wrap(la::lib_t::blas)

--- a/src/hamiltonian/hamiltonian.cpp
+++ b/src/hamiltonian/hamiltonian.cpp
@@ -153,8 +153,18 @@ Hamiltonian0<T>::apply_bmt(wf::Wave_functions<T>& psi__, std::vector<wf::Wave_fu
                     int lm1    = atom.type().indexb(xi1).lm;
                     int idxrf1 = atom.type().indexb(xi1).idxrf;
 
-                    zm(xi1, xi2, i) = atom.type().gaunt_coefs().sum_L3_gaunt(
-                            lm1, lm2, atom.b_radial_integrals(idxrf1, idxrf2, i));
+                    //zm(xi1, xi2, i) = atom.type().gaunt_coefs().sum_L3_gaunt(
+                    //        lm1, lm2, atom.b_radial_integrals(idxrf1, idxrf2, i));
+                    if (ctx_.num_mag_dims() == 1) {
+                        zm(xi1, xi2, i) = atom.template radial_integrals_sum_L3<2>({0, 1}, idxrf1, idxrf2,
+                                                    atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));
+                    }
+                    if (ctx_.num_mag_dims() == 3) {
+                        std::array<std::complex<double>, 4> c({0, 0, 0, 0});
+                        c[i + 1] = 1;
+                        zm(xi1, xi2, i) = atom.template radial_integrals_sum_L3<4>(c, idxrf1, idxrf2,
+                                                    atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));
+                    }
                 }
             }
         }

--- a/src/hamiltonian/hamiltonian.cpp
+++ b/src/hamiltonian/hamiltonian.cpp
@@ -89,30 +89,27 @@ Hamiltonian0<T>::~Hamiltonian0()
 
 template <typename T>
 void
-Hamiltonian0<T>::apply_hmt_to_apw(Atom const& atom__, spin_block_t sblock__, int ngv__,
-                                  mdarray<std::complex<T>, 2>& alm__, mdarray<std::complex<T>, 2>& halm__) const
+Hamiltonian0<T>::apply_hmt_to_apw(int ia__, spin_block_t sblock__, int ngv__,
+                                  mdarray<std::complex<T>, 2> const& alm__, mdarray<std::complex<T>, 2>& halm__) const
 {
-    auto& type = atom__.type();
+    auto& type = ctx_.unit_cell().atom(ia__).type();
 
-    // TODO: this is k-independent and can in principle be precomputed together with radial integrals if memory is
-    // available
-    // TODO: for spin-collinear case hmt is Hermitian; compute upper triangular part and use zhemm
-    mdarray<std::complex<T>, 2> hmt({type.mt_aw_basis_size(), type.mt_aw_basis_size()});
+    //mdarray<std::complex<T>, 2> hmt({type.mt_aw_basis_size(), type.mt_aw_basis_size()});
     /* compute the muffin-tin Hamiltonian */
-    for (int j2 = 0; j2 < type.mt_aw_basis_size(); j2++) {
-        int lm2    = type.indexb(j2).lm;
-        int idxrf2 = type.indexb(j2).idxrf;
-        for (int j1 = 0; j1 < type.mt_aw_basis_size(); j1++) {
-            int lm1    = type.indexb(j1).lm;
-            int idxrf1 = type.indexb(j1).idxrf;
-            hmt(j1, j2) =
-                    atom__.radial_integrals_sum_L3(sblock__, idxrf1, idxrf2, type.gaunt_coefs().gaunt_vector(lm1, lm2));
-        }
-    }
+    //for (int j2 = 0; j2 < type.mt_aw_basis_size(); j2++) {
+    //    int lm2    = type.indexb(j2).lm;
+    //    int idxrf2 = type.indexb(j2).idxrf;
+    //    for (int j1 = 0; j1 < type.mt_aw_basis_size(); j1++) {
+    //        int lm1    = type.indexb(j1).lm;
+    //        int idxrf1 = type.indexb(j1).idxrf;
+    //        hmt(j1, j2) =
+    //                atom__.radial_integrals_sum_L3(sblock__, idxrf1, idxrf2, type.gaunt_coefs().gaunt_vector(lm1, lm2));
+    //    }
+    //}
     la::wrap(la::lib_t::blas)
             .gemm('N', 'T', ngv__, type.mt_aw_basis_size(), type.mt_aw_basis_size(),
-                  &la::constant<std::complex<T>>::one(), alm__.at(memory_t::host), alm__.ld(), hmt.at(memory_t::host),
-                  hmt.ld(), &la::constant<std::complex<T>>::zero(), halm__.at(memory_t::host), halm__.ld());
+                  &la::constant<std::complex<T>>::one(), alm__.at(memory_t::host), alm__.ld(), hmt_[ia__].at(memory_t::host),
+                  hmt_[ia__].ld(), &la::constant<std::complex<T>>::zero(), halm__.at(memory_t::host), halm__.ld());
 }
 
 template <typename T>

--- a/src/hamiltonian/hamiltonian.cpp
+++ b/src/hamiltonian/hamiltonian.cpp
@@ -64,35 +64,35 @@ Hamiltonian0<T>::Hamiltonian0(Potential& potential__, bool precompute_lapw__, bo
                     int lm2    = type.indexb(j2).lm;
                     int idxrf2 = type.indexb(j2).idxrf;
                     for (int j1 = 0; j1 < nmt; j1++) {
-                        int lm1          = type.indexb(j1).lm;
-                        int idxrf1       = type.indexb(j1).idxrf;
+                        int lm1    = type.indexb(j1).lm;
+                        int idxrf1 = type.indexb(j1).idxrf;
                         switch (ctx_.num_mag_dims()) {
                             case 3: {
                                 // Bx + i By
-                                hmt_[ia](j1, j2, 2) = atom.radial_integrals_sum_L3<4>({0, 0, 1, 1}, idxrf1, idxrf2,
-                                                                        type.gaunt_coefs().gaunt_vector(lm1, lm2));
+                                hmt_[ia](j1, j2, 2) = atom.radial_integrals_sum_L3<4>(
+                                        {0, 0, 1, 1}, idxrf1, idxrf2, type.gaunt_coefs().gaunt_vector(lm1, lm2));
 
                                 // Bx - i By
-                                hmt_[ia](j1, j2, 3) = atom.radial_integrals_sum_L3<4>({0, 0, 1, -1}, idxrf1, idxrf2,
-                                                                        type.gaunt_coefs().gaunt_vector(lm1, lm2));
+                                hmt_[ia](j1, j2, 3) = atom.radial_integrals_sum_L3<4>(
+                                        {0, 0, 1, -1}, idxrf1, idxrf2, type.gaunt_coefs().gaunt_vector(lm1, lm2));
                             }
                             case 1: {
                                 if (ctx_.cfg().control().use_second_variation()) {
-                                    hmt_[ia](j1, j2, 0) = atom.radial_integrals_sum_L3<2>({1, 0}, idxrf1, idxrf2,
-                                                                        type.gaunt_coefs().gaunt_vector(lm1, lm2));
-                                    hmt_[ia](j1, j2, 1) = atom.radial_integrals_sum_L3<2>({0, 1}, idxrf1, idxrf2,
-                                                                        type.gaunt_coefs().gaunt_vector(lm1, lm2));
+                                    hmt_[ia](j1, j2, 0) = atom.radial_integrals_sum_L3<2>(
+                                            {1, 0}, idxrf1, idxrf2, type.gaunt_coefs().gaunt_vector(lm1, lm2));
+                                    hmt_[ia](j1, j2, 1) = atom.radial_integrals_sum_L3<2>(
+                                            {0, 1}, idxrf1, idxrf2, type.gaunt_coefs().gaunt_vector(lm1, lm2));
                                 } else {
-                                    hmt_[ia](j1, j2, 0) = atom.radial_integrals_sum_L3<2>({1, 1}, idxrf1, idxrf2,
-                                                                        type.gaunt_coefs().gaunt_vector(lm1, lm2));
-                                    hmt_[ia](j1, j2, 1) = atom.radial_integrals_sum_L3<2>({1, -1}, idxrf1, idxrf2,
-                                                                        type.gaunt_coefs().gaunt_vector(lm1, lm2));
+                                    hmt_[ia](j1, j2, 0) = atom.radial_integrals_sum_L3<2>(
+                                            {1, 1}, idxrf1, idxrf2, type.gaunt_coefs().gaunt_vector(lm1, lm2));
+                                    hmt_[ia](j1, j2, 1) = atom.radial_integrals_sum_L3<2>(
+                                            {1, -1}, idxrf1, idxrf2, type.gaunt_coefs().gaunt_vector(lm1, lm2));
                                 }
                                 break;
                             }
                             case 0: {
-                                hmt_[ia](j1, j2, 0) = atom.radial_integrals_sum_L3<1>({1}, idxrf1, idxrf2,
-                                                                        type.gaunt_coefs().gaunt_vector(lm1, lm2));
+                                hmt_[ia](j1, j2, 0) = atom.radial_integrals_sum_L3<1>(
+                                        {1}, idxrf1, idxrf2, type.gaunt_coefs().gaunt_vector(lm1, lm2));
                             }
                         }
                     }
@@ -115,15 +115,16 @@ Hamiltonian0<T>::~Hamiltonian0()
 
 template <typename T>
 void
-Hamiltonian0<T>::apply_hmt_to_apw(int ia__, int j__, int ngv__,
-                                  mdarray<std::complex<T>, 2> const& alm__, mdarray<std::complex<T>, 2>& halm__) const
+Hamiltonian0<T>::apply_hmt_to_apw(int ia__, int j__, int ngv__, mdarray<std::complex<T>, 2> const& alm__,
+                                  mdarray<std::complex<T>, 2>& halm__) const
 {
     auto& type = ctx_.unit_cell().atom(ia__).type();
 
     la::wrap(la::lib_t::blas)
             .gemm('N', 'T', ngv__, type.mt_aw_basis_size(), type.mt_aw_basis_size(),
-                  &la::constant<std::complex<T>>::one(), alm__.at(memory_t::host), alm__.ld(), hmt_[ia__].at(memory_t::host),
-                  hmt_[ia__].ld(), &la::constant<std::complex<T>>::zero(), halm__.at(memory_t::host), halm__.ld());
+                  &la::constant<std::complex<T>>::one(), alm__.at(memory_t::host), alm__.ld(),
+                  hmt_[ia__].at(memory_t::host), hmt_[ia__].ld(), &la::constant<std::complex<T>>::zero(),
+                  halm__.at(memory_t::host), halm__.ld());
 }
 
 template <typename T>
@@ -168,8 +169,9 @@ Hamiltonian0<T>::apply_bmt(wf::Wave_functions<T>& psi__, std::vector<wf::Wave_fu
         /* compute bwf = B_z*|wf_j> */
         la::wrap(la::lib_t::blas)
                 .hemm('L', 'U', mt_basis_size, ctx_.num_fv_states(), &la::constant<std::complex<T>>::one(),
-                      zm.at(memory_t::host, 0, 0, 1), zm.ld(), &psi__.mt_coeffs(0, it.li, wf::spin_index(0), wf::band_index(0)),
-                      psi__.ld(), &la::constant<std::complex<T>>::zero(),
+                      zm.at(memory_t::host, 0, 0, 1), zm.ld(),
+                      &psi__.mt_coeffs(0, it.li, wf::spin_index(0), wf::band_index(0)), psi__.ld(),
+                      &la::constant<std::complex<T>>::zero(),
                       &bpsi__[0].mt_coeffs(0, it.li, wf::spin_index(0), wf::band_index(0)), bpsi__[0].ld());
 
         /* compute bwf = (B_x - iB_y)|wf_j> */

--- a/src/hamiltonian/hamiltonian.cpp
+++ b/src/hamiltonian/hamiltonian.cpp
@@ -66,7 +66,7 @@ Hamiltonian0<T>::Hamiltonian0(Potential& potential__, bool precompute_lapw__, bo
                     for (int j1 = 0; j1 <= j2; j1++) {
                         int lm1          = type.indexb(j1).lm;
                         int idxrf1       = type.indexb(j1).idxrf;
-                        hmt_[ia](j1, j2) = atom.radial_integrals_sum_L3(spin_block_t::nm, idxrf1, idxrf2,
+                        hmt_[ia](j1, j2) = atom.radial_integrals_sum_L3<1>({1.0}, idxrf1, idxrf2,
                                                                         type.gaunt_coefs().gaunt_vector(lm1, lm2));
                         hmt_[ia](j2, j1) = std::conj(hmt_[ia](j1, j2));
                     }
@@ -89,23 +89,11 @@ Hamiltonian0<T>::~Hamiltonian0()
 
 template <typename T>
 void
-Hamiltonian0<T>::apply_hmt_to_apw(int ia__, spin_block_t sblock__, int ngv__,
+Hamiltonian0<T>::apply_hmt_to_apw(int ia__, int j__, int ngv__,
                                   mdarray<std::complex<T>, 2> const& alm__, mdarray<std::complex<T>, 2>& halm__) const
 {
     auto& type = ctx_.unit_cell().atom(ia__).type();
 
-    //mdarray<std::complex<T>, 2> hmt({type.mt_aw_basis_size(), type.mt_aw_basis_size()});
-    /* compute the muffin-tin Hamiltonian */
-    //for (int j2 = 0; j2 < type.mt_aw_basis_size(); j2++) {
-    //    int lm2    = type.indexb(j2).lm;
-    //    int idxrf2 = type.indexb(j2).idxrf;
-    //    for (int j1 = 0; j1 < type.mt_aw_basis_size(); j1++) {
-    //        int lm1    = type.indexb(j1).lm;
-    //        int idxrf1 = type.indexb(j1).idxrf;
-    //        hmt(j1, j2) =
-    //                atom__.radial_integrals_sum_L3(sblock__, idxrf1, idxrf2, type.gaunt_coefs().gaunt_vector(lm1, lm2));
-    //    }
-    //}
     la::wrap(la::lib_t::blas)
             .gemm('N', 'T', ngv__, type.mt_aw_basis_size(), type.mt_aw_basis_size(),
                   &la::constant<std::complex<T>>::one(), alm__.at(memory_t::host), alm__.ld(), hmt_[ia__].at(memory_t::host),

--- a/src/hamiltonian/hamiltonian.cpp
+++ b/src/hamiltonian/hamiltonian.cpp
@@ -158,67 +158,69 @@ template <typename T>
 void
 Hamiltonian0<T>::apply_bmt(wf::Wave_functions<T>& psi__, std::vector<wf::Wave_functions<T>>& bpsi__) const
 {
-    mdarray<std::complex<T>, 3> zm(
-            {unit_cell_.max_mt_basis_size(), unit_cell_.max_mt_basis_size(), ctx_.num_mag_dims()});
+    //mdarray<std::complex<T>, 3> zm(
+    //        {unit_cell_.max_mt_basis_size(), unit_cell_.max_mt_basis_size(), ctx_.num_mag_dims()});
 
     for (auto it : psi__.spl_num_atoms()) {
         auto ia           = it.i;
         auto& atom        = unit_cell_.atom(ia);
         int mt_basis_size = atom.type().mt_basis_size();
 
-        zm.zero();
+        auto const& zm = hmt_[ia];
 
-        /* only upper triangular part of zm is computed because it is a hermitian matrix */
-        #pragma omp parallel for default(shared)
-        for (int xi2 = 0; xi2 < mt_basis_size; xi2++) {
-            int lm2    = atom.type().indexb(xi2).lm;
-            int idxrf2 = atom.type().indexb(xi2).idxrf;
+        //zm.zero();
 
-            for (int i = 0; i < ctx_.num_mag_dims(); i++) {
-                for (int xi1 = 0; xi1 <= xi2; xi1++) {
-                    int lm1    = atom.type().indexb(xi1).lm;
-                    int idxrf1 = atom.type().indexb(xi1).idxrf;
+        ///* only upper triangular part of zm is computed because it is a hermitian matrix */
+        //#pragma omp parallel for default(shared)
+        //for (int xi2 = 0; xi2 < mt_basis_size; xi2++) {
+        //    int lm2    = atom.type().indexb(xi2).lm;
+        //    int idxrf2 = atom.type().indexb(xi2).idxrf;
 
-                    //zm(xi1, xi2, i) = atom.type().gaunt_coefs().sum_L3_gaunt(
-                    //        lm1, lm2, atom.b_radial_integrals(idxrf1, idxrf2, i));
-                    if (ctx_.num_mag_dims() == 1) {
-                        zm(xi1, xi2, i) = atom.template radial_integrals_sum_L3<2>({0, 1}, idxrf1, idxrf2,
-                                                    atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));
-                    }
-                    if (ctx_.num_mag_dims() == 3) {
-                        std::array<int, 4> c({0, 0, 0, 0});
-                        c[i + 1] = 1;
-                        zm(xi1, xi2, i) = atom.template radial_integrals_sum_L3<4>(c, idxrf1, idxrf2,
-                                                    atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));
-                    }
-                }
-            }
-        }
+        //    for (int i = 0; i < ctx_.num_mag_dims(); i++) {
+        //        for (int xi1 = 0; xi1 <= xi2; xi1++) {
+        //            int lm1    = atom.type().indexb(xi1).lm;
+        //            int idxrf1 = atom.type().indexb(xi1).idxrf;
+
+        //            //zm(xi1, xi2, i) = atom.type().gaunt_coefs().sum_L3_gaunt(
+        //            //        lm1, lm2, atom.b_radial_integrals(idxrf1, idxrf2, i));
+        //            //if (ctx_.num_mag_dims() == 1) {
+        //            //    zm(xi1, xi2, i) = atom.template radial_integrals_sum_L3<2>({0, 1}, idxrf1, idxrf2,
+        //            //                                atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));
+        //            //}
+        //            //if (ctx_.num_mag_dims() == 3) {
+        //            //    std::array<int, 4> c({0, 0, 0, 0});
+        //            //    c[i + 1] = 1;
+        //            //    zm(xi1, xi2, i) = atom.template radial_integrals_sum_L3<4>(c, idxrf1, idxrf2,
+        //            //                                atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));
+        //            //}
+        //        }
+        //    }
+        //}
         /* compute bwf = B_z*|wf_j> */
         la::wrap(la::lib_t::blas)
                 .hemm('L', 'U', mt_basis_size, ctx_.num_fv_states(), &la::constant<std::complex<T>>::one(),
-                      zm.at(memory_t::host), zm.ld(), &psi__.mt_coeffs(0, it.li, wf::spin_index(0), wf::band_index(0)),
+                      zm.at(memory_t::host, 0, 0, 1), zm.ld(), &psi__.mt_coeffs(0, it.li, wf::spin_index(0), wf::band_index(0)),
                       psi__.ld(), &la::constant<std::complex<T>>::zero(),
                       &bpsi__[0].mt_coeffs(0, it.li, wf::spin_index(0), wf::band_index(0)), bpsi__[0].ld());
 
         /* compute bwf = (B_x - iB_y)|wf_j> */
         if (bpsi__.size() == 3) {
-            /* reuse first (z) component of zm matrix to store (B_x - iB_y) */
-            for (int xi2 = 0; xi2 < mt_basis_size; xi2++) {
-                for (int xi1 = 0; xi1 <= xi2; xi1++) {
-                    zm(xi1, xi2, 0) = zm(xi1, xi2, 1) - std::complex<T>(0, 1) * zm(xi1, xi2, 2);
-                }
+            ///* reuse first (z) component of zm matrix to store (B_x - iB_y) */
+            //for (int xi2 = 0; xi2 < mt_basis_size; xi2++) {
+            //    for (int xi1 = 0; xi1 <= xi2; xi1++) {
+            //        zm(xi1, xi2, 0) = zm(xi1, xi2, 1) - std::complex<T>(0, 1) * zm(xi1, xi2, 2);
+            //    }
 
-                /* remember: zm for x,y,z, components of magnetic field is hermitian and we computed
-                 * only the upper triangular part */
-                for (int xi1 = xi2 + 1; xi1 < mt_basis_size; xi1++) {
-                    zm(xi1, xi2, 0) = std::conj(zm(xi2, xi1, 1)) - std::complex<T>(0, 1) * std::conj(zm(xi2, xi1, 2));
-                }
-            }
+            //    /* remember: zm for x,y,z, components of magnetic field is hermitian and we computed
+            //     * only the upper triangular part */
+            //    for (int xi1 = xi2 + 1; xi1 < mt_basis_size; xi1++) {
+            //        zm(xi1, xi2, 0) = std::conj(zm(xi2, xi1, 1)) - std::complex<T>(0, 1) * std::conj(zm(xi2, xi1, 2));
+            //    }
+            //}
 
             la::wrap(la::lib_t::blas)
                     .gemm('N', 'N', mt_basis_size, ctx_.num_fv_states(), mt_basis_size,
-                          &la::constant<std::complex<T>>::one(), zm.at(memory_t::host), zm.ld(),
+                          &la::constant<std::complex<T>>::one(), zm.at(memory_t::host, 0, 0, 3), zm.ld(),
                           &psi__.mt_coeffs(0, it.li, wf::spin_index(0), wf::band_index(0)), psi__.ld(),
                           &la::constant<std::complex<T>>::zero(),
                           &bpsi__[2].mt_coeffs(0, it.li, wf::spin_index(0), wf::band_index(0)), bpsi__[2].ld());

--- a/src/hamiltonian/hamiltonian.cpp
+++ b/src/hamiltonian/hamiltonian.cpp
@@ -45,7 +45,7 @@ Hamiltonian0<T>::Hamiltonian0(Potential& potential__, bool precompute_lapw__, bo
             }
             ctx_.unit_cell().generate_radial_integrals();
         }
-        hmt_    = std::vector<mdarray<std::complex<T>, 2>>(ctx_.unit_cell().num_atoms());
+        hmt_    = std::vector<mdarray<std::complex<T>, 3>>(ctx_.unit_cell().num_atoms());
         auto pu = ctx_.processing_unit();
         #pragma omp parallel
         {
@@ -57,18 +57,18 @@ Hamiltonian0<T>::Hamiltonian0(Potential& potential__, bool precompute_lapw__, bo
 
                 int nmt = type.mt_basis_size();
 
-                hmt_[ia] = mdarray<std::complex<T>, 2>({nmt, nmt}, mdarray_label("hmt"));
+                hmt_[ia] = mdarray<std::complex<T>, 3>({nmt, nmt, ctx_.num_mag_dims() + 1}, mdarray_label("hmt"));
 
                 /* compute muffin-tin Hamiltonian */
                 for (int j2 = 0; j2 < nmt; j2++) {
                     int lm2    = type.indexb(j2).lm;
                     int idxrf2 = type.indexb(j2).idxrf;
-                    for (int j1 = 0; j1 <= j2; j1++) {
+                    for (int j1 = 0; j1 < nmt; j1++) {
                         int lm1          = type.indexb(j1).lm;
                         int idxrf1       = type.indexb(j1).idxrf;
-                        hmt_[ia](j1, j2) = atom.radial_integrals_sum_L3<1>({1.0}, idxrf1, idxrf2,
+                        hmt_[ia](j1, j2, 0) = atom.radial_integrals_sum_L3<1>({1.0}, idxrf1, idxrf2,
                                                                         type.gaunt_coefs().gaunt_vector(lm1, lm2));
-                        hmt_[ia](j2, j1) = std::conj(hmt_[ia](j1, j2));
+                        //hmt_[ia](j2, j1) = std::conj(hmt_[ia](j1, j2));
                     }
                 }
                 if (pu == device_t::GPU) {

--- a/src/hamiltonian/hamiltonian.cpp
+++ b/src/hamiltonian/hamiltonian.cpp
@@ -66,9 +66,35 @@ Hamiltonian0<T>::Hamiltonian0(Potential& potential__, bool precompute_lapw__, bo
                     for (int j1 = 0; j1 < nmt; j1++) {
                         int lm1          = type.indexb(j1).lm;
                         int idxrf1       = type.indexb(j1).idxrf;
-                        hmt_[ia](j1, j2, 0) = atom.radial_integrals_sum_L3<1>({1.0}, idxrf1, idxrf2,
+                        switch (ctx_.num_mag_dims()) {
+                            case 3: {
+                                // Bx + i By
+                                hmt_[ia](j1, j2, 2) = atom.radial_integrals_sum_L3<4>({0, 0, 1, 1}, idxrf1, idxrf2,
                                                                         type.gaunt_coefs().gaunt_vector(lm1, lm2));
-                        //hmt_[ia](j2, j1) = std::conj(hmt_[ia](j1, j2));
+
+                                // Bx - i By
+                                hmt_[ia](j1, j2, 3) = atom.radial_integrals_sum_L3<4>({0, 0, 1, -1}, idxrf1, idxrf2,
+                                                                        type.gaunt_coefs().gaunt_vector(lm1, lm2));
+                            }
+                            case 1: {
+                                if (ctx_.cfg().control().use_second_variation()) {
+                                    hmt_[ia](j1, j2, 0) = atom.radial_integrals_sum_L3<2>({1, 0}, idxrf1, idxrf2,
+                                                                        type.gaunt_coefs().gaunt_vector(lm1, lm2));
+                                    hmt_[ia](j1, j2, 1) = atom.radial_integrals_sum_L3<2>({0, 1}, idxrf1, idxrf2,
+                                                                        type.gaunt_coefs().gaunt_vector(lm1, lm2));
+                                } else {
+                                    hmt_[ia](j1, j2, 0) = atom.radial_integrals_sum_L3<2>({1, 1}, idxrf1, idxrf2,
+                                                                        type.gaunt_coefs().gaunt_vector(lm1, lm2));
+                                    hmt_[ia](j1, j2, 1) = atom.radial_integrals_sum_L3<2>({1, -1}, idxrf1, idxrf2,
+                                                                        type.gaunt_coefs().gaunt_vector(lm1, lm2));
+                                }
+                                break;
+                            }
+                            case 0: {
+                                hmt_[ia](j1, j2, 0) = atom.radial_integrals_sum_L3<1>({1}, idxrf1, idxrf2,
+                                                                        type.gaunt_coefs().gaunt_vector(lm1, lm2));
+                            }
+                        }
                     }
                 }
                 if (pu == device_t::GPU) {
@@ -160,7 +186,7 @@ Hamiltonian0<T>::apply_bmt(wf::Wave_functions<T>& psi__, std::vector<wf::Wave_fu
                                                     atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));
                     }
                     if (ctx_.num_mag_dims() == 3) {
-                        std::array<std::complex<double>, 4> c({0, 0, 0, 0});
+                        std::array<int, 4> c({0, 0, 0, 0});
                         c[i + 1] = 1;
                         zm(xi1, xi2, i) = atom.template radial_integrals_sum_L3<4>(c, idxrf1, idxrf2,
                                                     atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));

--- a/src/hamiltonian/hamiltonian.cpp
+++ b/src/hamiltonian/hamiltonian.cpp
@@ -158,9 +158,6 @@ template <typename T>
 void
 Hamiltonian0<T>::apply_bmt(wf::Wave_functions<T>& psi__, std::vector<wf::Wave_functions<T>>& bpsi__) const
 {
-    //mdarray<std::complex<T>, 3> zm(
-    //        {unit_cell_.max_mt_basis_size(), unit_cell_.max_mt_basis_size(), ctx_.num_mag_dims()});
-
     for (auto it : psi__.spl_num_atoms()) {
         auto ia           = it.i;
         auto& atom        = unit_cell_.atom(ia);
@@ -168,34 +165,6 @@ Hamiltonian0<T>::apply_bmt(wf::Wave_functions<T>& psi__, std::vector<wf::Wave_fu
 
         auto const& zm = hmt_[ia];
 
-        //zm.zero();
-
-        ///* only upper triangular part of zm is computed because it is a hermitian matrix */
-        //#pragma omp parallel for default(shared)
-        //for (int xi2 = 0; xi2 < mt_basis_size; xi2++) {
-        //    int lm2    = atom.type().indexb(xi2).lm;
-        //    int idxrf2 = atom.type().indexb(xi2).idxrf;
-
-        //    for (int i = 0; i < ctx_.num_mag_dims(); i++) {
-        //        for (int xi1 = 0; xi1 <= xi2; xi1++) {
-        //            int lm1    = atom.type().indexb(xi1).lm;
-        //            int idxrf1 = atom.type().indexb(xi1).idxrf;
-
-        //            //zm(xi1, xi2, i) = atom.type().gaunt_coefs().sum_L3_gaunt(
-        //            //        lm1, lm2, atom.b_radial_integrals(idxrf1, idxrf2, i));
-        //            //if (ctx_.num_mag_dims() == 1) {
-        //            //    zm(xi1, xi2, i) = atom.template radial_integrals_sum_L3<2>({0, 1}, idxrf1, idxrf2,
-        //            //                                atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));
-        //            //}
-        //            //if (ctx_.num_mag_dims() == 3) {
-        //            //    std::array<int, 4> c({0, 0, 0, 0});
-        //            //    c[i + 1] = 1;
-        //            //    zm(xi1, xi2, i) = atom.template radial_integrals_sum_L3<4>(c, idxrf1, idxrf2,
-        //            //                                atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));
-        //            //}
-        //        }
-        //    }
-        //}
         /* compute bwf = B_z*|wf_j> */
         la::wrap(la::lib_t::blas)
                 .hemm('L', 'U', mt_basis_size, ctx_.num_fv_states(), &la::constant<std::complex<T>>::one(),
@@ -205,19 +174,6 @@ Hamiltonian0<T>::apply_bmt(wf::Wave_functions<T>& psi__, std::vector<wf::Wave_fu
 
         /* compute bwf = (B_x - iB_y)|wf_j> */
         if (bpsi__.size() == 3) {
-            ///* reuse first (z) component of zm matrix to store (B_x - iB_y) */
-            //for (int xi2 = 0; xi2 < mt_basis_size; xi2++) {
-            //    for (int xi1 = 0; xi1 <= xi2; xi1++) {
-            //        zm(xi1, xi2, 0) = zm(xi1, xi2, 1) - std::complex<T>(0, 1) * zm(xi1, xi2, 2);
-            //    }
-
-            //    /* remember: zm for x,y,z, components of magnetic field is hermitian and we computed
-            //     * only the upper triangular part */
-            //    for (int xi1 = xi2 + 1; xi1 < mt_basis_size; xi1++) {
-            //        zm(xi1, xi2, 0) = std::conj(zm(xi2, xi1, 1)) - std::complex<T>(0, 1) * std::conj(zm(xi2, xi1, 2));
-            //    }
-            //}
-
             la::wrap(la::lib_t::blas)
                     .gemm('N', 'N', mt_basis_size, ctx_.num_fv_states(), mt_basis_size,
                           &la::constant<std::complex<T>>::one(), zm.at(memory_t::host, 0, 0, 3), zm.ld(),

--- a/src/hamiltonian/hamiltonian.hpp
+++ b/src/hamiltonian/hamiltonian.hpp
@@ -147,7 +147,7 @@ class Hamiltonian0
      *  \f]
      */
     void
-    apply_hmt_to_apw(Atom const& atom__, spin_block_t sblock__, int ngv__, mdarray<std::complex<T>, 2>& alm__,
+    apply_hmt_to_apw(int ia__, spin_block_t sblock__, int ngv__, mdarray<std::complex<T>, 2> const& alm__,
                      mdarray<std::complex<T>, 2>& halm__) const;
 
     /// Add correction to LAPW overlap arising in the infinite-order relativistic approximation (IORA).

--- a/src/hamiltonian/hamiltonian.hpp
+++ b/src/hamiltonian/hamiltonian.hpp
@@ -147,7 +147,7 @@ class Hamiltonian0
      *  \f]
      */
     void
-    apply_hmt_to_apw(int ia__, spin_block_t sblock__, int ngv__, mdarray<std::complex<T>, 2> const& alm__,
+    apply_hmt_to_apw(int ia__, int j__, int ngv__, mdarray<std::complex<T>, 2> const& alm__,
                      mdarray<std::complex<T>, 2>& halm__) const;
 
     /// Add correction to LAPW overlap arising in the infinite-order relativistic approximation (IORA).

--- a/src/hamiltonian/hamiltonian.hpp
+++ b/src/hamiltonian/hamiltonian.hpp
@@ -80,7 +80,9 @@ class Hamiltonian0
     /// Q operator (non-local part of S-operator).
     std::unique_ptr<Q_operator<T>> q_op_;
 
-    std::vector<mdarray<std::complex<T>, 2>> hmt_;
+    /// Muffin-tin part of potential and magentic field.
+    /** This quantities are k-point independent and can be precomputed when H0 is created. */
+    std::vector<mdarray<std::complex<T>, 3>> hmt_;
 
     /* copy constructor is forbidden */
     Hamiltonian0(Hamiltonian0<T> const& src) = delete;

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -239,7 +239,7 @@ Hamiltonian_k<T>::get_h_o_diag_lapw() const
 
             kp_.alm_coeffs_loc().template generate<false>(atom, alm);
             if (what & 1) {
-                H0_.apply_hmt_to_apw(atom, spin_block_t::nm, kp_.num_gkvec_loc(), alm, halm);
+                H0_.apply_hmt_to_apw(ia, spin_block_t::nm, kp_.num_gkvec_loc(), alm, halm);
             }
 
             for (int xi = 0; xi < nmt; xi++) {
@@ -426,7 +426,7 @@ Hamiltonian_k<T>::set_fv_h_o(la::dmatrix<std::complex<T>>& h__, la::dmatrix<std:
 
                 /* can't copy alm to device now as it might be modified by the iora */
 
-                H0_.apply_hmt_to_apw(atom, spin_block_t::nm, kp_.num_gkvec_col(), alm_col_atom, halm_col_atom);
+                H0_.apply_hmt_to_apw(ia, spin_block_t::nm, kp_.num_gkvec_col(), alm_col_atom, halm_col_atom);
                 if (pu == device_t::GPU) {
                     halm_col_atom.copy_to(memory_t::device, acc::stream_id(tid));
                 }

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -21,7 +21,6 @@
 #include "core/profiler.hpp"
 #include "k_point/k_point.hpp"
 #include "lapw/generate_alm_block.hpp"
-#include <chrono>
 
 namespace sirius {
 
@@ -239,7 +238,7 @@ Hamiltonian_k<T>::get_h_o_diag_lapw() const
 
             kp_.alm_coeffs_loc().template generate<false>(atom, alm);
             if (what & 1) {
-                H0_.apply_hmt_to_apw(ia, spin_block_t::nm, kp_.num_gkvec_loc(), alm, halm);
+                H0_.apply_hmt_to_apw(ia, 0, kp_.num_gkvec_loc(), alm, halm);
             }
 
             for (int xi = 0; xi < nmt; xi++) {
@@ -426,7 +425,7 @@ Hamiltonian_k<T>::set_fv_h_o(la::dmatrix<std::complex<T>>& h__, la::dmatrix<std:
 
                 /* can't copy alm to device now as it might be modified by the iora */
 
-                H0_.apply_hmt_to_apw(ia, spin_block_t::nm, kp_.num_gkvec_col(), alm_col_atom, halm_col_atom);
+                H0_.apply_hmt_to_apw(ia, 0, kp_.num_gkvec_col(), alm_col_atom, halm_col_atom);
                 if (pu == device_t::GPU) {
                     halm_col_atom.copy_to(memory_t::device, acc::stream_id(tid));
                 }
@@ -530,7 +529,7 @@ Hamiltonian_k<T>::set_fv_h_o_apw_lo(Atom const& atom__, int ia__, mdarray<std::c
             int lm1    = type.indexb(j1).lm;
             int idxrf1 = type.indexb(j1).idxrf;
 
-            auto zsum = atom__.radial_integrals_sum_L3(spin_block_t::nm, idxrf, idxrf1,
+            auto zsum = atom__.radial_integrals_sum_L3<1>({1.0}, idxrf, idxrf1,
                                                        type.gaunt_coefs().gaunt_vector(lm1, lm));
 
             if (std::abs(zsum) > 1e-14) {
@@ -572,7 +571,7 @@ Hamiltonian_k<T>::set_fv_h_o_apw_lo(Atom const& atom__, int ia__, mdarray<std::c
             int lm1    = type.indexb(j1).lm;
             int idxrf1 = type.indexb(j1).idxrf;
 
-            auto zsum = atom__.radial_integrals_sum_L3(spin_block_t::nm, idxrf1, idxrf,
+            auto zsum = atom__.radial_integrals_sum_L3<1>({1.0}, idxrf1, idxrf,
                                                        type.gaunt_coefs().gaunt_vector(lm, lm1));
 
             if (std::abs(zsum) > 1e-14) {
@@ -623,8 +622,8 @@ Hamiltonian_k<T>::set_fv_h_o_lo_lo(la::dmatrix<std::complex<T>>& h__, la::dmatri
                 int lm1    = kp.lo_basis_descriptor_row(irow).lm;
                 int idxrf1 = kp.lo_basis_descriptor_row(irow).idxrf;
 
-                h__(kp.num_gkvec_row() + irow, kp.num_gkvec_col() + icol) += atom.radial_integrals_sum_L3(
-                        spin_block_t::nm, idxrf1, idxrf2, atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));
+                h__(kp.num_gkvec_row() + irow, kp.num_gkvec_col() + icol) += atom.template radial_integrals_sum_L3<1>(
+                        {1.0}, idxrf1, idxrf2, atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));
 
                 if (lm1 == lm2) {
                     int l      = kp.lo_basis_descriptor_row(irow).l;

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -524,13 +524,16 @@ Hamiltonian_k<T>::set_fv_h_o_apw_lo(Atom const& atom__, int ia__, mdarray<std::c
         int lm    = kp_.lo_basis_descriptor_col(icol).lm;
         int idxrf = kp_.lo_basis_descriptor_col(icol).idxrf;
         int order = kp_.lo_basis_descriptor_col(icol).order;
+        auto j0   = type.indexb().index_by_lm_order(lm, order);
         /* loop over apw components and update H */
         for (int j1 = 0; j1 < type.mt_aw_basis_size(); j1++) {
             int lm1    = type.indexb(j1).lm;
             int idxrf1 = type.indexb(j1).idxrf;
 
-            auto zsum = atom__.radial_integrals_sum_L3<1>({1}, idxrf, idxrf1,
-                                                       type.gaunt_coefs().gaunt_vector(lm1, lm));
+            //auto zsum = atom__.radial_integrals_sum_L3<1>({1}, idxrf, idxrf1,
+           //                                            type.gaunt_coefs().gaunt_vector(lm1, lm));
+            auto zsum = H0_.hmt(ia__)(j1, j0, 0);
+
 
             if (std::abs(zsum) > 1e-14) {
                 for (int igkloc = 0; igkloc < kp_.num_gkvec_row(); igkloc++) {

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -624,7 +624,7 @@ Hamiltonian_k<T>::set_fv_h_o_lo_lo(la::dmatrix<std::complex<T>>& h__, la::dmatri
 
                 int lm1    = kp.lo_basis_descriptor_row(irow).lm;
                 int idxrf1 = kp.lo_basis_descriptor_row(irow).idxrf;
-                int order1 = kp.lo_basis_descriptor_col(irow).order;
+                int order1 = kp.lo_basis_descriptor_row(irow).order;
 
                 auto j2 = atom.type().indexb().index_by_lm_order(lm2, order2);
                 auto j1 = atom.type().indexb().index_by_lm_order(lm1, order1);

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -569,13 +569,16 @@ Hamiltonian_k<T>::set_fv_h_o_apw_lo(Atom const& atom__, int ia__, mdarray<std::c
 
         std::fill(ztmp.begin(), ztmp.end(), 0);
 
+        auto j0   = type.indexb().index_by_lm_order(lm, order);
+
         /* loop over apw components */
         for (int j1 = 0; j1 < type.mt_aw_basis_size(); j1++) {
             int lm1    = type.indexb(j1).lm;
             int idxrf1 = type.indexb(j1).idxrf;
 
-            auto zsum = atom__.radial_integrals_sum_L3<1>({1}, idxrf1, idxrf,
-                                                       type.gaunt_coefs().gaunt_vector(lm, lm1));
+            //auto zsum = atom__.radial_integrals_sum_L3<1>({1}, idxrf1, idxrf,
+            auto zsum = H0_.hmt(ia__)(j0, j1, 0);
+                                      //                 type.gaunt_coefs().gaunt_vector(lm, lm1));
 
             if (std::abs(zsum) > 1e-14) {
                 for (int igkloc = 0; igkloc < kp_.num_gkvec_col(); igkloc++) {
@@ -617,16 +620,25 @@ Hamiltonian_k<T>::set_fv_h_o_lo_lo(la::dmatrix<std::complex<T>>& h__, la::dmatri
         int ia     = kp.lo_basis_descriptor_col(icol).ia;
         int lm2    = kp.lo_basis_descriptor_col(icol).lm;
         int idxrf2 = kp.lo_basis_descriptor_col(icol).idxrf;
+        int order2 = kp.lo_basis_descriptor_col(icol).order;
 
         for (int irow = 0; irow < kp.num_lo_row(); irow++) {
             /* lo-lo block is diagonal in atom index */
             if (ia == kp.lo_basis_descriptor_row(irow).ia) {
                 auto& atom = H0_.ctx().unit_cell().atom(ia);
+                
                 int lm1    = kp.lo_basis_descriptor_row(irow).lm;
                 int idxrf1 = kp.lo_basis_descriptor_row(irow).idxrf;
+                int order1 = kp.lo_basis_descriptor_col(irow).order;
 
-                h__(kp.num_gkvec_row() + irow, kp.num_gkvec_col() + icol) += atom.template radial_integrals_sum_L3<1>(
-                        {1}, idxrf1, idxrf2, atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));
+                auto j2   = atom.type().indexb().index_by_lm_order(lm2, order2);
+                auto j1   = atom.type().indexb().index_by_lm_order(lm1, order1);
+
+
+                h__(kp.num_gkvec_row() + irow, kp.num_gkvec_col() + icol) += H0_.hmt(ia)(j1, j2, 0);
+
+                    //atom.template radial_integrals_sum_L3<1>(
+                    //    {1}, idxrf1, idxrf2, atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));
 
                 if (lm1 == lm2) {
                     int l      = kp.lo_basis_descriptor_row(irow).l;

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -529,7 +529,7 @@ Hamiltonian_k<T>::set_fv_h_o_apw_lo(Atom const& atom__, int ia__, mdarray<std::c
             int lm1    = type.indexb(j1).lm;
             int idxrf1 = type.indexb(j1).idxrf;
 
-            auto zsum = atom__.radial_integrals_sum_L3<1>({1.0}, idxrf, idxrf1,
+            auto zsum = atom__.radial_integrals_sum_L3<1>({1}, idxrf, idxrf1,
                                                        type.gaunt_coefs().gaunt_vector(lm1, lm));
 
             if (std::abs(zsum) > 1e-14) {
@@ -571,7 +571,7 @@ Hamiltonian_k<T>::set_fv_h_o_apw_lo(Atom const& atom__, int ia__, mdarray<std::c
             int lm1    = type.indexb(j1).lm;
             int idxrf1 = type.indexb(j1).idxrf;
 
-            auto zsum = atom__.radial_integrals_sum_L3<1>({1.0}, idxrf1, idxrf,
+            auto zsum = atom__.radial_integrals_sum_L3<1>({1}, idxrf1, idxrf,
                                                        type.gaunt_coefs().gaunt_vector(lm, lm1));
 
             if (std::abs(zsum) > 1e-14) {
@@ -623,7 +623,7 @@ Hamiltonian_k<T>::set_fv_h_o_lo_lo(la::dmatrix<std::complex<T>>& h__, la::dmatri
                 int idxrf1 = kp.lo_basis_descriptor_row(irow).idxrf;
 
                 h__(kp.num_gkvec_row() + irow, kp.num_gkvec_col() + icol) += atom.template radial_integrals_sum_L3<1>(
-                        {1.0}, idxrf1, idxrf2, atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));
+                        {1}, idxrf1, idxrf2, atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));
 
                 if (lm1 == lm2) {
                     int l      = kp.lo_basis_descriptor_row(irow).l;

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -273,7 +273,7 @@ Hamiltonian_k<T>::get_h_o_diag_lapw() const
         for (int ilo = 0; ilo < type.mt_lo_basis_size(); ilo++) {
             int xi_lo = type.mt_aw_basis_size() + ilo;
             if (what & 1) {
-                h_diag[kp_.num_gkvec_loc() + nlo + ilo] = hmt(xi_lo, xi_lo).real();
+                h_diag[kp_.num_gkvec_loc() + nlo + ilo] = hmt(xi_lo, xi_lo, 0).real();
             }
             if (what & 2) {
                 o_diag[kp_.num_gkvec_loc() + nlo + ilo] = 1;
@@ -859,7 +859,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
 
             auto& hmt = this->H0_.hmt(ia);
 
-            la::wrap(la).gemm('N', 'N', naw, b__.size(), nlo, &la::constant<Tc>::one(), hmt.at(mem, 0, naw), hmt.ld(),
+            la::wrap(la).gemm('N', 'N', naw, b__.size(), nlo, &la::constant<Tc>::one(), hmt.at(mem, 0, naw, 0), hmt.ld(),
                               phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())), phi__.ld(),
                               &la::constant<Tc>::zero(),
                               h_apw_lo__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(0)), h_apw_lo__.ld(),
@@ -917,7 +917,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
 
             auto& hmt = H0_.hmt(ia);
 
-            la::wrap(la).gemm('N', 'N', nlo, b__.size(), nlo, &la::constant<Tc>::one(), hmt.at(mem, naw, naw), hmt.ld(),
+            la::wrap(la).gemm('N', 'N', nlo, b__.size(), nlo, &la::constant<Tc>::one(), hmt.at(mem, naw, naw, 0), hmt.ld(),
                               phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())), phi__.ld(),
                               &la::constant<Tc>::one(),
                               hphi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())), hphi__.ld(),
@@ -999,7 +999,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
 
             // TODO: add stream_id
 
-            la::wrap(la).gemm('N', 'N', nlo, b__.size(), naw, &la::constant<Tc>::one(), hmt.at(mem, naw, 0), hmt.ld(),
+            la::wrap(la).gemm('N', 'N', nlo, b__.size(), naw, &la::constant<Tc>::one(), hmt.at(mem, naw, 0, 0), hmt.ld(),
                               alm_phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(0)), alm_phi__.ld(),
                               &la::constant<Tc>::one(),
                               hphi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())), hphi__.ld(),

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -865,9 +865,9 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
 
             auto& hmt = this->H0_.hmt(ia);
 
-            la::wrap(la).gemm('N', 'N', naw, b__.size(), nlo, &la::constant<Tc>::one(), hmt.at(mem, 0, naw, 0), hmt.ld(),
-                              phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())), phi__.ld(),
-                              &la::constant<Tc>::zero(),
+            la::wrap(la).gemm('N', 'N', naw, b__.size(), nlo, &la::constant<Tc>::one(), hmt.at(mem, 0, naw, 0),
+                              hmt.ld(), phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())),
+                              phi__.ld(), &la::constant<Tc>::zero(),
                               h_apw_lo__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(0)), h_apw_lo__.ld(),
                               acc::stream_id(tid));
         }
@@ -923,9 +923,9 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
 
             auto& hmt = H0_.hmt(ia);
 
-            la::wrap(la).gemm('N', 'N', nlo, b__.size(), nlo, &la::constant<Tc>::one(), hmt.at(mem, naw, naw, 0), hmt.ld(),
-                              phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())), phi__.ld(),
-                              &la::constant<Tc>::one(),
+            la::wrap(la).gemm('N', 'N', nlo, b__.size(), nlo, &la::constant<Tc>::one(), hmt.at(mem, naw, naw, 0),
+                              hmt.ld(), phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())),
+                              phi__.ld(), &la::constant<Tc>::one(),
                               hphi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())), hphi__.ld(),
                               acc::stream_id(tid));
         }
@@ -1005,9 +1005,9 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
 
             // TODO: add stream_id
 
-            la::wrap(la).gemm('N', 'N', nlo, b__.size(), naw, &la::constant<Tc>::one(), hmt.at(mem, naw, 0, 0), hmt.ld(),
-                              alm_phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(0)), alm_phi__.ld(),
-                              &la::constant<Tc>::one(),
+            la::wrap(la).gemm('N', 'N', nlo, b__.size(), naw, &la::constant<Tc>::one(), hmt.at(mem, naw, 0, 0),
+                              hmt.ld(), alm_phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(0)),
+                              alm_phi__.ld(), &la::constant<Tc>::one(),
                               hphi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())), hphi__.ld(),
                               acc::stream_id(tid));
         }

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -530,10 +530,7 @@ Hamiltonian_k<T>::set_fv_h_o_apw_lo(Atom const& atom__, int ia__, mdarray<std::c
             int lm1    = type.indexb(j1).lm;
             int idxrf1 = type.indexb(j1).idxrf;
 
-            //auto zsum = atom__.radial_integrals_sum_L3<1>({1}, idxrf, idxrf1,
-           //                                            type.gaunt_coefs().gaunt_vector(lm1, lm));
             auto zsum = H0_.hmt(ia__)(j1, j0, 0);
-
 
             if (std::abs(zsum) > 1e-14) {
                 for (int igkloc = 0; igkloc < kp_.num_gkvec_row(); igkloc++) {
@@ -569,16 +566,14 @@ Hamiltonian_k<T>::set_fv_h_o_apw_lo(Atom const& atom__, int ia__, mdarray<std::c
 
         std::fill(ztmp.begin(), ztmp.end(), 0);
 
-        auto j0   = type.indexb().index_by_lm_order(lm, order);
+        auto j0 = type.indexb().index_by_lm_order(lm, order);
 
         /* loop over apw components */
         for (int j1 = 0; j1 < type.mt_aw_basis_size(); j1++) {
             int lm1    = type.indexb(j1).lm;
             int idxrf1 = type.indexb(j1).idxrf;
 
-            //auto zsum = atom__.radial_integrals_sum_L3<1>({1}, idxrf1, idxrf,
             auto zsum = H0_.hmt(ia__)(j0, j1, 0);
-                                      //                 type.gaunt_coefs().gaunt_vector(lm, lm1));
 
             if (std::abs(zsum) > 1e-14) {
                 for (int igkloc = 0; igkloc < kp_.num_gkvec_col(); igkloc++) {
@@ -626,19 +621,15 @@ Hamiltonian_k<T>::set_fv_h_o_lo_lo(la::dmatrix<std::complex<T>>& h__, la::dmatri
             /* lo-lo block is diagonal in atom index */
             if (ia == kp.lo_basis_descriptor_row(irow).ia) {
                 auto& atom = H0_.ctx().unit_cell().atom(ia);
-                
+
                 int lm1    = kp.lo_basis_descriptor_row(irow).lm;
                 int idxrf1 = kp.lo_basis_descriptor_row(irow).idxrf;
                 int order1 = kp.lo_basis_descriptor_col(irow).order;
 
-                auto j2   = atom.type().indexb().index_by_lm_order(lm2, order2);
-                auto j1   = atom.type().indexb().index_by_lm_order(lm1, order1);
-
+                auto j2 = atom.type().indexb().index_by_lm_order(lm2, order2);
+                auto j1 = atom.type().indexb().index_by_lm_order(lm1, order1);
 
                 h__(kp.num_gkvec_row() + irow, kp.num_gkvec_col() + icol) += H0_.hmt(ia)(j1, j2, 0);
-
-                    //atom.template radial_integrals_sum_L3<1>(
-                    //    {1}, idxrf1, idxrf2, atom.type().gaunt_coefs().gaunt_vector(lm1, lm2));
 
                 if (lm1 == lm2) {
                     int l      = kp.lo_basis_descriptor_row(irow).l;

--- a/src/unit_cell/atom.hpp
+++ b/src/unit_cell/atom.hpp
@@ -455,7 +455,7 @@ class Atom
      */
     template <int N>
     inline auto
-    radial_integrals_sum_L3(std::array<std::complex<double>, N> c__, int idxrf1__, int idxrf2__,
+    radial_integrals_sum_L3(std::array<int, N> c__, int idxrf1__, int idxrf2__,
                             std::vector<gaunt_L3<std::complex<double>>> const& gnt__) const
     {
         static_assert(N == 1 || N == 2 || N == 4, "wrong size of coefficients array");
@@ -466,17 +466,17 @@ class Atom
         };
         auto f = [h_int, b_int, &c__](auto const& gaunt_l3) {
             if (N == 1) {
-                return c__[0] * h_int(gaunt_l3.lm3) * gaunt_l3.coef;
+                return h_int(gaunt_l3.lm3) * gaunt_l3.coef;
             }
             if (N == 2) {
-                return (c__[0] * h_int(gaunt_l3.lm3) +
+                return (h_int(gaunt_l3.lm3) +
                         c__[1] * b_int(gaunt_l3.lm3, 0)) * gaunt_l3.coef;
             }
             if (N == 4) {
-                return (c__[0] *  h_int(gaunt_l3.lm3) +
-                        c__[1] *  b_int(gaunt_l3.lm3, 0) +
-                        c__[2] *  b_int(gaunt_l3.lm3, 1) +
-                        c__[3] *  b_int(gaunt_l3.lm3, 2)) * gaunt_l3.coef;
+                return (h_int(gaunt_l3.lm3) +
+                        c__[1] * b_int(gaunt_l3.lm3, 0) +
+                        std::complex<double>(c__[2], 0) *  b_int(gaunt_l3.lm3, 1) +
+                        std::complex<double>(0, c__[3]) *  b_int(gaunt_l3.lm3, 2)) * gaunt_l3.coef;
             }
         };
 

--- a/src/unit_cell/atom.hpp
+++ b/src/unit_cell/atom.hpp
@@ -444,68 +444,89 @@ class Atom
         return &b_radial_integrals_(0, idxrf1, idxrf2, x);
     }
 
-    /** Compute the following kinds of sums for different spin-blocks of the Hamiltonian:
+    /** Compute the following kinds of sums for different components of the Hamiltonian:
      *  \f[
      *      \sum_{L_3} \langle Y_{L_1} u_{\ell_1 \nu_1} | R_{L_3} h_{L_3} | Y_{L_2} u_{\ell_2 \nu_2} \rangle =
      *      \sum_{L_3} \langle u_{\ell_1 \nu_1} | h_{L_3} | u_{\ell_2 \nu_2} \rangle
      *                 \langle Y_{L_1} | R_{L_3} | Y_{L_2} \rangle
      *  \f]
+     *
+     *  For the non-collinear case, up-dn block corresponds to Bx - i By and dn-up block corresponds to Bx + i By
      */
+    template <int N>
     inline auto
-    radial_integrals_sum_L3(spin_block_t sblock, int idxrf1__, int idxrf2__,
+    radial_integrals_sum_L3(std::array<std::complex<double>, N> c__, int idxrf1__, int idxrf2__,
                             std::vector<gaunt_L3<std::complex<double>>> const& gnt__) const
     {
+        static_assert(N == 1 || N == 2 || N == 3, "wrong size of coefficients array");
+
         auto h_int = [this, idxrf1__, idxrf2__](int lm3) { return this->h_radial_integrals_(lm3, idxrf1__, idxrf2__); };
         auto b_int = [this, idxrf1__, idxrf2__](int lm3, int i) {
             return this->b_radial_integrals_(lm3, idxrf1__, idxrf2__, i);
         };
-        /* just the Hamiltonian */
-        auto nm = [h_int](const auto& gaunt_l3) { return gaunt_l3.coef * h_int(gaunt_l3.lm3); };
-        /* h + Bz */
-        auto uu = [h_int, b_int](const auto& gaunt_l3) {
-            return gaunt_l3.coef * (h_int(gaunt_l3.lm3) + b_int(gaunt_l3.lm3, 0));
-        };
-        /* h - Bz */
-        auto dd = [h_int, b_int](const auto& gaunt_l3) {
-            return gaunt_l3.coef * (h_int(gaunt_l3.lm3) - b_int(gaunt_l3.lm3, 0));
-        };
-        /* Bx - i By */
-        auto ud = [b_int](const auto& gaunt_l3) {
-            return gaunt_l3.coef * std::complex<double>(b_int(gaunt_l3.lm3, 1), -b_int(gaunt_l3.lm3, 2));
-        };
-        /* Bx + i By */
-        auto du = [b_int](const auto& gaunt_l3) {
-            return gaunt_l3.coef * std::complex<double>(b_int(gaunt_l3.lm3, 1), b_int(gaunt_l3.lm3, 2));
+        auto f = [h_int, b_int, &c__](auto const& gaunt_l3) {
+            if (N == 1) {
+                return c__[0] * gaunt_l3.coef * h_int(gaunt_l3.lm3);
+            }
+            if (N == 2) {
+                return c__[0] * gaunt_l3.coef * h_int(gaunt_l3.lm3) + c__[1] * gaunt_l3.coef * b_int(gaunt_l3.lm3, 0);
+            }
+            if (N == 4) {
+                return c__[0] * gaunt_l3.coef * h_int(gaunt_l3.lm3) + c__[1] * gaunt_l3.coef * b_int(gaunt_l3.lm3, 0) +
+                    c__[2] * gaunt_l3.coef * b_int(gaunt_l3.lm3, 1) + c__[3] * gaunt_l3.coef * b_int(gaunt_l3.lm3, 2);
+            }
         };
 
-        std::complex<double> res{0};
-        switch (sblock) {
-            case spin_block_t::nm: {
-                res = std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, nm);
-                break;
-            }
-            case spin_block_t::uu: {
-                res = std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, uu);
-                break;
-            }
-            case spin_block_t::dd: {
-                res = std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, dd);
-                break;
-            }
-            case spin_block_t::ud: {
-                res = std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, ud);
-                break;
-            }
-            case spin_block_t::du: {
-                res = std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, du);
-                break;
-            }
-            default: {
-                RTE_THROW("unknown value for spin_block_t");
-            }
-        }
 
-        return res;
+        ///* just the Hamiltonian */
+        //auto nm = [h_int](const auto& gaunt_l3) { return gaunt_l3.coef * h_int(gaunt_l3.lm3); };
+        ///* h + Bz */
+        //auto uu = [h_int, b_int](const auto& gaunt_l3) {
+        //    return gaunt_l3.coef * (h_int(gaunt_l3.lm3) + b_int(gaunt_l3.lm3, 0));
+        //};
+        ///* h - Bz */
+        //auto dd = [h_int, b_int](const auto& gaunt_l3) {
+        //    return gaunt_l3.coef * (h_int(gaunt_l3.lm3) - b_int(gaunt_l3.lm3, 0));
+        //};
+        ///* Bx - i By */
+        //auto ud = [b_int](const auto& gaunt_l3) {
+        //    return gaunt_l3.coef * std::complex<double>(b_int(gaunt_l3.lm3, 1), -b_int(gaunt_l3.lm3, 2));
+        //};
+        ///* Bx + i By */
+        //auto du = [b_int](const auto& gaunt_l3) {
+        //    return gaunt_l3.coef * std::complex<double>(b_int(gaunt_l3.lm3, 1), b_int(gaunt_l3.lm3, 2));
+        //};
+
+        //std::complex<double> res{0};
+        return std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, f);
+
+        //switch (sblock) {
+        //    case spin_block_t::nm: {
+        //        res = std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, nm);
+        //        break;
+        //    }
+        //    case spin_block_t::uu: {
+        //        res = std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, uu);
+        //        break;
+        //    }
+        //    case spin_block_t::dd: {
+        //        res = std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, dd);
+        //        break;
+        //    }
+        //    case spin_block_t::ud: {
+        //        res = std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, ud);
+        //        break;
+        //    }
+        //    case spin_block_t::du: {
+        //        res = std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, du);
+        //        break;
+        //    }
+        //    default: {
+        //        RTE_THROW("unknown value for spin_block_t");
+        //    }
+        //}
+
+        //return res;
     }
 
     inline int

--- a/src/unit_cell/atom.hpp
+++ b/src/unit_cell/atom.hpp
@@ -458,7 +458,7 @@ class Atom
     radial_integrals_sum_L3(std::array<std::complex<double>, N> c__, int idxrf1__, int idxrf2__,
                             std::vector<gaunt_L3<std::complex<double>>> const& gnt__) const
     {
-        static_assert(N == 1 || N == 2 || N == 3, "wrong size of coefficients array");
+        static_assert(N == 1 || N == 2 || N == 4, "wrong size of coefficients array");
 
         auto h_int = [this, idxrf1__, idxrf2__](int lm3) { return this->h_radial_integrals_(lm3, idxrf1__, idxrf2__); };
         auto b_int = [this, idxrf1__, idxrf2__](int lm3, int i) {
@@ -466,67 +466,21 @@ class Atom
         };
         auto f = [h_int, b_int, &c__](auto const& gaunt_l3) {
             if (N == 1) {
-                return c__[0] * gaunt_l3.coef * h_int(gaunt_l3.lm3);
+                return c__[0] * h_int(gaunt_l3.lm3) * gaunt_l3.coef;
             }
             if (N == 2) {
-                return c__[0] * gaunt_l3.coef * h_int(gaunt_l3.lm3) + c__[1] * gaunt_l3.coef * b_int(gaunt_l3.lm3, 0);
+                return (c__[0] * h_int(gaunt_l3.lm3) +
+                        c__[1] * b_int(gaunt_l3.lm3, 0)) * gaunt_l3.coef;
             }
             if (N == 4) {
-                return c__[0] * gaunt_l3.coef * h_int(gaunt_l3.lm3) + c__[1] * gaunt_l3.coef * b_int(gaunt_l3.lm3, 0) +
-                    c__[2] * gaunt_l3.coef * b_int(gaunt_l3.lm3, 1) + c__[3] * gaunt_l3.coef * b_int(gaunt_l3.lm3, 2);
+                return (c__[0] *  h_int(gaunt_l3.lm3) +
+                        c__[1] *  b_int(gaunt_l3.lm3, 0) +
+                        c__[2] *  b_int(gaunt_l3.lm3, 1) +
+                        c__[3] *  b_int(gaunt_l3.lm3, 2)) * gaunt_l3.coef;
             }
         };
 
-
-        ///* just the Hamiltonian */
-        //auto nm = [h_int](const auto& gaunt_l3) { return gaunt_l3.coef * h_int(gaunt_l3.lm3); };
-        ///* h + Bz */
-        //auto uu = [h_int, b_int](const auto& gaunt_l3) {
-        //    return gaunt_l3.coef * (h_int(gaunt_l3.lm3) + b_int(gaunt_l3.lm3, 0));
-        //};
-        ///* h - Bz */
-        //auto dd = [h_int, b_int](const auto& gaunt_l3) {
-        //    return gaunt_l3.coef * (h_int(gaunt_l3.lm3) - b_int(gaunt_l3.lm3, 0));
-        //};
-        ///* Bx - i By */
-        //auto ud = [b_int](const auto& gaunt_l3) {
-        //    return gaunt_l3.coef * std::complex<double>(b_int(gaunt_l3.lm3, 1), -b_int(gaunt_l3.lm3, 2));
-        //};
-        ///* Bx + i By */
-        //auto du = [b_int](const auto& gaunt_l3) {
-        //    return gaunt_l3.coef * std::complex<double>(b_int(gaunt_l3.lm3, 1), b_int(gaunt_l3.lm3, 2));
-        //};
-
-        //std::complex<double> res{0};
         return std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, f);
-
-        //switch (sblock) {
-        //    case spin_block_t::nm: {
-        //        res = std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, nm);
-        //        break;
-        //    }
-        //    case spin_block_t::uu: {
-        //        res = std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, uu);
-        //        break;
-        //    }
-        //    case spin_block_t::dd: {
-        //        res = std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, dd);
-        //        break;
-        //    }
-        //    case spin_block_t::ud: {
-        //        res = std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, ud);
-        //        break;
-        //    }
-        //    case spin_block_t::du: {
-        //        res = std::transform_reduce(gnt__.begin(), gnt__.end(), std::complex<double>{0}, std::plus{}, du);
-        //        break;
-        //    }
-        //    default: {
-        //        RTE_THROW("unknown value for spin_block_t");
-        //    }
-        //}
-
-        //return res;
     }
 
     inline int

--- a/src/unit_cell/atom.hpp
+++ b/src/unit_cell/atom.hpp
@@ -469,14 +469,13 @@ class Atom
                 return h_int(gaunt_l3.lm3) * gaunt_l3.coef;
             }
             if (N == 2) {
-                return (c__[0] * h_int(gaunt_l3.lm3) +
-                        c__[1] * b_int(gaunt_l3.lm3, 0)) * gaunt_l3.coef;
+                return (c__[0] * h_int(gaunt_l3.lm3) + c__[1] * b_int(gaunt_l3.lm3, 0)) * gaunt_l3.coef;
             }
             if (N == 4) {
-                return (c__[0] * h_int(gaunt_l3.lm3) +
-                        c__[1] * b_int(gaunt_l3.lm3, 0) +
-                        std::complex<double>(c__[2], 0) *  b_int(gaunt_l3.lm3, 1) +
-                        std::complex<double>(0, c__[3]) *  b_int(gaunt_l3.lm3, 2)) * gaunt_l3.coef;
+                return (c__[0] * h_int(gaunt_l3.lm3) + c__[1] * b_int(gaunt_l3.lm3, 0) +
+                        std::complex<double>(c__[2], 0) * b_int(gaunt_l3.lm3, 1) +
+                        std::complex<double>(0, c__[3]) * b_int(gaunt_l3.lm3, 2)) *
+                       gaunt_l3.coef;
             }
         };
 

--- a/src/unit_cell/atom.hpp
+++ b/src/unit_cell/atom.hpp
@@ -469,11 +469,11 @@ class Atom
                 return h_int(gaunt_l3.lm3) * gaunt_l3.coef;
             }
             if (N == 2) {
-                return (h_int(gaunt_l3.lm3) +
+                return (c__[0] * h_int(gaunt_l3.lm3) +
                         c__[1] * b_int(gaunt_l3.lm3, 0)) * gaunt_l3.coef;
             }
             if (N == 4) {
-                return (h_int(gaunt_l3.lm3) +
+                return (c__[0] * h_int(gaunt_l3.lm3) +
                         c__[1] * b_int(gaunt_l3.lm3, 0) +
                         std::complex<double>(c__[2], 0) *  b_int(gaunt_l3.lm3, 1) +
                         std::complex<double>(0, c__[3]) *  b_int(gaunt_l3.lm3, 2)) * gaunt_l3.coef;

--- a/verification/test30/sirius.json
+++ b/verification/test30/sirius.json
@@ -20,7 +20,6 @@
         "rmt_max": 2.2,
         "spglib_tolerance": 0.00009999999747378752,
         "std_evp_solver_name": "lapack",
-        "use_second_variation": true,
         "verbosity": 2,
         "verification": 0
     },


### PR DESCRIPTION
Muffin-tin Hamiltonian and potential matrix elements are k-point independent and can be precomputed once when H0 is created. 