### PR TITLE
cleanup includes in memory.hpp

### DIFF
--- a/src/core/memory.hpp
+++ b/src/core/memory.hpp
@@ -14,7 +14,6 @@
 #ifndef __MEMORY_HPP__
 #define __MEMORY_HPP__
 
-#include <list>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -25,6 +24,7 @@
 #include <complex>
 #include <cassert>
 #include <stdexcept>
+#include <cstdint>
 
 #ifdef SIRIUS_USE_MEMORY_POOL
 #include <umpire/ResourceManager.hpp>


### PR DESCRIPTION
fyi @sgwzq, thanks for pointing this out. Compilation worked for me with gcc 15.2.1, but you're correct that `cstdint` should be included in `memory.hpp`.
