### PR TITLE
[Enhancement] fix minor performance issues to run the benchmarks

### DIFF
--- a/apps/mini_app/sirius.scf.cpp
+++ b/apps/mini_app/sirius.scf.cpp
@@ -677,8 +677,8 @@ main(int argn, char** argv)
 
     if (my_rank == 0) {
         bool flatten{true};
-        auto timing_result = flatten ? global_rtgraph_timer.process().flatten(1).sort_nodes() :
-                                       global_rtgraph_timer.process();
+        auto timing_result =
+                flatten ? global_rtgraph_timer.process().flatten(1).sort_nodes() : global_rtgraph_timer.process();
         std::cout << timing_result.print({rt_graph::Stat::Count, rt_graph::Stat::Total, rt_graph::Stat::Percentage,
                                           rt_graph::Stat::SelfPercentage, rt_graph::Stat::Median, rt_graph::Stat::Min,
                                           rt_graph::Stat::Max});

--- a/apps/mini_app/sirius.scf.cpp
+++ b/apps/mini_app/sirius.scf.cpp
@@ -676,8 +676,9 @@ main(int argn, char** argv)
     sirius::finalize(1);
 
     if (my_rank == 0) {
-        auto timing_result = global_rtgraph_timer.process().flatten(1).sort_nodes();
-        //auto timing_result = global_rtgraph_timer.process();
+        bool flatten{true};
+        auto timing_result = flatten ? global_rtgraph_timer.process().flatten(1).sort_nodes() :
+                                       global_rtgraph_timer.process();
         std::cout << timing_result.print({rt_graph::Stat::Count, rt_graph::Stat::Total, rt_graph::Stat::Percentage,
                                           rt_graph::Stat::SelfPercentage, rt_graph::Stat::Median, rt_graph::Stat::Min,
                                           rt_graph::Stat::Max});

--- a/apps/mini_app/sirius.scf.cpp
+++ b/apps/mini_app/sirius.scf.cpp
@@ -156,6 +156,7 @@ ground_state(Simulation_context& ctx, int task_id, cmd_args const& args, int wri
     auto& potential = dft.potential();
     auto& density   = dft.density();
 
+    /* in case of restart, read density from file */
     if (task_id == task_t::ground_state_restart) {
         auto fname = args.value<fs::path>("input", storage_file_name);
         if (!isHDF5(fname)) {
@@ -247,7 +248,6 @@ ground_state(Simulation_context& ctx, int task_id, cmd_args const& args, int wri
         dict["task"]         = task_id;
         dict["context"]      = ctx.serialize();
         dict["ground_state"] = result;
-        // dict["timers"] = utils::timer::serialize();
         dict["counters"]                               = json::object();
         dict["counters"]["local_operator_num_applied"] = ctx.num_loc_op_applied();
         dict["counters"]["band_evp_work_count"]        = ctx.evp_work_count();
@@ -419,6 +419,7 @@ run_tasks(cmd_args const& args)
     }
 
     auto fname = fpath.string();
+    /* ground state runs */
     if (task_id == task_t::ground_state_new || task_id == task_t::ground_state_restart ||
         task_id == task_t::ground_state_new_relax || task_id == task_t::ground_state_new_vcrelax) {
         auto ctx = create_sim_ctx(fname, args);
@@ -426,6 +427,7 @@ run_tasks(cmd_args const& args)
         int write_output{1};
         ground_state(*ctx, task_id, args, write_output);
     }
+    /* EoS */
     if (task_id == task_t::eos) {
         auto vs0            = args.value<double>("volume_scale0", 0.94);
         auto vs1            = args.value<double>("volume_scale1", 1.06);
@@ -674,8 +676,8 @@ main(int argn, char** argv)
     sirius::finalize(1);
 
     if (my_rank == 0) {
-        // auto timing_result = ::utils::global_rtgraph_timer.process().flatten(1).sort_nodes();
-        auto timing_result = global_rtgraph_timer.process();
+        auto timing_result = global_rtgraph_timer.process().flatten(1).sort_nodes();
+        //auto timing_result = global_rtgraph_timer.process();
         std::cout << timing_result.print({rt_graph::Stat::Count, rt_graph::Stat::Total, rt_graph::Stat::Percentage,
                                           rt_graph::Stat::SelfPercentage, rt_graph::Stat::Median, rt_graph::Stat::Min,
                                           rt_graph::Stat::Max});

--- a/apps/mini_app/sirius.scf.cpp
+++ b/apps/mini_app/sirius.scf.cpp
@@ -245,9 +245,9 @@ ground_state(Simulation_context& ctx, int task_id, cmd_args const& args, int wri
         json dict;
         json_output_common(dict);
 
-        dict["task"]         = task_id;
-        dict["context"]      = ctx.serialize();
-        dict["ground_state"] = result;
+        dict["task"]                                   = task_id;
+        dict["context"]                                = ctx.serialize();
+        dict["ground_state"]                           = result;
         dict["counters"]                               = json::object();
         dict["counters"]["local_operator_num_applied"] = ctx.num_loc_op_applied();
         dict["counters"]["band_evp_work_count"]        = ctx.evp_work_count();

--- a/apps/tests/test_mpi_alltoall.cpp
+++ b/apps/tests/test_mpi_alltoall.cpp
@@ -38,8 +38,9 @@ test_mpi_alltoall_impl(int M__, int N__)
     rd.calc_offsets();
 
     if (comm.rank() == 0) {
-        printf("number of ranks: %i\n", comm.size());
-        printf("local buffer size: %f Mb\n", spl_M.local_size() * N__ * sizeof(std::complex<double>) / double(1 << 20));
+        std::cout << "number of ranks   : " << comm.size() << std::endl;
+        std::cout << "local buffer size : " <<
+            spl_M.local_size() * N__ * sizeof(std::complex<double>) / double(1 << 20) << " Mb" << std::endl;
     }
 
     /* P MPI ranks reshuffle data. Each rank stores N * M / P elements which it sends and receives.
@@ -49,6 +50,9 @@ test_mpi_alltoall_impl(int M__, int N__)
     auto t0 = time_now();
     comm.alltoall(&a(0, 0), &sd.counts[0], &sd.offsets[0], &b(0, 0), &rd.counts[0], &rd.offsets[0]);
     double t = time_interval(t0);
+    if (comm.rank() == 0) {
+        std::cout << "alltoall time : " << t << " sec" << std::endl;
+    }
 
     comm.alltoall(&b(0, 0), &rd.counts[0], &rd.offsets[0], &a(0, 0), &sd.counts[0], &sd.offsets[0]);
 
@@ -70,8 +74,8 @@ test_mpi_alltoall(cmd_args const& args__)
         perf.push_back(test_mpi_alltoall_impl(M, N));
     }
     if (mpi::Communicator::world().rank() == 0) {
-        printf("average performance: %12.4f GB/s/rank\n", perf.average());
-        printf("sigma: %12.4f GB/s/rank\n", perf.sigma());
+        std::cout << "average performance : " << perf.average() << " GB/s/rank" << std::endl;
+        std::cout << "sigma               : " << perf.sigma() << " GB/s/rank" << std::endl;
     }
     return 0;
 }

--- a/apps/tests/test_mpi_alltoall.cpp
+++ b/apps/tests/test_mpi_alltoall.cpp
@@ -39,8 +39,8 @@ test_mpi_alltoall_impl(int M__, int N__)
 
     if (comm.rank() == 0) {
         std::cout << "number of ranks   : " << comm.size() << std::endl;
-        std::cout << "local buffer size : " <<
-            spl_M.local_size() * N__ * sizeof(std::complex<double>) / double(1 << 20) << " Mb" << std::endl;
+        std::cout << "local buffer size : " << spl_M.local_size() * N__ * sizeof(std::complex<double>) / double(1 << 20)
+                  << " Mb" << std::endl;
     }
 
     /* P MPI ranks reshuffle data. Each rank stores N * M / P elements which it sends and receives.

--- a/apps/tests/test_wf_inner.cpp
+++ b/apps/tests/test_wf_inner.cpp
@@ -101,17 +101,19 @@ test_wf_inner_impl(std::vector<int> mpi_grid_dims__, double cutoff__, int num_ba
         if (true && mpi_grid_dims__[0] * mpi_grid_dims__[1] == 1) {
             mpi::Communicator::world().barrier();
             double t0 = ::sirius::wtime();
-            la::wrap(la::lib_t::blas).gemm('C', 'N', num_bands__, num_bands__, gvec->count(),
-                    &la::constant<std::complex<double>>::one(), phi1.at(memory_t::host, 0, wf::spin_index(0), wf::band_index(0)), phi1.ld(),
-                    phi2.at(memory_t::host, 0, wf::spin_index(0), wf::band_index(0)), phi2.ld(), &la::constant<std::complex<double>>::zero(),
-                    ovlp.at(memory_t::host), ovlp.ld());
+            la::wrap(la::lib_t::blas)
+                    .gemm('C', 'N', num_bands__, num_bands__, gvec->count(), &la::constant<std::complex<double>>::one(),
+                          phi1.at(memory_t::host, 0, wf::spin_index(0), wf::band_index(0)), phi1.ld(),
+                          phi2.at(memory_t::host, 0, wf::spin_index(0), wf::band_index(0)), phi2.ld(),
+                          &la::constant<std::complex<double>>::zero(), ovlp.at(memory_t::host), ovlp.ld());
             mpi::Communicator::world().barrier();
             double t1 = ::sirius::wtime();
             mpi::Communicator::world().allreduce(ovlp.at(memory_t::host), num_bands__ * num_bands__);
             mpi::Communicator::world().barrier();
             double t2 = ::sirius::wtime();
             std::cout << "local zgemm time : " << t1 - t0 << ", allreduce time : " << t2 - t1
-                << ", effective performance : " << 8e-9 * num_bands__ * num_bands__ * gvec->num_gvec() / (t2 - t0) << " gflops" << std::endl;
+                      << ", effective performance : " << 8e-9 * num_bands__ * num_bands__ * gvec->num_gvec() / (t2 - t0)
+                      << " gflops" << std::endl;
         }
     }
     if (mpi::Communicator::world().rank() == 0) {

--- a/apps/tests/test_wf_inner.cpp
+++ b/apps/tests/test_wf_inner.cpp
@@ -60,8 +60,8 @@ test_wf_inner_impl(std::vector<int> mpi_grid_dims__, double cutoff__, int num_ba
     /* warmup call */
     wf::inner(spla_ctx, mem__, sr, phi1, wf::band_range(0, num_bands__), phi2, wf::band_range(0, num_bands__), ovlp, 0,
               0);
-    mpi::Communicator::world().barrier();
 
+    mpi::Communicator::world().barrier();
     Measurement stat;
 
     int ierr{0};
@@ -97,6 +97,21 @@ test_wf_inner_impl(std::vector<int> mpi_grid_dims__, double cutoff__, int num_ba
         }
         if (max_diff > 1e-8) {
             ierr++;
+        }
+        if (true && mpi_grid_dims__[0] * mpi_grid_dims__[1] == 1) {
+            mpi::Communicator::world().barrier();
+            double t0 = ::sirius::wtime();
+            la::wrap(la::lib_t::blas).gemm('C', 'N', num_bands__, num_bands__, gvec->count(),
+                    &la::constant<std::complex<double>>::one(), phi1.at(memory_t::host, 0, wf::spin_index(0), wf::band_index(0)), phi1.ld(),
+                    phi2.at(memory_t::host, 0, wf::spin_index(0), wf::band_index(0)), phi2.ld(), &la::constant<std::complex<double>>::zero(),
+                    ovlp.at(memory_t::host), ovlp.ld());
+            mpi::Communicator::world().barrier();
+            double t1 = ::sirius::wtime();
+            mpi::Communicator::world().allreduce(ovlp.at(memory_t::host), num_bands__ * num_bands__);
+            mpi::Communicator::world().barrier();
+            double t2 = ::sirius::wtime();
+            std::cout << "local zgemm time : " << t1 - t0 << ", allreduce time : " << t2 - t1
+                << ", effective performance : " << 8e-9 * num_bands__ * num_bands__ * gvec->num_gvec() / (t2 - t0) << " gflops" << std::endl;
         }
     }
     if (mpi::Communicator::world().rank() == 0) {

--- a/doc/doxygen.cfg
+++ b/doc/doxygen.cfg
@@ -39,7 +39,7 @@ PROJECT_NAME           = "SIRIUS"
 # control system is used.
 
 
-PROJECT_NUMBER         = "7.10.0"
+PROJECT_NUMBER         = "7.11.1"
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/python_module/py_sirius.cpp
+++ b/python_module/py_sirius.cpp
@@ -164,8 +164,6 @@ PYBIND11_MODULE(py_sirius, m)
                     /* call MPI_Finalize */
                     true,
                     /* reset device */
-                    false,
-                    /* fftw cleanup */
                     false);
         }
     }));

--- a/src/api/generate_api.py
+++ b/src/api/generate_api.py
@@ -201,7 +201,12 @@ class Argument:
 
     def append_interface_call(self, out):
 
-        if self.type_id() in ('bool', 'string'):
+        needs_post_call = (
+            self.type_id() == 'string' or
+            (self.type_id() == 'bool' and self.attr().intent() in ['inout', 'out'])
+        )
+
+        if needs_post_call:
 
             if self.attr().required() == 'optional':
                 out.write(f'if (present({self.name()})) then\n')

--- a/src/api/sirius.f90
+++ b/src/api/sirius.f90
@@ -116,31 +116,26 @@ end subroutine sirius_initialize
 !> @brief Shut down the SIRIUS library
 !> @param [in] call_mpi_fin If .true. then MPI_Finalize must be called after the shutdown.
 !> @param [in] call_device_reset If .true. then cuda device is reset after shutdown.
-!> @param [in] call_fftw_fin If .true. then fft_cleanup must be called after the shutdown.
 !> @param [out] error_code Error code.
-subroutine sirius_finalize(call_mpi_fin,call_device_reset,call_fftw_fin,error_code)
+subroutine sirius_finalize(call_mpi_fin,call_device_reset,error_code)
 implicit none
 !
 logical, optional, target, intent(in) :: call_mpi_fin
 logical, optional, target, intent(in) :: call_device_reset
-logical, optional, target, intent(in) :: call_fftw_fin
 integer, optional, target, intent(out) :: error_code
 !
 type(C_PTR) :: call_mpi_fin_ptr
 logical(C_BOOL), target :: call_mpi_fin_c_type
 type(C_PTR) :: call_device_reset_ptr
 logical(C_BOOL), target :: call_device_reset_c_type
-type(C_PTR) :: call_fftw_fin_ptr
-logical(C_BOOL), target :: call_fftw_fin_c_type
 type(C_PTR) :: error_code_ptr
 !
 interface
-subroutine sirius_finalize_aux(call_mpi_fin,call_device_reset,call_fftw_fin,error_code)&
+subroutine sirius_finalize_aux(call_mpi_fin,call_device_reset,error_code)&
 &bind(C, name="sirius_finalize")
 use, intrinsic :: ISO_C_BINDING
 type(C_PTR), value :: call_mpi_fin
 type(C_PTR), value :: call_device_reset
-type(C_PTR), value :: call_fftw_fin
 type(C_PTR), value :: error_code
 end subroutine
 end interface
@@ -155,22 +150,14 @@ if (present(call_device_reset)) then
 call_device_reset_c_type = call_device_reset
 call_device_reset_ptr = C_LOC(call_device_reset_c_type)
 endif
-call_fftw_fin_ptr = C_NULL_PTR
-if (present(call_fftw_fin)) then
-call_fftw_fin_c_type = call_fftw_fin
-call_fftw_fin_ptr = C_LOC(call_fftw_fin_c_type)
-endif
 error_code_ptr = C_NULL_PTR
 if (present(error_code)) then
 error_code_ptr = C_LOC(error_code)
 endif
-call sirius_finalize_aux(call_mpi_fin_ptr,call_device_reset_ptr,call_fftw_fin_ptr,&
-&error_code_ptr)
+call sirius_finalize_aux(call_mpi_fin_ptr,call_device_reset_ptr,error_code_ptr)
 if (present(call_mpi_fin)) then
 endif
 if (present(call_device_reset)) then
-endif
-if (present(call_fftw_fin)) then
 endif
 end subroutine sirius_finalize
 
@@ -3073,6 +3060,14 @@ error_code_ptr = C_LOC(error_code)
 endif
 call sirius_generate_density_aux(gs_handler_ptr,add_core_ptr,transform_to_rg_ptr,&
 &paw_only_ptr,efermi_ptr,error_code_ptr)
+if (present(add_core)) then
+endif
+if (present(transform_to_rg)) then
+endif
+if (present(paw_only)) then
+endif
+if (present(efermi)) then
+endif
 end subroutine sirius_generate_density
 
 !
@@ -7395,7 +7390,7 @@ endif
 end subroutine sirius_set_dftd3_correction
 
 !
-!> @brief Set the parameters controlling the dftd3 correction.
+!> @brief Set the parameters controlling the dftd4 correction.
 !> @param [in] handler Simulation context handler.
 !> @param [in] method family of predefined parameters. Linked to the functional
 !> @param [in] damping damping correction, auto, manual.

--- a/src/api/sirius.f90
+++ b/src/api/sirius.f90
@@ -155,10 +155,6 @@ if (present(error_code)) then
 error_code_ptr = C_LOC(error_code)
 endif
 call sirius_finalize_aux(call_mpi_fin_ptr,call_device_reset_ptr,error_code_ptr)
-if (present(call_mpi_fin)) then
-endif
-if (present(call_device_reset)) then
-endif
 end subroutine sirius_finalize
 
 !
@@ -749,12 +745,6 @@ call sirius_set_parameters_aux(handler_ptr,lmax_apw_ptr,lmax_rho_ptr,lmax_pot_pt
 &hubbard_correction_kind_ptr,hubbard_full_orthogonalization_ptr,hubbard_constrained_calculation_ptr,&
 &hubbard_orbitals_ptr,dftd3_correction_ptr,sht_coverage_ptr,min_occupancy_ptr,smearing_ptr,&
 &smearing_width_ptr,spglib_tol_ptr,electronic_structure_method_ptr,error_code_ptr)
-if (present(gamma_point)) then
-endif
-if (present(use_symmetry)) then
-endif
-if (present(so_correction)) then
-endif
 if (present(valence_rel)) then
 deallocate(valence_rel_c_type)
 endif
@@ -763,12 +753,6 @@ deallocate(core_rel_c_type)
 endif
 if (present(iter_solver_type)) then
 deallocate(iter_solver_type_c_type)
-endif
-if (present(hubbard_correction)) then
-endif
-if (present(hubbard_full_orthogonalization)) then
-endif
-if (present(hubbard_constrained_calculation)) then
 endif
 if (present(hubbard_orbitals)) then
 deallocate(hubbard_orbitals_c_type)
@@ -1946,10 +1930,6 @@ endif
 call sirius_find_ground_state_aux(gs_handler_ptr,density_tol_ptr,energy_tol_ptr,&
 &iter_solver_tol_ptr,initial_guess_ptr,max_niter_ptr,save_state_ptr,converged_ptr,&
 &niter_ptr,rho_min_ptr,error_code_ptr)
-if (present(initial_guess)) then
-endif
-if (present(save_state)) then
-endif
 if (present(converged)) then
 converged = converged_c_type
 endif
@@ -2111,8 +2091,6 @@ deallocate(fname_c_type)
 endif
 if (present(symbol)) then
 deallocate(symbol_c_type)
-endif
-if (present(spin_orbit)) then
 endif
 end subroutine sirius_add_atom_type
 
@@ -2721,8 +2699,6 @@ endif
 call sirius_set_pw_coeffs_aux(gs_handler_ptr,label_ptr,pw_coeffs_ptr,transform_to_rg_ptr,&
 &ngv_ptr,gvl_ptr,comm_ptr,error_code_ptr)
 deallocate(label_c_type)
-if (present(transform_to_rg)) then
-endif
 end subroutine sirius_set_pw_coeffs
 
 !
@@ -2918,12 +2894,6 @@ error_code_ptr = C_LOC(error_code)
 endif
 call sirius_find_eigen_states_aux(gs_handler_ptr,ks_handler_ptr,precompute_pw_ptr,&
 &precompute_rf_ptr,precompute_ri_ptr,iter_solver_tol_ptr,iter_solver_steps_ptr,error_code_ptr)
-if (present(precompute_pw)) then
-endif
-if (present(precompute_rf)) then
-endif
-if (present(precompute_ri)) then
-endif
 end subroutine sirius_find_eigen_states
 
 !
@@ -3060,14 +3030,6 @@ error_code_ptr = C_LOC(error_code)
 endif
 call sirius_generate_density_aux(gs_handler_ptr,add_core_ptr,transform_to_rg_ptr,&
 &paw_only_ptr,efermi_ptr,error_code_ptr)
-if (present(add_core)) then
-endif
-if (present(transform_to_rg)) then
-endif
-if (present(paw_only)) then
-endif
-if (present(efermi)) then
-endif
 end subroutine sirius_generate_density
 
 !
@@ -5035,8 +4997,6 @@ call sirius_option_set_aux(handler_ptr,section_ptr,name_ptr,type_ptr,data_ptr,ma
 &append_ptr,error_code_ptr)
 deallocate(section_c_type)
 deallocate(name_c_type)
-if (present(append)) then
-endif
 end subroutine sirius_option_set
 
 !
@@ -5319,8 +5279,6 @@ endif
 call sirius_set_rg_values_aux(gs_handler_ptr,label_ptr,grid_dims_ptr,local_box_origin_ptr,&
 &local_box_size_ptr,fcomm_ptr,values_ptr,transform_to_pw_ptr,error_code_ptr)
 deallocate(label_c_type)
-if (present(transform_to_pw)) then
-endif
 end subroutine sirius_set_rg_values
 
 !
@@ -5405,8 +5363,6 @@ endif
 call sirius_get_rg_values_aux(gs_handler_ptr,label_ptr,grid_dims_ptr,local_box_origin_ptr,&
 &local_box_size_ptr,fcomm_ptr,values_ptr,transform_to_rg_ptr,error_code_ptr)
 deallocate(label_c_type)
-if (present(transform_to_rg)) then
-endif
 end subroutine sirius_get_rg_values
 
 !
@@ -6965,8 +6921,6 @@ endif
 call sirius_diagonalize_hamiltonian_aux(handler_ptr,gs_handler_ptr,H0_handler_ptr,&
 &iter_solver_tol_ptr,max_steps_ptr,converge_by_energy_ptr,exact_diagonalization_ptr,&
 &converged_ptr,niter_ptr,error_code_ptr)
-if (present(exact_diagonalization)) then
-endif
 converged = converged_c_type
 end subroutine sirius_diagonalize_hamiltonian
 
@@ -7382,8 +7336,6 @@ deallocate(method_c_type)
 if (present(damping)) then
 deallocate(damping_c_type)
 endif
-if (present(atm)) then
-endif
 if (present(damping_term)) then
 deallocate(damping_term_c_type)
 endif
@@ -7513,8 +7465,6 @@ call sirius_set_dftd4_correction_aux(handler_ptr,method_ptr,damping_ptr,atm_ptr,
 deallocate(method_c_type)
 if (present(damping)) then
 deallocate(damping_c_type)
-endif
-if (present(atm)) then
 endif
 if (present(damping_term)) then
 deallocate(damping_term_c_type)

--- a/src/api/sirius_api.cpp
+++ b/src/api/sirius_api.cpp
@@ -387,10 +387,6 @@ sirius_finalize:
       type: bool
       attr: in, optional
       doc: If .true. then cuda device is reset after shutdown.
-    call_fftw_fin:
-      type: bool
-      attr: in, optional
-      doc: If .true. then fft_cleanup must be called after the shutdown.
     error_code:
       type: int
       attr: out, optional
@@ -398,8 +394,7 @@ sirius_finalize:
 @api end
 */
 void
-sirius_finalize(bool const* call_mpi_fin__, bool const* call_device_reset__, bool const* call_fftw_fin__,
-                int* error_code__)
+sirius_finalize(bool const* call_mpi_fin__, bool const* call_device_reset__, int* error_code__)
 {
     call_sirius(
             [&]() {
@@ -408,7 +403,6 @@ sirius_finalize(bool const* call_mpi_fin__, bool const* call_device_reset__, boo
 #endif
                 bool mpi_fin{true};
                 bool device_reset{true};
-                bool fftw_fin{true};
 
                 if (call_mpi_fin__ != nullptr) {
                     mpi_fin = *call_mpi_fin__;
@@ -418,11 +412,7 @@ sirius_finalize(bool const* call_mpi_fin__, bool const* call_device_reset__, boo
                     device_reset = *call_device_reset__;
                 }
 
-                if (call_fftw_fin__ != nullptr) {
-                    fftw_fin = *call_fftw_fin__;
-                }
-
-                sirius::finalize(mpi_fin, device_reset, fftw_fin);
+                sirius::finalize(mpi_fin, device_reset);
             },
             error_code__);
 }

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -1006,7 +1006,7 @@ Simulation_context::update()
     /* After each update of the lattice vectors we might get a different set of G-vector shells.
      * Always update the mapping between the canonical FFT distribution and "local G-shells"
      * distribution which is used in symmetriezation of lattice periodic functions. */
-    remap_gvec_ = std::make_unique<fft::Gvec_shells>(gvec());
+    gvec_sym_ = std::make_unique<fft::Gvec_sym>(gvec());
 
     /* check symmetry of G-vectors */
     if (unit_cell().num_atoms() != 0 && use_symmetry() && cfg().control().verification() >= 1) {
@@ -1014,7 +1014,7 @@ Simulation_context::update()
         if (!full_potential()) {
             check_gvec(gvec_coarse(), unit_cell().symmetry());
         }
-        check_gvec(*remap_gvec_, unit_cell().symmetry());
+        check_gvec(*gvec_sym_, unit_cell().symmetry());
     }
 
     /* check if FFT grid is OK; this check is especially needed if the grid is set as external parameter */

--- a/src/context/simulation_context.hpp
+++ b/src/context/simulation_context.hpp
@@ -212,7 +212,7 @@ class Simulation_context : public Simulation_parameters
 
     std::shared_ptr<fft::Gvec_fft> gvec_coarse_fft_;
 
-    std::shared_ptr<fft::Gvec_shells> remap_gvec_;
+    std::shared_ptr<fft::Gvec_sym> gvec_sym_;
 
     /// Creation time of the parameters.
     timeval start_time_;
@@ -464,9 +464,9 @@ class Simulation_context : public Simulation_parameters
     }
 
     auto const&
-    remap_gvec() const
+    gvec_sym() const
     {
-        return *remap_gvec_;
+        return *gvec_sym_;
     }
 
     auto const&

--- a/src/core/fft/gvec.cpp
+++ b/src/core/fft/gvec.cpp
@@ -665,9 +665,9 @@ Gvec_fft::Gvec_fft(Gvec const& gvec__, mpi::Communicator const& comm_fft__, mpi:
     pile_gvec();
 }
 
-Gvec_shells::Gvec_shells(Gvec const& gvec__)
-    : comm_(gvec__.comm())
-    , gvec_(gvec__)
+Gvec_sym::Gvec_sym(Gvec const& gvec__)
+    : gvec_(gvec__)
+    , comm_(gvec__.comm())
 {
     PROFILE("fft::Gvec_shells");
 
@@ -677,7 +677,7 @@ Gvec_shells::Gvec_shells(Gvec const& gvec__)
     /* split G-vector shells between ranks in cyclic order */
     spl_num_gsh_ = splindex_block_cyclic<>(gvec_.num_shells(), n_blocks(comm_.size()), block_id(comm_.rank()), 1);
 
-    /* each rank sends a fraction of its local G-vectors to other ranks */
+    /* each rank repacks and sends a fraction of its local G-vectors to other ranks */
     /* count this fraction */
     for (int igloc = 0; igloc < gvec_.count(); igloc++) {
         int ig   = gvec_.offset() + igloc;
@@ -703,15 +703,21 @@ Gvec_shells::Gvec_shells(Gvec const& gvec__)
     }
     a2a_recv_.calc_offsets();
     /* sanity check: sum of local sizes in the remapped order is equal to the total number of G-vectors */
-    int ng = gvec_count_remapped();
+    int ng = this->count();
     comm_.allreduce(&ng, 1);
     if (ng != gvec_.num_gvec()) {
         RTE_THROW("wrong number of G-vectors");
     }
+    //int ng_min = this->count();
+    //comm_.allreduce<int, mpi::op_t::min>(&ng_min, 1);
+    //int ng_max = this->count();
+    //comm_.allreduce<int, mpi::op_t::max>(&ng_max, 1);
+
+    //std::cout << "debug: Gvec_shells: Gvec imbalance : " << 1.0 * ng_min / ng_max << std::endl;
 
     /* local set of G-vectors in the remapped order */
-    gvec_remapped_       = mdarray<int, 2>({3, gvec_count_remapped()}, mdarray_label("gvec_remapped_"));
-    gvec_shell_remapped_ = mdarray<int, 1>({gvec_count_remapped()}, mdarray_label("gvec_shell_remapped_"));
+    gvec_remapped_       = mdarray<int, 2>({3, this->count()}, mdarray_label("gvec_remapped_"));
+    gvec_shell_remapped_ = mdarray<int, 1>({this->count()}, mdarray_label("gvec_shell_remapped_"));
     std::vector<int> counts(comm_.size(), 0);
     for (int r = 0; r < comm_.size(); r++) {
         for (int igloc = 0; igloc < gvec_.count(r); igloc++) {
@@ -727,11 +733,12 @@ Gvec_shells::Gvec_shells(Gvec const& gvec__)
             }
         }
     }
-    for (int ig = 0; ig < gvec_count_remapped(); ig++) {
+    for (int ig = 0; ig < this->count(); ig++) {
+        /* G -> ig mapping */
         idx_gvec_[gvec_remapped(ig)] = ig;
     }
     /* sanity check */
-    for (int igloc = 0; igloc < this->gvec_count_remapped(); igloc++) {
+    for (int igloc = 0; igloc < this->count(); igloc++) {
         auto G = this->gvec_remapped(igloc);
         if (this->index_by_gvec(G) != igloc) {
             RTE_THROW("Wrong remapped index of G-vector");
@@ -740,6 +747,12 @@ Gvec_shells::Gvec_shells(Gvec const& gvec__)
         if (igsh != this->gvec().shell(G)) {
             RTE_THROW("Wrong remapped shell of G-vector");
         }
+    }
+
+    gvec_shells_.resize(spl_num_gsh_.local_size());
+    for (int igloc = 0; igloc < this->count(); igloc++) {
+        int igsh = this->gvec_shell_remapped(igloc);
+        gvec_shells_[spl_num_gsh_.location(igsh).index_local].push_back(igloc);
     }
 }
 

--- a/src/core/fft/gvec.hpp
+++ b/src/core/fft/gvec.hpp
@@ -955,22 +955,35 @@ class Gvec_fft
     }
 };
 
+/// Hash function for the std::unordered_map<r3::vector<int>..>
+struct r3_int_hash
+{
+    std::size_t
+    operator()(r3::vector<int> const& v) const noexcept
+    {
+        std::size_t h = std::hash<int>{}(v[0]);
+        h ^= std::hash<int>{}(v[1]) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+        h ^= std::hash<int>{}(v[2]) + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2);
+        return h;
+    }
+};
+
 /// Helper class to manage G-vector shells and redistribute G-vectors for symmetrization.
 /** G-vectors are remapped from default distribution which balances both the local number
     of z-columns and G-vectors to the distribution of G-vector shells in which each MPI rank stores
     local set of complete G-vector shells such that the "rotated" G-vector remains on the same MPI rank.
  */
-class Gvec_shells
+class Gvec_sym
 {
   private:
+    /// Original set of G-vectors.
+    Gvec const& gvec_;
+
     /// Sending counts and offsets.
     mpi::block_data_descriptor a2a_send_;
 
     /// Receiving counts and offsets.
     mpi::block_data_descriptor a2a_recv_;
-
-    /// Split global index of G-shells between MPI ranks.
-    splindex_block_cyclic<> spl_num_gsh_;
 
     /// List of G-vectors in the remapped storage.
     mdarray<int, 2> gvec_remapped_;
@@ -981,13 +994,25 @@ class Gvec_shells
     /// Alias for the G-vector communicator.
     mpi::Communicator const& comm_;
 
-    Gvec const& gvec_;
+    /// A mapping between G-vector and its local index in the new distribution.
+    std::unordered_map<r3::vector<int>, int, r3_int_hash> idx_gvec_;
 
-    /// A mapping between G-vector and it's local index in the new distribution.
-    std::map<r3::vector<int>, int> idx_gvec_;
+    /// Grouping of G-vectors by shells.
+    /** Local index of shell on current MPI rank is used. */
+    std::vector<std::vector<int>> gvec_shells_;
+
+    /// Split global index of G-shells between MPI ranks.
+    splindex_block_cyclic<> spl_num_gsh_;
 
   public:
-    Gvec_shells(Gvec const& gvec__);
+    Gvec_sym(Gvec const& gvec__);
+
+    /// G-vector by local index (in the remapped set).
+    inline auto
+    gvec_remapped(int igloc__) const
+    {
+        return r3::vector<int>(gvec_remapped_(0, igloc__), gvec_remapped_(1, igloc__), gvec_remapped_(2, igloc__));
+    }
 
     inline void
     print_gvec(std::ostream& out__) const
@@ -995,7 +1020,7 @@ class Gvec_shells
         mpi::pstdout pout(gvec_.comm());
         pout << "rank: " << gvec_.comm().rank() << std::endl;
         pout << "-- list of G-vectors in the remapped distribution --" << std::endl;
-        for (int igloc = 0; igloc < gvec_count_remapped(); igloc++) {
+        for (int igloc = 0; igloc < this->count(); igloc++) {
             auto G = gvec_remapped(igloc);
 
             int igsh = gvec_shell_remapped(igloc);
@@ -1009,42 +1034,36 @@ class Gvec_shells
     }
 
     /// Local number of G-vectors in the remapped distribution with complete shells on each rank.
-    int
-    gvec_count_remapped() const
+    inline int
+    count() const
     {
         return a2a_recv_.size();
     }
 
-    /// G-vector by local index (in the remapped set).
-    r3::vector<int>
-    gvec_remapped(int igloc__) const
-    {
-        return r3::vector<int>(gvec_remapped_(0, igloc__), gvec_remapped_(1, igloc__), gvec_remapped_(2, igloc__));
-    }
-
     /// Return local index of the G-vector in the remapped set.
-    int
-    index_by_gvec(r3::vector<int> G__) const
+    inline int
+    index_by_gvec(r3::vector<int> const& G__) const
     {
-        if (idx_gvec_.count(G__)) {
-            return idx_gvec_.at(G__);
-        } else {
+        auto it = idx_gvec_.find(G__);
+        if (it == idx_gvec_.end()) {
             return -1;
         }
+        return it->second;
     }
 
     /// Index of the G-vector shell by the local G-vector index (in the remapped set).
-    int
+    inline int
     gvec_shell_remapped(int igloc__) const
     {
         return gvec_shell_remapped_(igloc__);
     }
 
+    /// Redistribute G-vectors and collect complete shells on MPI ranks.
     template <typename T>
     auto
     remap_forward(T* data__) const
     {
-        PROFILE("fft::Gvec_shells::remap_forward");
+        PROFILE("fft::Gvec_sym::remap_forward");
 
         std::vector<T> send_buf(gvec_.count());
         std::vector<int> counts(comm_.size(), 0);
@@ -1056,7 +1075,7 @@ class Gvec_shells
             counts[r]++;
         }
 
-        std::vector<T> recv_buf(gvec_count_remapped());
+        std::vector<T> recv_buf(this->count());
 
         comm_.alltoall(send_buf.data(), a2a_send_.counts.data(), a2a_send_.offsets.data(), recv_buf.data(),
                        a2a_recv_.counts.data(), a2a_recv_.offsets.data());
@@ -1064,11 +1083,12 @@ class Gvec_shells
         return recv_buf;
     }
 
+    /// Redistribute G-vectors back to default order.
     template <typename T>
     void
     remap_backward(std::vector<T> buf__, T* data__) const
     {
-        PROFILE("fft::Gvec_shells::remap_backward");
+        PROFILE("fft::Gvec_sym::remap_backward");
 
         std::vector<T> recv_buf(gvec_.count());
 
@@ -1085,7 +1105,13 @@ class Gvec_shells
         }
     }
 
-    inline Gvec const&
+    inline auto const&
+    gvec_shells() const
+    {
+        return gvec_shells_;
+    }
+
+    inline auto const&
     gvec() const
     {
         return gvec_;

--- a/src/core/wf/wave_functions.hpp
+++ b/src/core/wf/wave_functions.hpp
@@ -993,8 +993,9 @@ class Wave_functions_fft : public Wave_functions_base<T>
 
         if (env::print_performance() && wf_->gkvec().comm().rank() == 0) {
             auto t = ::sirius::time_interval(t0);
-            std::cout << "[transform_to_fft_layout] throughput: "
-                      << 2 * sizeof(T) * wf_->gkvec().num_gvec() * b__.size() / std::pow(2.0, 30) / t << " Gb/sec"
+            double gbs = 2 * sizeof(T) * wf_->gkvec().num_gvec() * b__.size() / std::pow(2.0, 30) / t;
+            std::cout << "[shuffle_to_fft_layout] throughput: "
+                      << gbs << " Gb/sec, " << gbs / wf_->gkvec().comm().size() << "Gb/rank/sec"
                       << std::endl;
         }
     }
@@ -1087,8 +1088,9 @@ class Wave_functions_fft : public Wave_functions_base<T>
         }
         if (pp && wf_->gkvec().comm().rank() == 0) {
             auto t = ::sirius::time_interval(t0);
-            std::cout << "[transform_from_fft_layout] throughput: "
-                      << 2 * sizeof(T) * wf_->gkvec().num_gvec() * b__.size() / std::pow(2.0, 30) / t << " Gb/sec"
+            double gbs = 2 * sizeof(T) * wf_->gkvec().num_gvec() * b__.size() / std::pow(2.0, 30) / t;
+            std::cout << "[shuffle_to_wf_layout] throughput: "
+                      << gbs << " Gb/sec, " << gbs / wf_->gkvec().comm().size() << " Gb/rank/sec"
                       << std::endl;
         }
     }

--- a/src/core/wf/wave_functions.hpp
+++ b/src/core/wf/wave_functions.hpp
@@ -992,11 +992,10 @@ class Wave_functions_fft : public Wave_functions_base<T>
         }
 
         if (env::print_performance() && wf_->gkvec().comm().rank() == 0) {
-            auto t = ::sirius::time_interval(t0);
+            auto t     = ::sirius::time_interval(t0);
             double gbs = 2 * sizeof(T) * wf_->gkvec().num_gvec() * b__.size() / std::pow(2.0, 30) / t;
-            std::cout << "[shuffle_to_fft_layout] throughput: "
-                      << gbs << " Gb/sec, " << gbs / wf_->gkvec().comm().size() << "Gb/rank/sec"
-                      << std::endl;
+            std::cout << "[shuffle_to_fft_layout] throughput: " << gbs << " Gb/sec, "
+                      << gbs / wf_->gkvec().comm().size() << "Gb/rank/sec" << std::endl;
         }
     }
 
@@ -1087,11 +1086,10 @@ class Wave_functions_fft : public Wave_functions_base<T>
             }
         }
         if (pp && wf_->gkvec().comm().rank() == 0) {
-            auto t = ::sirius::time_interval(t0);
+            auto t     = ::sirius::time_interval(t0);
             double gbs = 2 * sizeof(T) * wf_->gkvec().num_gvec() * b__.size() / std::pow(2.0, 30) / t;
-            std::cout << "[shuffle_to_wf_layout] throughput: "
-                      << gbs << " Gb/sec, " << gbs / wf_->gkvec().comm().size() << " Gb/rank/sec"
-                      << std::endl;
+            std::cout << "[shuffle_to_wf_layout] throughput: " << gbs << " Gb/sec, " << gbs / wf_->gkvec().comm().size()
+                      << " Gb/rank/sec" << std::endl;
         }
     }
 

