### PR TITLE
Added # to the printf statement to accomade CP2K

### DIFF
--- a/src/sirius.hpp
+++ b/src/sirius.hpp
@@ -91,10 +91,10 @@ initialize(bool call_mpi_init__ = true)
 #endif
 
     if (mpi::Communicator::world().rank() == 0) {
-        std::printf("SIRIUS %i.%i.%i, git hash: %s\n", major_version(), minor_version(), revision(),
+        std::printf("# SIRIUS %i.%i.%i, git hash: %s\n", major_version(), minor_version(), revision(),
                     git_hash().c_str());
 #if !defined(NDEBUG)
-        std::printf("Warning! Compiled in 'debug' mode with assert statements enabled!\n");
+        std::printf("# Warning! Compiled in 'debug' mode with assert statements enabled!\n");
 #endif
     }
     /* get number of ranks per node during the global call to sirius::initialize() */


### PR DESCRIPTION
CP2K echoes input files using the standard output which conflicts with SIRIUS initialization message printed in the standard output. Added a # in front of the message so that the message is considered as a comment by CP2K.

https://github.com/cp2k/cp2k/issues/4564#issuecomment-3586844886

We may need a minor revision. 