### PR TITLE
fix cmake for eigen3 v5.0

### DIFF
--- a/apps/mini_app/CMakeLists.txt
+++ b/apps/mini_app/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(SIRIUS_USE_VCSQNM)
-  find_package (Eigen3 3.3 REQUIRED NO_MODULE)
+  find_package (Eigen3 REQUIRED NO_MODULE)
 endif()
 add_executable(sirius.scf sirius.scf.cpp)
 target_link_libraries(sirius.scf PRIVATE sirius_cxx)

--- a/apps/unit_tests/multi_cg/CMakeLists.txt
+++ b/apps/unit_tests/multi_cg/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package (Eigen3 3.3 REQUIRED NO_MODULE)
+find_package (Eigen3 REQUIRED NO_MODULE)
  
 add_executable (test_multi_cg test_multi_cg.cpp)
 target_link_libraries (test_multi_cg Eigen3::Eigen sirius_cxx)


### PR DESCRIPTION
Eigen3 has been released in v5.0.0 recently, remove the version constraint from cmake

pre-requisite for beverin uenv which uses latest spack-repo