--- a/src/sirius.hpp
+++ b/src/sirius.hpp
@@ -133,7 +133,7 @@ initialize(bool call_mpi_init__ = true)
 
 /// Shut down the library.
 inline void
-finalize(bool call_mpi_fin__ = true, bool reset_device__ = true, bool fftw_cleanup__ = true)
+finalize(bool call_mpi_fin__ = true, bool reset_device__ = true)
 {
     PROFILE_START("sirius::finalize");
     if (!is_initialized()) {

--- a/src/symmetry/check_gvec.hpp
+++ b/src/symmetry/check_gvec.hpp
@@ -75,33 +75,33 @@ check_gvec(fft::Gvec const& gvec__, Crystal_symmetry const& sym__)
 }
 
 inline void
-check_gvec(fft::Gvec_shells const& gvec_shells__, Crystal_symmetry const& sym__)
+check_gvec(fft::Gvec_sym const& gvec_sym__, Crystal_symmetry const& sym__)
 {
     /* check G-vector symmetries */
-    for (int igloc = 0; igloc < gvec_shells__.gvec_count_remapped(); igloc++) {
-        auto G = gvec_shells__.gvec_remapped(igloc);
+    for (int igloc = 0; igloc < gvec_sym__.count(); igloc++) {
+        auto G = gvec_sym__.gvec_remapped(igloc);
 
         for (int i = 0; i < sym__.size(); i++) {
             auto& invRT = sym__[i].spg_op.invRT;
             auto gv_rot = dot(invRT, G);
 
             /* local index of a rotated G-vector */
-            int ig_rot = gvec_shells__.index_by_gvec(gv_rot);
+            int ig_rot = gvec_sym__.index_by_gvec(gv_rot);
 
             if (ig_rot == -1) {
                 gv_rot = gv_rot * (-1);
-                ig_rot = gvec_shells__.index_by_gvec(gv_rot);
+                ig_rot = gvec_sym__.index_by_gvec(gv_rot);
                 if (ig_rot == -1) {
                     std::stringstream s;
                     s << "Failed to find a rotated G-vector in the list" << std::endl
                       << "  local index of original vector: " << igloc << std::endl
-                      << "  global index of G-shell: " << gvec_shells__.gvec_shell_remapped(igloc) << std::endl
+                      << "  global index of G-shell: " << gvec_sym__.gvec_shell_remapped(igloc) << std::endl
                       << "  original G-vector: " << G << std::endl
                       << "  rotated G-vector: " << gv_rot;
                     RTE_THROW(s);
                 }
             }
-            if (ig_rot >= gvec_shells__.gvec_count_remapped()) {
+            if (ig_rot >= gvec_sym__.count()) {
                 std::stringstream s;
                 s << "G-vector index is above the boundary";
                 RTE_THROW(s);

--- a/src/symmetry/rotation.hpp
+++ b/src/symmetry/rotation.hpp
@@ -34,7 +34,7 @@ phi_by_sin_cos(double sinp, double cosp)
 
 /// Generate SU(2) rotation matrix from the axes and angle.
 inline auto
-rotation_matrix_su2(std::array<double, 3> u__, double theta__)
+rotation_matrix_su2(r3::vector<double> u__, double theta__)
 {
     mdarray<std::complex<double>, 2> rotm({2, 2});
 

--- a/src/symmetry/symmetrize_field4d.hpp
+++ b/src/symmetry/symmetrize_field4d.hpp
@@ -31,7 +31,7 @@ symmetrize_field4d(Field4D& f__)
     }
 
     /* symmetrize PW components */
-    symmetrize_pw_function(ctx.unit_cell().symmetry(), ctx.remap_gvec(), ctx.sym_phase_factors(), ctx.num_mag_dims(),
+    symmetrize_pw_function(ctx.unit_cell().symmetry(), ctx.gvec_sym(), ctx.sym_phase_factors(), ctx.num_mag_dims(),
                            f__.pw_components());
 
     if (ctx.full_potential()) {

--- a/src/symmetry/symmetrize_pw_function.hpp
+++ b/src/symmetry/symmetrize_pw_function.hpp
@@ -87,8 +87,8 @@ namespace sirius {
 template <int num_mag_dims>
 inline void
 symmetrize_pw_function_impl(Crystal_symmetry const& sym__, fft::Gvec_sym const& gvec_sym__,
-                       mdarray<std::complex<double>, 3> const& sym_phase_factors__,
-                       std::vector<Smooth_periodic_function<double>*> frg__)
+                            mdarray<std::complex<double>, 3> const& sym_phase_factors__,
+                            std::vector<Smooth_periodic_function<double>*> frg__)
 {
     PROFILE("sirius::symmetrize_pw_function");
 
@@ -132,7 +132,7 @@ symmetrize_pw_function_impl(Crystal_symmetry const& sym__, fft::Gvec_sym const& 
         int tid = omp_get_thread_num();
 
         double t0;
-        double ta{0},tb{0};
+        double ta{0}, tb{0};
 
         for (int igloc = 0; igloc < ngv; igloc++) {
             auto G = gvec_sym__.gvec_remapped(igloc);
@@ -178,7 +178,7 @@ symmetrize_pw_function_impl(Crystal_symmetry const& sym__, fft::Gvec_sym const& 
                     if (ig1 == -1) {
                         G1         = G1 * (-1);
                         conj_coeff = true;
-                        ig1 = gvec_sym__.index_by_gvec(G1);
+                        ig1        = gvec_sym__.index_by_gvec(G1);
                     }
 #if !defined(NDEBUG)
                     if (igsh != gvec_sym__.gvec().shell(G1)) {
@@ -354,8 +354,8 @@ symmetrize_pw_function_impl(Crystal_symmetry const& sym__, fft::Gvec_sym const& 
 template <int num_mag_dims>
 inline void
 symmetrize_pw_function_impl_v2(Crystal_symmetry const& sym__, fft::Gvec_sym const& gvec_sym__,
-                       mdarray<std::complex<double>, 3> const& sym_phase_factors__,
-                       std::vector<Smooth_periodic_function<double>*> frg__)
+                               mdarray<std::complex<double>, 3> const& sym_phase_factors__,
+                               std::vector<Smooth_periodic_function<double>*> frg__)
 {
     PROFILE("sirius::symmetrize_pw_function");
 
@@ -386,7 +386,7 @@ symmetrize_pw_function_impl_v2(Crystal_symmetry const& sym__, fft::Gvec_sym cons
 
         std::unordered_map<r3::vector<int>, char, fft::r3_int_hash> is_done;
         for (auto igloc : e) {
-            auto G = gvec_sym__.gvec_remapped(igloc);
+            auto G     = gvec_sym__.gvec_remapped(igloc);
             is_done[G] = 0;
         }
 
@@ -419,7 +419,7 @@ symmetrize_pw_function_impl_v2(Crystal_symmetry const& sym__, fft::Gvec_sym cons
                 if (ig1 == -1) {
                     G1         = G1 * (-1);
                     conj_coeff = true;
-                    ig1 = gvec_sym__.index_by_gvec(G1);
+                    ig1        = gvec_sym__.index_by_gvec(G1);
                 }
                 RTE_ASSERT(ig1 >= 0 && ig1 < ngv);
 
@@ -438,9 +438,8 @@ symmetrize_pw_function_impl_v2(Crystal_symmetry const& sym__, fft::Gvec_sym cons
                     symz += val * phase * S(2, 2);
                 }
                 if (num_mag_dims == 3) {
-                    auto v =
-                            r3::dot(S, r3::vector<std::complex<double>>(
-                                               {fpw_remapped[1][ig1], fpw_remapped[2][ig1], fpw_remapped[3][ig1]}));
+                    auto v = r3::dot(S, r3::vector<std::complex<double>>(
+                                                {fpw_remapped[1][ig1], fpw_remapped[2][ig1], fpw_remapped[3][ig1]}));
                     if (conj_coeff) {
                         v[0] = std::conj(v[0]);
                         v[1] = std::conj(v[1]);
@@ -478,7 +477,7 @@ symmetrize_pw_function_impl_v2(Crystal_symmetry const& sym__, fft::Gvec_sym cons
                             fpw_sym[1][ig1] = symz * phase * S(2, 2);
                         }
                         if (num_mag_dims == 3) {
-                            auto v = r3::dot(S, r3::vector<std::complex<double>>({symx, symy, symz}));
+                            auto v          = r3::dot(S, r3::vector<std::complex<double>>({symx, symy, symz}));
                             fpw_sym[1][ig1] = v[0] * phase;
                             fpw_sym[2][ig1] = v[1] * phase;
                             fpw_sym[3][ig1] = v[2] * phase;

--- a/src/symmetry/symmetrize_pw_function.hpp
+++ b/src/symmetry/symmetrize_pw_function.hpp
@@ -78,7 +78,7 @@ namespace sirius {
        f_{\mathrm{sym}}({\bf G}') = \hat{\bf S}f_{\mathrm{sym}}({\bf G})e^{-i{\bf G'}{\bf t}}
     \f]
 
-    \tparam [in] num_mag_dims     Number of magnetic dimensions.
+    \tparam num_mag_dims          Number of magnetic dimensions.
 
     \param [in] sym               Description of the crystal symmetry.
     \param [in] gvec_sym          Description of the G-vector set for symmetrization.

--- a/src/symmetry/symmetrize_pw_function.hpp
+++ b/src/symmetry/symmetrize_pw_function.hpp
@@ -78,13 +78,18 @@ namespace sirius {
        f_{\mathrm{sym}}({\bf G}') = \hat{\bf S}f_{\mathrm{sym}}({\bf G})e^{-i{\bf G'}{\bf t}}
     \f]
 
+    \tparam [in] num_mag_dims     Number of magnetic dimensions.
+
     \param [in] sym               Description of the crystal symmetry.
-    \param [in] gvec_sym          Description of the G-vector set for symmetrisation.
+    \param [in] gvec_sym          Description of the G-vector set for symmetrization.
     \param [in] sym_phase_factors Phase factors associated with fractional translations.
-    \param [in] num_mag_dims      Number of magnetic dimensions.
     \param [inout] frg            Array of pointers to scalar and vector parts of the filed being symmetrized.
+
+    \note
+    symmetrize_pw_function_impl() is kept as a reference implementation with additional sanity checks for
+    debugging symmetrization. The optimized implementation is symmetrize_pw_function_impl_v2().
  */
-template <int num_mag_dims> /* keep this variant for verification */
+template <int num_mag_dims>
 inline void
 symmetrize_pw_function_impl(Crystal_symmetry const& sym__, fft::Gvec_sym const& gvec_sym__,
                             mdarray<std::complex<double>, 3> const& sym_phase_factors__,
@@ -358,7 +363,7 @@ symmetrize_pw_function_impl_v2(Crystal_symmetry const& sym__, fft::Gvec_sym cons
 
     PROFILE_START("sirius::symmetrize|fpw|local");
 
-    #pragma omp parallel for schedule(static,1)
+    #pragma omp parallel for schedule(static, 1)
     for (auto& e : gvec_sym__.gvec_shells()) {
 
         std::unordered_map<r3::vector<int>, char, fft::r3_int_hash> is_done;

--- a/src/symmetry/symmetrize_pw_function.hpp
+++ b/src/symmetry/symmetrize_pw_function.hpp
@@ -79,14 +79,15 @@ namespace sirius {
     \f]
 
     \param [in] sym               Description of the crystal symmetry.
-    \param [in] gvec_shells       Description of the G-vector shells.
+    \param [in] gvec_sym          Description of the G-vector set for symmetrisation.
     \param [in] sym_phase_factors Phase factors associated with fractional translations.
     \param [in] num_mag_dims      Number of magnetic dimensions.
     \param [inout] frg            Array of pointers to scalar and vector parts of the filed being symmetrized.
  */
+template <int num_mag_dims>
 inline void
-symmetrize_pw_function(Crystal_symmetry const& sym__, fft::Gvec_shells const& gvec_shells__,
-                       mdarray<std::complex<double>, 3> const& sym_phase_factors__, int num_mag_dims__,
+symmetrize_pw_function_impl(Crystal_symmetry const& sym__, fft::Gvec_sym const& gvec_sym__,
+                       mdarray<std::complex<double>, 3> const& sym_phase_factors__,
                        std::vector<Smooth_periodic_function<double>*> frg__)
 {
     PROFILE("sirius::symmetrize_pw_function");
@@ -95,14 +96,14 @@ symmetrize_pw_function(Crystal_symmetry const& sym__, fft::Gvec_shells const& gv
     std::array<std::vector<std::complex<double>>, 4> fpw_sym;
 
     /* local number of G-vectors in a distribution with complete G-vector shells */
-    int ngv = gvec_shells__.gvec_count_remapped();
+    int ngv = gvec_sym__.count();
 
-    for (int j = 0; j < num_mag_dims__ + 1; j++) {
-        fpw_remapped[j] = gvec_shells__.remap_forward(&frg__[j]->f_pw_local(0));
+    for (int j = 0; j < num_mag_dims + 1; j++) {
+        fpw_remapped[j] = gvec_sym__.remap_forward(&frg__[j]->f_pw_local(0));
         fpw_sym[j]      = std::vector<std::complex<double>>(ngv, 0);
     }
 
-    std::vector<bool> is_done(ngv, false);
+    std::vector<char> is_done(ngv, 0);
 
     double norm = 1 / double(sym__.size());
 
@@ -113,6 +114,16 @@ symmetrize_pw_function(Crystal_symmetry const& sym__, fft::Gvec_shells const& gv
 
     double const eps{1e-9};
 
+    //mdarray<int, 2> index_by_gvec({sym__.size(), ngv}, get_memory_pool(memory_t::host));
+    //#pragma omp parallel for
+    //for (int igloc = 0; igloc < ngv; igloc++) {
+    //    for (int i = 0; i < sym__.size(); i++) {
+    //        auto G = gvec_sym__.gvec_remapped(igloc);
+    //        auto G1 = r3::dot(G, sym__[i].spg_op.R);
+    //        index_by_gvec(i, igloc) = gvec_sym__.index_by_gvec(G1);
+    //    }
+    //}
+
     PROFILE_START("sirius::symmetrize|fpw|local");
 
     #pragma omp parallel
@@ -120,23 +131,28 @@ symmetrize_pw_function(Crystal_symmetry const& sym__, fft::Gvec_shells const& gv
         int nt  = omp_get_max_threads();
         int tid = omp_get_thread_num();
 
-        for (int igloc = 0; igloc < gvec_shells__.gvec_count_remapped(); igloc++) {
-            auto G = gvec_shells__.gvec_remapped(igloc);
+        double t0;
+        double ta{0},tb{0};
 
-            int igsh = gvec_shells__.gvec_shell_remapped(igloc);
+        for (int igloc = 0; igloc < ngv; igloc++) {
+            auto G = gvec_sym__.gvec_remapped(igloc);
+
+            int igsh = gvec_sym__.gvec_shell_remapped(igloc);
 
 #if !defined(NDEBUG)
-            if (igsh != gvec_shells__.gvec().shell(G)) {
+            if (igsh != gvec_sym__.gvec().shell(G)) {
                 std::stringstream s;
                 s << "wrong index of G-shell" << std::endl
                   << "  G-vector : " << G << std::endl
                   << "  igsh in the remapped set : " << igsh << std::endl
-                  << "  igsh in the original set : " << gvec_shells__.gvec().shell(G);
+                  << "  igsh in the original set : " << gvec_sym__.gvec().shell(G);
                 RTE_THROW(s);
             }
 #endif
             /* each thread is working on full shell of G-vectors */
             if (igsh % nt == tid && !is_done[igloc]) {
+
+                t0 = omp_get_wtime();
 
                 std::complex<double> symf(0, 0);
                 std::complex<double> symx(0, 0);
@@ -148,12 +164,13 @@ symmetrize_pw_function(Crystal_symmetry const& sym__, fft::Gvec_shells const& gv
                 for (int i = 0; i < sym__.size(); i++) {
                     auto G1 = r3::dot(G, sym__[i].spg_op.R);
 
-                    auto S = sym__[i].spin_rotation;
+                    auto const& S = sym__[i].spin_rotation;
 
                     auto phase = std::conj(phase_factor(i, G));
 
                     /* local index of a rotated G-vector */
-                    int ig1 = gvec_shells__.index_by_gvec(G1);
+                    int ig1 = gvec_sym__.index_by_gvec(G1);
+                    //int ig1 = index_by_gvec(i, igloc);
 
                     bool conj_coeff{false};
 
@@ -161,55 +178,71 @@ symmetrize_pw_function(Crystal_symmetry const& sym__, fft::Gvec_shells const& gv
                     if (ig1 == -1) {
                         G1         = G1 * (-1);
                         conj_coeff = true;
+                        ig1 = gvec_sym__.index_by_gvec(G1);
                     }
-                    auto do_conj = (conj_coeff) ? [](std::complex<double> z) { return std::conj(z); }
-                                                : [](std::complex<double> z) { return z; };
 #if !defined(NDEBUG)
-                    if (igsh != gvec_shells__.gvec().shell(G1)) {
+                    if (igsh != gvec_sym__.gvec().shell(G1)) {
                         std::stringstream s;
                         s << "wrong index of G-shell" << std::endl
                           << "  index of G-shell : " << igsh << std::endl
                           << "  symmetry operation : " << sym__[i].spg_op.R << std::endl
                           << "  G-vector : " << G << std::endl
                           << "  rotated G-vector : " << G1 << std::endl
-                          << "  G-vector index : " << gvec_shells__.index_by_gvec(G1) << std::endl
-                          << "  index of rotated G-vector shell : " << gvec_shells__.gvec().shell(G1);
+                          << "  G-vector index : " << gvec_sym__.index_by_gvec(G1) << std::endl
+                          << "  index of rotated G-vector shell : " << gvec_sym__.gvec().shell(G1);
                         RTE_THROW(s);
                     }
 #endif
-                    ig1 = gvec_shells__.index_by_gvec(G1);
                     RTE_ASSERT(ig1 >= 0 && ig1 < ngv);
 
                     if (frg__[0]) {
-                        symf += do_conj(fpw_remapped[0][ig1]) * phase;
+                        auto val = fpw_remapped[0][ig1];
+                        if (conj_coeff) {
+                            val = std::conj(val);
+                        }
+                        symf += val * phase;
                     }
-                    if (num_mag_dims__ == 1 && frg__[1]) {
-                        symz += do_conj(fpw_remapped[1][ig1]) * phase * S(2, 2);
+                    if (num_mag_dims == 1 && frg__[1]) {
+                        auto val = fpw_remapped[1][ig1];
+                        if (conj_coeff) {
+                            val = std::conj(val);
+                        }
+                        symz += val * phase * S(2, 2);
                     }
-                    if (num_mag_dims__ == 3) {
+                    if (num_mag_dims == 3) {
                         auto v =
                                 r3::dot(S, r3::vector<std::complex<double>>(
                                                    {fpw_remapped[1][ig1], fpw_remapped[2][ig1], fpw_remapped[3][ig1]}));
-                        symx += do_conj(v[0]) * phase;
-                        symy += do_conj(v[1]) * phase;
-                        symz += do_conj(v[2]) * phase;
+                        if (conj_coeff) {
+                            v[0] = std::conj(v[0]);
+                            v[1] = std::conj(v[1]);
+                            v[2] = std::conj(v[2]);
+                        }
+                        symx += v[0] * phase;
+                        symy += v[1] * phase;
+                        symz += v[2] * phase;
                     }
                 } /* loop over symmetries */
+
+                ta += (omp_get_wtime() - t0);
 
                 symf *= norm;
                 symx *= norm;
                 symy *= norm;
                 symz *= norm;
 
+                t0 = omp_get_wtime();
+
                 /* apply symmetry operation and get all other plane-wave coefficients */
 
                 for (int isym = 0; isym < sym__.size(); isym++) {
-                    auto S = sym__[isym].spin_rotation;
+                    auto const& S = sym__[isym].spin_rotation;
 
                     /* get rotated G-vector */
                     auto G1 = r3::dot(sym__[isym].spg_op.invRT, G);
                     /* index of a rotated G-vector */
-                    int ig1 = gvec_shells__.index_by_gvec(G1);
+                    int ig1 = gvec_sym__.index_by_gvec(G1);
+                    //int ig1 = index_by_gvec(isym, igloc);
 
                     if (ig1 != -1) {
                         RTE_ASSERT(ig1 >= 0 && ig1 < ngv);
@@ -218,10 +251,10 @@ symmetrize_pw_function(Crystal_symmetry const& sym__, fft::Gvec_shells const& gv
                         if (frg__[0]) {
                             symf1 = symf * phase;
                         }
-                        if (num_mag_dims__ == 1 && frg__[1]) {
+                        if (num_mag_dims == 1 && frg__[1]) {
                             symz1 = symz * phase * S(2, 2);
                         }
-                        if (num_mag_dims__ == 3) {
+                        if (num_mag_dims == 3) {
                             auto v = r3::dot(S, r3::vector<std::complex<double>>({symx, symy, symz}));
                             symx1  = v[0] * phase;
                             symy1  = v[1] * phase;
@@ -229,6 +262,7 @@ symmetrize_pw_function(Crystal_symmetry const& sym__, fft::Gvec_shells const& gv
                         }
 
                         if (is_done[ig1]) {
+#if !defined(NDEBUG)
                             /* run checks */
                             if (frg__[0]) {
                                 /* check that another symmetry operation leads to the same coefficient */
@@ -241,7 +275,7 @@ symmetrize_pw_function(Crystal_symmetry const& sym__, fft::Gvec_shells const& gv
                                     RTE_THROW(s);
                                 }
                             }
-                            if (num_mag_dims__ == 1 && frg__[1]) {
+                            if (num_mag_dims == 1 && frg__[1]) {
                                 if (abs_diff(fpw_sym[1][ig1], symz1) > eps) {
                                     std::stringstream s;
                                     s << "inconsistent symmetry operation" << std::endl
@@ -251,42 +285,45 @@ symmetrize_pw_function(Crystal_symmetry const& sym__, fft::Gvec_shells const& gv
                                     RTE_THROW(s);
                                 }
                             }
-                            if (num_mag_dims__ == 3) {
+                            if (num_mag_dims == 3) {
                                 if (abs_diff(fpw_sym[1][ig1], symx1) > eps || abs_diff(fpw_sym[2][ig1], symy1) > eps ||
                                     abs_diff(fpw_sym[3][ig1], symz1) > eps) {
 
                                     RTE_THROW("inconsistent symmetry operation");
                                 }
                             }
+#endif
                         } else {
                             if (frg__[0]) {
                                 fpw_sym[0][ig1] = symf1;
                             }
-                            if (num_mag_dims__ == 1 && frg__[1]) {
+                            if (num_mag_dims == 1 && frg__[1]) {
                                 fpw_sym[1][ig1] = symz1;
                             }
-                            if (num_mag_dims__ == 3) {
+                            if (num_mag_dims == 3) {
                                 fpw_sym[1][ig1] = symx1;
                                 fpw_sym[2][ig1] = symy1;
                                 fpw_sym[3][ig1] = symz1;
                             }
-                            is_done[ig1] = true;
+                            is_done[ig1] = 1;
                         }
                     }
                 } /* loop over symmetries */
+                tb += (omp_get_wtime() - t0);
             }
         } /* loop over igloc */
+        std::cout << "thread : " << tid << ", ta : " << ta << ", tb : " << tb << std::endl;
     }
     PROFILE_STOP("sirius::symmetrize|fpw|local");
 
 #if !defined(NDEBUG)
-    for (int igloc = 0; igloc < gvec_shells__.gvec_count_remapped(); igloc++) {
-        auto G = gvec_shells__.gvec_remapped(igloc);
+    for (int igloc = 0; igloc < ngv; igloc++) {
+        auto G = gvec_sym__.gvec_remapped(igloc);
         for (int isym = 0; isym < sym__.size(); isym++) {
             auto S      = sym__[isym].spin_rotation;
             auto gv_rot = r3::dot(sym__[isym].spg_op.invRT, G);
             /* index of a rotated G-vector */
-            int ig_rot                 = gvec_shells__.index_by_gvec(gv_rot);
+            int ig_rot                 = gvec_sym__.index_by_gvec(gv_rot);
             std::complex<double> phase = std::conj(phase_factor(isym, gv_rot));
 
             if (frg__[0] && ig_rot != -1) {
@@ -297,7 +334,7 @@ symmetrize_pw_function(Crystal_symmetry const& sym__, fft::Gvec_shells const& gv
                     RTE_THROW(s);
                 }
             }
-            if (num_mag_dims__ == 1 && frg__[1] && ig_rot != -1) {
+            if (num_mag_dims == 1 && frg__[1] && ig_rot != -1) {
                 auto diff = abs_diff(fpw_sym[1][ig_rot], fpw_sym[1][igloc] * phase * S(2, 2));
                 if (diff > eps) {
                     std::stringstream s;
@@ -309,8 +346,171 @@ symmetrize_pw_function(Crystal_symmetry const& sym__, fft::Gvec_shells const& gv
     }
 #endif
 
-    for (int j = 0; j < num_mag_dims__ + 1; j++) {
-        gvec_shells__.remap_backward(fpw_sym[j], &frg__[j]->f_pw_local(0));
+    for (int j = 0; j < num_mag_dims + 1; j++) {
+        gvec_sym__.remap_backward(fpw_sym[j], &frg__[j]->f_pw_local(0));
+    }
+}
+
+template <int num_mag_dims>
+inline void
+symmetrize_pw_function_impl_v2(Crystal_symmetry const& sym__, fft::Gvec_sym const& gvec_sym__,
+                       mdarray<std::complex<double>, 3> const& sym_phase_factors__,
+                       std::vector<Smooth_periodic_function<double>*> frg__)
+{
+    PROFILE("sirius::symmetrize_pw_function");
+
+    std::array<std::vector<std::complex<double>>, 4> fpw_remapped;
+    std::array<std::vector<std::complex<double>>, 4> fpw_sym;
+
+    /* local number of G-vectors in a distribution with complete G-vector shells */
+    int ngv = gvec_sym__.count();
+
+    for (int j = 0; j < num_mag_dims + 1; j++) {
+        fpw_remapped[j] = gvec_sym__.remap_forward(&frg__[j]->f_pw_local(0));
+        fpw_sym[j]      = std::vector<std::complex<double>>(ngv, 0);
+    }
+
+    std::vector<char> is_done(ngv, 0);
+
+    double norm = 1 / double(sym__.size());
+
+    auto phase_factor = [&](int isym, r3::vector<int> G) {
+        return sym_phase_factors__(0, G[0], isym) * sym_phase_factors__(1, G[1], isym) *
+               sym_phase_factors__(2, G[2], isym);
+    };
+
+    double const eps{1e-9};
+
+    PROFILE_START("sirius::symmetrize|fpw|local");
+
+    #pragma omp parallel for schedule(static,1)
+    for (auto& e : gvec_sym__.gvec_shells()) {
+
+        std::unordered_map<r3::vector<int>, char, fft::r3_int_hash> is_done;
+        for (auto igloc : e) {
+            auto G = gvec_sym__.gvec_remapped(igloc);
+            is_done[G] = igloc;
+        }
+
+        for (auto igloc : e) {
+            // loop over shells of G-vectors
+            std::complex<double> symf(0, 0);
+            std::complex<double> symx(0, 0);
+            std::complex<double> symy(0, 0);
+            std::complex<double> symz(0, 0);
+
+            auto G = gvec_sym__.gvec_remapped(igloc);
+            if (is_done[G]) {
+                continue;
+            }
+
+            /* find the symmetrized PW coefficient */
+            for (int isym = 0; isym < sym__.size(); isym++) {
+                auto G1 = r3::dot(G, sym__[isym].spg_op.R);
+
+                auto const& S = sym__[isym].spin_rotation;
+
+                auto phase = std::conj(phase_factor(isym, G));
+
+                /* local index of a rotated G-vector */
+                int ig1 = gvec_sym__.index_by_gvec(G1);
+
+                bool conj_coeff{false};
+
+                /* check the reduced G-vector */
+                if (ig1 == -1) {
+                    G1         = G1 * (-1);
+                    conj_coeff = true;
+                    ig1 = gvec_sym__.index_by_gvec(G1);
+                }
+                RTE_ASSERT(ig1 >= 0 && ig1 < ngv);
+
+                if (frg__[0]) {
+                    auto val = fpw_remapped[0][ig1];
+                    if (conj_coeff) {
+                        val = std::conj(val);
+                    }
+                    symf += val * phase;
+                }
+                if (num_mag_dims == 1 && frg__[1]) {
+                    auto val = fpw_remapped[1][ig1];
+                    if (conj_coeff) {
+                        val = std::conj(val);
+                    }
+                    symz += val * phase * S(2, 2);
+                }
+                if (num_mag_dims == 3) {
+                    auto v =
+                            r3::dot(S, r3::vector<std::complex<double>>(
+                                               {fpw_remapped[1][ig1], fpw_remapped[2][ig1], fpw_remapped[3][ig1]}));
+                    if (conj_coeff) {
+                        v[0] = std::conj(v[0]);
+                        v[1] = std::conj(v[1]);
+                        v[2] = std::conj(v[2]);
+                    }
+                    symx += v[0] * phase;
+                    symy += v[1] * phase;
+                    symz += v[2] * phase;
+                }
+            } /* loop over symmetries */
+
+            symf *= norm;
+            symx *= norm;
+            symy *= norm;
+            symz *= norm;
+
+            /* apply symmetry operation and get all other plane-wave coefficients */
+            for (int isym = 0; isym < sym__.size(); isym++) {
+                auto const& S = sym__[isym].spin_rotation;
+
+                /* get rotated G-vector */
+                auto G1 = r3::dot(sym__[isym].spg_op.invRT, G);
+                /* index of a rotated G-vector */
+                int ig1 = gvec_sym__.index_by_gvec(G1);
+
+                if (ig1 != -1) {
+                    RTE_ASSERT(ig1 >= 0 && ig1 < ngv);
+                    if (!is_done[G1]) {
+                        auto phase = std::conj(phase_factor(isym, G1));
+
+                        if (frg__[0]) {
+                            fpw_sym[0][ig1] = symf * phase;
+                        }
+                        if (num_mag_dims == 1 && frg__[1]) {
+                            fpw_sym[1][ig1] = symz * phase * S(2, 2);
+                        }
+                        if (num_mag_dims == 3) {
+                            auto v = r3::dot(S, r3::vector<std::complex<double>>({symx, symy, symz}));
+                            fpw_sym[1][ig1] = v[0] * phase;
+                            fpw_sym[2][ig1] = v[1] * phase;
+                            fpw_sym[3][ig1] = v[2] * phase;
+                        }
+                        is_done[G1] = 1;
+                    }
+                }
+            } /* loop over symmetries */
+        } /* loop over igloc */
+    }
+    PROFILE_STOP("sirius::symmetrize|fpw|local");
+
+    for (int j = 0; j < num_mag_dims + 1; j++) {
+        gvec_sym__.remap_backward(fpw_sym[j], &frg__[j]->f_pw_local(0));
+    }
+}
+
+inline void
+symmetrize_pw_function(Crystal_symmetry const& sym__, fft::Gvec_sym const& gvec_sym__,
+                       mdarray<std::complex<double>, 3> const& sym_phase_factors__, int num_mag_dims__,
+                       std::vector<Smooth_periodic_function<double>*> frg__)
+{
+    if (num_mag_dims__ == 0) {
+        symmetrize_pw_function_impl_v2<0>(sym__, gvec_sym__, sym_phase_factors__, frg__);
+    }
+    if (num_mag_dims__ == 1) {
+        symmetrize_pw_function_impl_v2<1>(sym__, gvec_sym__, sym_phase_factors__, frg__);
+    }
+    if (num_mag_dims__ == 3) {
+        symmetrize_pw_function_impl_v2<3>(sym__, gvec_sym__, sym_phase_factors__, frg__);
     }
 }
 

--- a/src/symmetry/symmetrize_pw_function.hpp
+++ b/src/symmetry/symmetrize_pw_function.hpp
@@ -370,8 +370,6 @@ symmetrize_pw_function_impl_v2(Crystal_symmetry const& sym__, fft::Gvec_sym cons
         fpw_sym[j]      = std::vector<std::complex<double>>(ngv, 0);
     }
 
-    std::vector<char> is_done(ngv, 0);
-
     double norm = 1 / double(sym__.size());
 
     auto phase_factor = [&](int isym, r3::vector<int> G) {
@@ -389,7 +387,7 @@ symmetrize_pw_function_impl_v2(Crystal_symmetry const& sym__, fft::Gvec_sym cons
         std::unordered_map<r3::vector<int>, char, fft::r3_int_hash> is_done;
         for (auto igloc : e) {
             auto G = gvec_sym__.gvec_remapped(igloc);
-            is_done[G] = igloc;
+            is_done[G] = 0;
         }
 
         for (auto igloc : e) {

--- a/src/symmetry/symmetrize_pw_function.hpp
+++ b/src/symmetry/symmetrize_pw_function.hpp
@@ -84,7 +84,7 @@ namespace sirius {
     \param [in] num_mag_dims      Number of magnetic dimensions.
     \param [inout] frg            Array of pointers to scalar and vector parts of the filed being symmetrized.
  */
-template <int num_mag_dims>
+template <int num_mag_dims> /* keep this variant for verification */
 inline void
 symmetrize_pw_function_impl(Crystal_symmetry const& sym__, fft::Gvec_sym const& gvec_sym__,
                             mdarray<std::complex<double>, 3> const& sym_phase_factors__,
@@ -114,25 +114,12 @@ symmetrize_pw_function_impl(Crystal_symmetry const& sym__, fft::Gvec_sym const& 
 
     double const eps{1e-9};
 
-    //mdarray<int, 2> index_by_gvec({sym__.size(), ngv}, get_memory_pool(memory_t::host));
-    //#pragma omp parallel for
-    //for (int igloc = 0; igloc < ngv; igloc++) {
-    //    for (int i = 0; i < sym__.size(); i++) {
-    //        auto G = gvec_sym__.gvec_remapped(igloc);
-    //        auto G1 = r3::dot(G, sym__[i].spg_op.R);
-    //        index_by_gvec(i, igloc) = gvec_sym__.index_by_gvec(G1);
-    //    }
-    //}
-
     PROFILE_START("sirius::symmetrize|fpw|local");
 
     #pragma omp parallel
     {
         int nt  = omp_get_max_threads();
         int tid = omp_get_thread_num();
-
-        double t0;
-        double ta{0}, tb{0};
 
         for (int igloc = 0; igloc < ngv; igloc++) {
             auto G = gvec_sym__.gvec_remapped(igloc);
@@ -152,8 +139,6 @@ symmetrize_pw_function_impl(Crystal_symmetry const& sym__, fft::Gvec_sym const& 
             /* each thread is working on full shell of G-vectors */
             if (igsh % nt == tid && !is_done[igloc]) {
 
-                t0 = omp_get_wtime();
-
                 std::complex<double> symf(0, 0);
                 std::complex<double> symx(0, 0);
                 std::complex<double> symy(0, 0);
@@ -170,7 +155,6 @@ symmetrize_pw_function_impl(Crystal_symmetry const& sym__, fft::Gvec_sym const& 
 
                     /* local index of a rotated G-vector */
                     int ig1 = gvec_sym__.index_by_gvec(G1);
-                    //int ig1 = index_by_gvec(i, igloc);
 
                     bool conj_coeff{false};
 
@@ -224,17 +208,12 @@ symmetrize_pw_function_impl(Crystal_symmetry const& sym__, fft::Gvec_sym const& 
                     }
                 } /* loop over symmetries */
 
-                ta += (omp_get_wtime() - t0);
-
                 symf *= norm;
                 symx *= norm;
                 symy *= norm;
                 symz *= norm;
 
-                t0 = omp_get_wtime();
-
                 /* apply symmetry operation and get all other plane-wave coefficients */
-
                 for (int isym = 0; isym < sym__.size(); isym++) {
                     auto const& S = sym__[isym].spin_rotation;
 
@@ -309,10 +288,8 @@ symmetrize_pw_function_impl(Crystal_symmetry const& sym__, fft::Gvec_sym const& 
                         }
                     }
                 } /* loop over symmetries */
-                tb += (omp_get_wtime() - t0);
             }
         } /* loop over igloc */
-        std::cout << "thread : " << tid << ", ta : " << ta << ", tb : " << tb << std::endl;
     }
     PROFILE_STOP("sirius::symmetrize|fpw|local");
 

--- a/src/symmetry/symmetrize_stress_tensor.hpp
+++ b/src/symmetry/symmetrize_stress_tensor.hpp
@@ -18,6 +18,17 @@
 
 namespace sirius {
 
+/// Symmetrize the lattice stress tensor with the crystal point-group operations.
+/** Applies the group average
+    \f[
+        \sigma_{\mathrm{sym}} = \frac{1}{N_{sym}} \sum_R R^T \sigma R
+    \f]
+    over the Cartesian rotation matrices of the crystal symmetry group.
+    The result is then explicitly made symmetric in the off-diagonal components.
+
+    \param [in] sym Crystal symmetry operations.
+    \param [in,out] s Stress tensor to symmetrize.
+ */
 inline void
 symmetrize_stress_tensor(Crystal_symmetry const& sym__, r3::matrix<double>& s__)
 {


### PR DESCRIPTION
Major fix:
- performance fix in symmetrization routine; symmetrize_pw_function() is rewritten for better OMP parallelization 

Minor fixes:
- added simple zgemm test in test_wf_inner.cpp in case of single MPI rank
- remove last bits of fftw flags and update sirius API
- rename Gvec_shells -> Gvec_sym to highlight the purpose of the class
- rename Gvec_sym::gvec_count_remapped() -> Gvec_sym::count() to be aligned with Gvec class
- use unordered_map to get index by G-vector