### PR TITLE
Fix to IBS force.cpp

### DIFF
--- a/src/geometry/force.cpp
+++ b/src/geometry/force.cpp
@@ -846,6 +846,10 @@ Force::add_ibs_force(K_point<double>* kp__, Hamiltonian_k<double>& Hk__, mdarray
         }
 
         for (int x = 0; x < 3; x++) {
+
+            o1.zero();
+            h1.zero();
+            
             for (int igk_col = 0; igk_col < kp__->num_gkvec_col(); igk_col++) { // loop over columns
                 auto gvec_col = kp__->gkvec_col().gvec(gvec_index_t::local(igk_col));
                 for (int igk_row = 0; igk_row < kp__->num_gkvec_row(); igk_row++) { // loop over rows


### PR DESCRIPTION
For LAPW+lo IBS is giving NaN in the case there in some grid configurations (if more than one process is assigned to the k-point group). See the following output of exciting with SIRIUS:
<img width="1135" height="478" alt="image" src="https://github.com/user-attachments/assets/e5156022-deaa-4abe-804f-e868ae64372b" />
This patch solves it by initializing h1 and o1 (the derivatives) to 0 inside the Cartesian axis loop. The result looks like:
<img width="1135" height="478" alt="Screenshot from 2026-04-09 14-29-07" src="https://github.com/user-attachments/assets/a8445de7-dee7-41d1-985c-c53b1a6023cd" />