### PR TITLE
Fix ROCm<6 compilation and unify device UUID formatting

### DIFF
--- a/src/core/acc/acc.hpp
+++ b/src/core/acc/acc.hpp
@@ -336,25 +336,21 @@ get_uuid(int device_id__)
 {
 #if defined(SIRIUS_CUDA)
     cudaDeviceProp devprop;
+    CALL_DEVICE_API(GetDeviceProperties, (&devprop, device_id__));
+    auto const& uuid_bytes = devprop.uuid.bytes;
 #elif defined(SIRIUS_ROCM)
-    hipDeviceProp_t devprop;
+    hipUUID uuid;
+    CALL_DEVICE_API(DeviceGetUuid, (&uuid, device_id__));
+    auto const& uuid_bytes = uuid.bytes;
 #endif
 
-    CALL_DEVICE_API(GetDeviceProperties, (&devprop, device_id__));
-
     std::stringstream s;
-#if defined(SIRIUS_CUDA)
     for (int i = 0; i < 16; i++) {
         if (i == 4 || i == 6 || i == 8 || i == 10) {
             s << '-';
         }
-        s << std::hex << std::setw(2) << std::setfill('0') << (int)devprop.uuid.bytes[i];
+        s << std::hex << std::setw(2) << std::setfill('0') << (int)uuid_bytes[i];
     }
-#elif defined(SIRIUS_ROCM)
-    for (int i = 0; i < 16; ++i) {
-        s << std::hex << devprop.uuid.bytes[i];
-    }
-#endif
     return s.str();
 }
 

--- a/src/core/acc/acc.hpp
+++ b/src/core/acc/acc.hpp
@@ -345,12 +345,14 @@ get_uuid(int device_id__)
 #endif
 
     std::stringstream s;
+#if defined(SIRIUS_CUDA) || defined(SIRIUS_ROCM)
     for (int i = 0; i < 16; i++) {
         if (i == 4 || i == 6 || i == 8 || i == 10) {
             s << '-';
         }
         s << std::hex << std::setw(2) << std::setfill('0') << (int)uuid_bytes[i];
     }
+#endif
     return s.str();
 }
 


### PR DESCRIPTION
`hipDeviceProp_t.uuid` is defined on ROCm 6.0 and later, which causes compilation to fail on older ROCm versions (e.g., ROCm 5.x). This PR addresses this backward compatibility issue and fixes a string formatting bug in the `get_uuid()` function.

- Switched to using `hipUUID` and the `DeviceGetUuid` API directly for the ROCm backend, safely resolving the build issue for ROCm < 6.0.
- Unified the string formatting `for` loop. By abstracting the byte array into a constant reference (`auto const& uuid_bytes`), both CUDA and ROCm backends now share the exact same logic.