### PR TITLE
Fix typo

### DIFF
--- a/cmake/sirius_cxxConfig.cmake.in
+++ b/cmake/sirius_cxxConfig.cmake.in
@@ -56,7 +56,7 @@ if(NOT TARGET sirius::sirius_cxx)
   endif()
 
   if(@SIRIUS_USE_DFTD4@)
-    set(SIRIUS_USE_DFTD3 @SIRIUS_USE_DFTD4@)
+    set(SIRIUS_USE_DFTD4 @SIRIUS_USE_DFTD4@)
     find_dependency(DFTD4 ${mode})
   endif()
 

--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -7555,7 +7555,7 @@ sirius_set_dftd4_correction(void* const* handler__, char const* method__, char c
     call_sirius(
             [&]() {
                 auto& sim_ctx = get_sim_ctx(handler__);
-                sim_ctx.cfg().dftd3().method(method__);
+                sim_ctx.cfg().dftd4().method(method__);
                 if (damping__ != nullptr) {
                     sim_ctx.cfg().dftd4().damping(damping__);
                 }


### PR DESCRIPTION
There are two places writing "dftd3" in dftd4 section (?)