### PR TITLE
[feature] improve storage and generation of matching coefficients

### DIFF
--- a/apps/tests/CMakeLists.txt
+++ b/apps/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ test_mem_pool;test_mem_alloc;test_examples;test_mpi_p2p_cyclic;test_pw_sph_exp;t
 test_wf_ortho;test_mixer;test_davidson;test_lapw_xc;test_phase;test_fp;test_pppw_xc;\
 test_atomic_orbital_index;test_sym;test_blacs;test_reduce;test_mpi_comm_split;test_wf_trans;\
 test_wf_fft;test_potrf;test_lr_solver;test_radial_solver;test_radial_dirac;test_radial_schroed;test_iter_gvec;\
-test_max_mem")
+test_max_mem;test_alm_copy")
 
 foreach(_test ${_tests})
   add_executable(${_test} ${_test}.cpp)

--- a/apps/tests/test_alm_copy.cpp
+++ b/apps/tests/test_alm_copy.cpp
@@ -46,9 +46,9 @@ template <typename T>
 int
 test_alm_copy_v2()
 {
-    size_t m = 200000; // number of G+k vectors
-    size_t n = 300;    // number of AW coefficients per atom
-    size_t k = 64;     // number of atoms in a block
+    int m = 200000; // number of G+k vectors
+    int n = 300;    // number of AW coefficients per atom
+    int k = 64;     // number of atoms in a block
 
     auto& mp = get_memory_pool(memory_t::host_pinned);
 

--- a/apps/tests/test_alm_copy.cpp
+++ b/apps/tests/test_alm_copy.cpp
@@ -11,35 +11,109 @@
 
 using namespace sirius;
 
+/* use std::vector */
+template <typename T>
 int
 test_alm_copy()
 {
     size_t m = 200000;
     size_t n = 300;
-    size_t k = 20;
-    std::vector<std::complex<double>> v1(m * n * k, 1.0);
-    std::vector<std::complex<double>> v2(v1.size(), 2.0);
+    size_t k = 64;
+    std::vector<T> v1(m * n * k, 1.0);
+    std::vector<T> v2(v1.size(), 2.0);
 
     for (int repeat = 0; repeat < 4; repeat++) {
         double t = omp_get_wtime();
         #pragma omp parallel
         {
-            //int tid = omp_get_thread_num();
             #pragma omp for schedule(static, 1)
             for (int i = 0; i < k; i++) {
-                auto ptr_in = &v1[m * n * i];
+                auto ptr_in  = &v1[m * n * i];
                 auto ptr_out = &v2[m * n * i];
                 std::copy(ptr_in, ptr_in + m * n, ptr_out);
             }
         }
-        t = (omp_get_wtime() - t);
-        std::cout << "repeat : " << repeat << ", effective BW : " << 2 * v1.size() * sizeof(std::complex<double>) / t / (1 << 30) << " GB/s" << std::endl;
+        t          = omp_get_wtime() - t;
+        auto bytes = 2.0 * v1.size() * sizeof(T);
+        std::cout << "repeat : " << repeat << ", time : " << t << ", effective BW : " << bytes / t / (1 << 30)
+                  << " GB/s" << std::endl;
     }
+    return 0;
+}
+
+/* use host-pinned memory */
+template <typename T>
+int
+test_alm_copy_v2()
+{
+    size_t m = 200000; // number of G+k vectors
+    size_t n = 300;    // number of AW coefficients per atom
+    size_t k = 64;     // number of atoms in a block
+
+    auto& mp = get_memory_pool(memory_t::host_pinned);
+
+    mdarray<T, 2> alm_all({m, n * k}, mp, mdarray_label("alm_all"));
+    mdarray<T, 2> alm_blk({m, n * k}, mp, mdarray_label("alm_blk"));
+
+    #pragma omp parallel for
+    for (size_t i = 0; i < alm_all.size(); i++) {
+        alm_all[i] = 1;
+        alm_blk[i] = 0;
+    }
+
+    for (int repeat = 0; repeat < 4; repeat++) {
+        double t = omp_get_wtime();
+
+        #pragma omp parallel
+        {
+            #pragma omp for schedule(static, 1)
+            for (int ia = 0; ia < static_cast<int>(k); ia++) {
+                auto ptr_in  = alm_all.at(memory_t::host, 0, n * ia);
+                auto ptr_out = alm_blk.at(memory_t::host, 0, n * ia);
+
+                std::copy(ptr_in, ptr_in + m * n, ptr_out);
+            }
+        }
+
+        t = omp_get_wtime() - t;
+
+        auto bytes = 2.0 * alm_all.size() * sizeof(T);
+        std::cout << "copy repeat : " << repeat << ", time : " << t << ", effective BW : " << bytes / t / (1 << 30)
+                  << " GB/s" << std::endl;
+    }
+
+    for (int repeat = 0; repeat < 4; repeat++) {
+        double t = omp_get_wtime();
+
+        #pragma omp parallel
+        {
+            #pragma omp for schedule(static, 1)
+            for (int ia = 0; ia < static_cast<int>(k); ia++) {
+                auto ptr_in  = alm_all.at(memory_t::host, 0, n * ia);
+                auto ptr_out = alm_blk.at(memory_t::host, 0, n * ia);
+
+                for (size_t j = 0; j < m * n; j++) {
+                    ptr_out[j] = conj(ptr_in[j]);
+                }
+            }
+        }
+
+        t = omp_get_wtime() - t;
+
+        auto bytes = 2.0 * alm_all.size() * sizeof(std::complex<double>);
+        std::cout << "copy+conj repeat : " << repeat << ", effective BW : " << bytes / t / (1 << 30) << " GB/s"
+                  << std::endl;
+    }
+
     return 0;
 }
 
 int
 main(int argn, char** argv)
 {
-    return call_test("test_alm_copy", test_alm_copy);
+    call_test("test_alm_copy v1 double", test_alm_copy<double>);
+    call_test("test_alm_copy v1 double_complex", test_alm_copy<std::complex<double>>);
+    call_test("test_alm_copy v2 double", test_alm_copy_v2<double>);
+    call_test("test_alm_copy v2 double_complex", test_alm_copy_v2<std::complex<double>>);
+    return 0;
 }

--- a/apps/tests/test_alm_copy.cpp
+++ b/apps/tests/test_alm_copy.cpp
@@ -1,0 +1,45 @@
+/* This file is part of SIRIUS electronic structure library.
+ *
+ * Copyright (c), ETH Zurich.  All rights reserved.
+ *
+ * Please, refer to the LICENSE file in the root directory.
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include <sirius.hpp>
+#include <testing.hpp>
+
+using namespace sirius;
+
+int
+test_alm_copy()
+{
+    size_t m = 200000;
+    size_t n = 300;
+    size_t k = 20;
+    std::vector<std::complex<double>> v1(m * n * k, 1.0);
+    std::vector<std::complex<double>> v2(v1.size(), 2.0);
+
+    for (int repeat = 0; repeat < 4; repeat++) {
+        double t = omp_get_wtime();
+        #pragma omp parallel
+        {
+            //int tid = omp_get_thread_num();
+            #pragma omp for schedule(static, 1)
+            for (int i = 0; i < k; i++) {
+                auto ptr_in = &v1[m * n * i];
+                auto ptr_out = &v2[m * n * i];
+                std::copy(ptr_in, ptr_in + m * n, ptr_out);
+            }
+        }
+        t = (omp_get_wtime() - t);
+        std::cout << "repeat : " << repeat << ", effective BW : " << 2 * v1.size() * sizeof(std::complex<double>) / t / (1 << 30) << " GB/s" << std::endl;
+    }
+    return 0;
+}
+
+int
+main(int argn, char** argv)
+{
+    return call_test("test_alm_copy", test_alm_copy);
+}

--- a/apps/tests/test_memop.cpp
+++ b/apps/tests/test_memop.cpp
@@ -22,34 +22,41 @@ memcpy_simple_1(char* dest__, char* src__, size_t n__)
 int
 test_memop()
 {
-    int n = 20000000;
+    size_t n = 2000 * 1000 * 1000;
     std::vector<double> v1(n, 1.0);
     std::vector<double> v2(n, 2.0);
 
-    double t = -omp_get_wtime();
-    std::memcpy(&v1[0], &v2[0], n * sizeof(double));
-    t += omp_get_wtime();
-    printf("memcpy(stdlib) bandwidth: %f GB/s \n", double(2 * n * sizeof(double)) / t / (1 << 30));
+    std::cout << "total size : " << v1.size() * sizeof(double) / 1024 / 1024 / 1024.0 << " GB" << std::endl;
 
-    t = -omp_get_wtime();
-    memcpy_simple_1((char*)&v1[0], (char*)&v2[0], n * sizeof(double));
-    t += omp_get_wtime();
-    printf("memcpy(simple) bandwidth: %f GB/s \n", double(2 * n * sizeof(double)) / t / (1 << 30));
+    for (int i = 0; i < 4; i++) {
+        std::cout << "pass : " << i << std::endl;
+        double t = -omp_get_wtime();
+        std::memcpy(&v1[0], &v2[0], n * sizeof(double));
+        t += omp_get_wtime();
+        std::cout << "memcpy(stdlib) time : " << t <<", bandwidth: " << 2 * n * sizeof(double) / t / (1 << 30) << "GB/s" << std::endl;
 
-    t = -omp_get_wtime();
-    std::copy(v2.begin(), v2.end(), v1.begin());
-    t += omp_get_wtime();
-    printf("std::copy bandwidth     : %f GB/s \n", double(2 * n * sizeof(double)) / t / (1 << 30));
+        t = -omp_get_wtime();
+        memcpy_simple_1((char*)&v1[0], (char*)&v2[0], n * sizeof(double));
+        t += omp_get_wtime();
+        std::cout << "memcpy(simple) time : " << t <<", bandwidth: " << 2 * n * sizeof(double) / t / (1 << 30) << "GB/s" << std::endl;
 
-    t = -omp_get_wtime();
-    std::memset(&v1[0], 0, n * sizeof(double));
-    t += omp_get_wtime();
-    printf("memset(stdlib) bandwidth: %f GB/s \n", double(n * sizeof(double)) / t / (1 << 30));
+        t = -omp_get_wtime();
+        std::copy(v2.begin(), v2.end(), v1.begin());
+        t += omp_get_wtime();
+        std::cout << "std::copy time : " << t <<", bandwidth: " << 2 * n * sizeof(double) / t / (1 << 30) << "GB/s" << std::endl;
 
-    t = -omp_get_wtime();
-    std::fill(v1.begin(), v1.end(), 0.0);
-    t += omp_get_wtime();
-    printf("std::fill bandwidth     : %f GB/s \n", double(n * sizeof(double)) / t / (1 << 30));
+        t = -omp_get_wtime();
+        std::memset(&v1[0], 0, n * sizeof(double));
+        t += omp_get_wtime();
+        std::cout << "memset(stdlib) time : " << t <<", bandwidth: " << n * sizeof(double) / t / (1 << 30) << "GB/s" << std::endl;
+
+        t = -omp_get_wtime();
+        std::fill(v1.begin(), v1.end(), 0.0);
+        t += omp_get_wtime();
+        std::cout << "std::fill time : " << t <<", bandwidth: " << n * sizeof(double) / t / (1 << 30) << "GB/s" << std::endl;
+
+        std::cout << std::endl;
+    }
 
     return 0;
 }

--- a/apps/tests/test_memop.cpp
+++ b/apps/tests/test_memop.cpp
@@ -33,27 +33,32 @@ test_memop()
         double t = -omp_get_wtime();
         std::memcpy(&v1[0], &v2[0], n * sizeof(double));
         t += omp_get_wtime();
-        std::cout << "memcpy(stdlib) time : " << t <<", bandwidth: " << 2 * n * sizeof(double) / t / (1 << 30) << "GB/s" << std::endl;
+        std::cout << "memcpy(stdlib) time : " << t << ", bandwidth: " << 2 * n * sizeof(double) / t / (1 << 30)
+                  << "GB/s" << std::endl;
 
         t = -omp_get_wtime();
         memcpy_simple_1((char*)&v1[0], (char*)&v2[0], n * sizeof(double));
         t += omp_get_wtime();
-        std::cout << "memcpy(simple) time : " << t <<", bandwidth: " << 2 * n * sizeof(double) / t / (1 << 30) << "GB/s" << std::endl;
+        std::cout << "memcpy(simple) time : " << t << ", bandwidth: " << 2 * n * sizeof(double) / t / (1 << 30)
+                  << "GB/s" << std::endl;
 
         t = -omp_get_wtime();
         std::copy(v2.begin(), v2.end(), v1.begin());
         t += omp_get_wtime();
-        std::cout << "std::copy time : " << t <<", bandwidth: " << 2 * n * sizeof(double) / t / (1 << 30) << "GB/s" << std::endl;
+        std::cout << "std::copy time : " << t << ", bandwidth: " << 2 * n * sizeof(double) / t / (1 << 30) << "GB/s"
+                  << std::endl;
 
         t = -omp_get_wtime();
         std::memset(&v1[0], 0, n * sizeof(double));
         t += omp_get_wtime();
-        std::cout << "memset(stdlib) time : " << t <<", bandwidth: " << n * sizeof(double) / t / (1 << 30) << "GB/s" << std::endl;
+        std::cout << "memset(stdlib) time : " << t << ", bandwidth: " << n * sizeof(double) / t / (1 << 30) << "GB/s"
+                  << std::endl;
 
         t = -omp_get_wtime();
         std::fill(v1.begin(), v1.end(), 0.0);
         t += omp_get_wtime();
-        std::cout << "std::fill time : " << t <<", bandwidth: " << n * sizeof(double) / t / (1 << 30) << "GB/s" << std::endl;
+        std::cout << "std::fill time : " << t << ", bandwidth: " << n * sizeof(double) / t / (1 << 30) << "GB/s"
+                  << std::endl;
 
         std::cout << std::endl;
     }

--- a/src/beta_projectors/beta_projectors_base.cpp
+++ b/src/beta_projectors/beta_projectors_base.cpp
@@ -140,19 +140,15 @@ Beta_projectors_base<T>::split_in_chunks()
         return;
     }
 
-    /* initial chunk size */
-    int chunk_size = std::min(uc.num_atoms(), ctx_.cfg().control().beta_chunk_size());
-    /* maximum number of chunks */
-    int num_chunks = uc.num_atoms() / chunk_size + std::min(1, uc.num_atoms() % chunk_size);
-    /* final maximum chunk size */
-    chunk_size = uc.num_atoms() / num_chunks + std::min(1, uc.num_atoms() % num_chunks);
+    auto atom_chunks = split_in_blocks(uc.num_atoms(), ctx_.cfg().control().max_atom_chunk_size());
 
     int offset_in_beta_gk{0};
-    beta_chunks_ = std::vector<beta_chunk_t>(num_chunks);
+    beta_chunks_ = std::vector<beta_chunk_t>(atom_chunks.size());
 
-    for (int ib = 0; ib < num_chunks; ib++) {
+    int begin_atom{0};
+    for (int ib = 0; ib < static_cast<int>(atom_chunks.size()); ib++) {
         /* number of atoms in this chunk */
-        int na                      = std::min(uc.num_atoms(), (ib + 1) * chunk_size) - ib * chunk_size;
+        int na                      = atom_chunks[ib];
         beta_chunks_[ib].num_atoms_ = na;
         beta_chunks_[ib].desc_      = mdarray<int, 2>({4, na});
         beta_chunks_[ib].atom_pos_  = mdarray<double, 2>({3, na});
@@ -160,7 +156,7 @@ Beta_projectors_base<T>::split_in_chunks()
         int num_beta{0};
         for (int i = 0; i < na; i++) {
             /* global index of atom by local index and chunk */
-            int ia     = ib * chunk_size + i;
+            int ia     = begin_atom + i;
             auto pos   = uc.atom(ia).position();
             auto& type = uc.atom(ia).type();
             /* atom fractional coordinates */
@@ -178,6 +174,7 @@ Beta_projectors_base<T>::split_in_chunks()
 
             num_beta += type.mt_basis_size();
         }
+        begin_atom += na;
         /* number of beta-projectors in this chunk */
         beta_chunks_[ib].num_beta_ = num_beta;
         beta_chunks_[ib].offset_   = offset_in_beta_gk;

--- a/src/context/config.hpp
+++ b/src/context/config.hpp
@@ -934,17 +934,17 @@ class config_t
             }
             dict_["/control/use_second_variation"_json_pointer] = use_second_variation__;
         }
-        /// Number of atoms in a chunk of beta-projectors.
-        inline auto beta_chunk_size() const
+        /// Maximum number of atoms per chunk when splitting the full atom index.
+        inline auto max_atom_chunk_size() const
         {
-            return dict_.at("/control/beta_chunk_size"_json_pointer).get<int>();
+            return dict_.at("/control/max_atom_chunk_size"_json_pointer).get<int>();
         }
-        inline void beta_chunk_size(int beta_chunk_size__)
+        inline void max_atom_chunk_size(int max_atom_chunk_size__)
         {
             if (dict_.contains("locked")) {
                 throw std::runtime_error(locked_msg);
             }
-            dict_["/control/beta_chunk_size"_json_pointer] = beta_chunk_size__;
+            dict_["/control/max_atom_chunk_size"_json_pointer] = max_atom_chunk_size__;
         }
         /// True if whole set of beta-projectors can be allocated on device for the entire run.
         inline auto beta_on_device() const

--- a/src/context/input_schema.json
+++ b/src/context/input_schema.json
@@ -510,10 +510,10 @@
                     "default": true,
                     "title": "True if second-variational diagonalization is used in LAPW method."
                 },
-                "beta_chunk_size": {
+                "max_atom_chunk_size": {
                     "type": "integer",
-                    "default": 256,
-                    "title": "Number of atoms in a chunk of beta-projectors."
+                    "default": -1,
+                    "title": "Maximum number of atoms per chunk when splitting the full atom index."
                 },
                 "beta_on_device": {
                     "type": "boolean",

--- a/src/context/simulation_context.cpp
+++ b/src/context/simulation_context.cpp
@@ -250,6 +250,14 @@ Simulation_context::initialize()
         pw_cutoff(full_potential() ? 12 : 20);
     }
 
+    if (cfg().control().max_atom_chunk_size() == -1) {
+        if (full_potential()) {
+            cfg().control().max_atom_chunk_size(64);
+        } else {
+            cfg().control().max_atom_chunk_size(256);
+        }
+    }
+
     print_memory_usage(this->out(), FILE_LINE);
 
     /* initialize variables related to the unit cell */

--- a/src/core/memory.hpp
+++ b/src/core/memory.hpp
@@ -26,7 +26,7 @@
 #include <stdexcept>
 #include <cstdint>
 
-#ifdef SIRIUS_USE_MEMORY_POOL
+#if defined(SIRIUS_USE_MEMORY_POOL)
 #include <umpire/ResourceManager.hpp>
 #include <umpire/Allocator.hpp>
 #include <umpire/util/wrap_allocator.hpp>
@@ -84,6 +84,40 @@ inline constexpr bool
 is_device_memory(memory_t mem__)
 {
     return static_cast<unsigned int>(mem__) & 0b1000;
+}
+
+inline char const*
+memory_t_name(memory_t mem__)
+{
+    switch (mem__) {
+        case memory_t::none: {
+            return "none";
+        }
+        case memory_t::host: {
+            return "host";
+        }
+        case memory_t::host_pinned: {
+            return "host_pinned";
+        }
+        case memory_t::device: {
+            return "device";
+        }
+        case memory_t::managed: {
+            return "managed";
+        }
+    }
+    return "unknown";
+}
+
+inline void
+print_mdarray_allocation(size_t num_bytes__, char const* location__, char const* allocator__,
+                         std::string const& label__)
+{
+    size_t const one_gb = 1024ULL * 1024ULL * 1024ULL;
+    if (num_bytes__ > one_gb) {
+        std::cout << "mdarray allocation: " << static_cast<double>(num_bytes__) / one_gb << " Gb"
+                  << ", " << location__ << ", " << allocator__ << ", label: " << label__ << std::endl;
+    }
 }
 
 /// Get a memory type from a string.
@@ -165,14 +199,14 @@ allocate(size_t n__, memory_t M__)
             return static_cast<T*>(std::malloc(n__ * sizeof(T)));
         }
         case memory_t::host_pinned: {
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
             return acc::allocate_host<T>(n__);
 #else
             return nullptr;
 #endif
         }
         case memory_t::device: {
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
             return acc::allocate<T>(n__);
 #else
             return nullptr;
@@ -197,13 +231,13 @@ deallocate(void* ptr__, memory_t M__)
             break;
         }
         case memory_t::host_pinned: {
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
             acc::deallocate_host(ptr__);
 #endif
             break;
         }
         case memory_t::device: {
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
             acc::deallocate(ptr__);
 #endif
             break;
@@ -274,7 +308,7 @@ class memory_pool
     /// Type of memory that is handeled by this pool.
     memory_t M_;
 
-#ifdef SIRIUS_USE_MEMORY_POOL
+#if defined(SIRIUS_USE_MEMORY_POOL)
     /// Handler to umpire allocator.
     umpire::Allocator allocator_;
     /// Handler to umpire memory pool.
@@ -302,7 +336,7 @@ class memory_pool
                 break;
             }
             case memory_t::device: {
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
                 std::stringstream s;
                 s << "DEVICE::" << acc::get_device_id();
                 mem_type = s.str();
@@ -320,7 +354,7 @@ class memory_pool
                 break;
             }
         }
-#ifdef SIRIUS_USE_MEMORY_POOL
+#if defined(SIRIUS_USE_MEMORY_POOL)
         if (M_ != memory_t::none) {
             auto& rm         = umpire::ResourceManager::getInstance();
             this->allocator_ = rm.getAllocator(mem_type);
@@ -445,7 +479,7 @@ class memory_pool
 memory_pool&
 get_memory_pool(memory_t M__);
 
-#ifdef NDEBUG
+#if defined(NDEBUG)
 #define mdarray_assert(condition__)
 #else
 #define mdarray_assert(condition__)                                                                                    \
@@ -531,7 +565,7 @@ class index_range
     inline bool
     check_range([[maybe_unused]] index_type i__) const
     {
-#ifdef NDEBUG
+#if defined(NDEBUG)
         return true;
 #else
         if (i__ < begin_ || i__ >= end_) {
@@ -585,7 +619,7 @@ class mdarray
 
     /// Raw pointer.
     T* raw_ptr_{nullptr};
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
     /// Unique pointer to the allocated GPU memory.
     std::unique_ptr<T, std::function<void(void*)>> unique_ptr_device_{nullptr};
 
@@ -866,7 +900,7 @@ mdarray<T, N>::at_idx(memory_t mem__, index_type const idx__) const
             return &raw_ptr_[idx__];
         }
         case memory_t::device: {
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
             if constexpr (check_assert) {
                 mdarray_assert(raw_ptr_device_ != nullptr);
             }
@@ -918,7 +952,7 @@ mdarray<T, N>::mdarray(std::array<index_range, N> const dims__, T* ptr__, T* ptr
                        std::string label__)
     : label_{label__}
     , raw_ptr_{ptr__}
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
     , raw_ptr_device_{ptr_device__}
 #endif
 {
@@ -930,7 +964,7 @@ mdarray<T, N>::mdarray(mdarray<T, N>&& src)
     : label_(src.label_)
     , unique_ptr_(std::move(src.unique_ptr_))
     , raw_ptr_(src.raw_ptr_)
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
     , unique_ptr_device_(std::move(src.unique_ptr_device_))
     , raw_ptr_device_(src.raw_ptr_device_)
 #endif
@@ -940,7 +974,7 @@ mdarray<T, N>::mdarray(mdarray<T, N>&& src)
         offsets_[i] = src.offsets_[i];
     }
     src.raw_ptr_ = nullptr;
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
     src.raw_ptr_device_ = nullptr;
 #endif
 }
@@ -954,7 +988,7 @@ mdarray<T, N>::operator=(mdarray<T, N>&& src)
         unique_ptr_  = std::move(src.unique_ptr_);
         raw_ptr_     = src.raw_ptr_;
         src.raw_ptr_ = nullptr;
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
         unique_ptr_device_  = std::move(src.unique_ptr_device_);
         raw_ptr_device_     = src.raw_ptr_device_;
         src.raw_ptr_device_ = nullptr;
@@ -980,13 +1014,19 @@ mdarray<T, N>::allocate(memory_t memory__)
     if (is_host_memory(memory__)) {
         unique_ptr_ = sirius::get_unique_ptr<T>(this->size(), memory__);
         raw_ptr_    = unique_ptr_.get();
+#if defined(SIRIUS_PRINT_MEMORY_ALLOCATION)
+        print_mdarray_allocation(this->size() * sizeof(T), memory_t_name(memory__), "direct", label_);
+#endif
         call_constructor();
     }
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
     /* device allocation */
     if (is_device_memory(memory__)) {
         unique_ptr_device_ = sirius::get_unique_ptr<T>(this->size(), memory__);
         raw_ptr_device_    = unique_ptr_device_.get();
+#if defined(SIRIUS_PRINT_MEMORY_ALLOCATION)
+        print_mdarray_allocation(this->size() * sizeof(T), memory_t_name(memory__), "direct", label_);
+#endif
     }
 #endif
     return *this;
@@ -1004,13 +1044,19 @@ mdarray<T, N>::allocate(memory_pool& mp__)
     if (is_host_memory(mp__.memory_type())) {
         unique_ptr_ = mp__.get_unique_ptr<T>(this->size());
         raw_ptr_    = unique_ptr_.get();
+#if defined(SIRIUS_PRINT_MEMORY_ALLOCATION)
+        print_mdarray_allocation(this->size() * sizeof(T), memory_t_name(mp__.memory_type()), "pool", label_);
+#endif
         call_constructor();
     }
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
     /* device allocation */
     if (is_device_memory(mp__.memory_type())) {
         unique_ptr_device_ = mp__.get_unique_ptr<T>(this->size());
         raw_ptr_device_    = unique_ptr_device_.get();
+#if defined(SIRIUS_PRINT_MEMORY_ALLOCATION)
+        print_mdarray_allocation(this->size() * sizeof(T), memory_t_name(mp__.memory_type()), "pool", label_);
+#endif
     }
 #endif
     return *this;
@@ -1028,7 +1074,7 @@ mdarray<T, N>::deallocate(memory_t memory__)
         unique_ptr_.reset(nullptr);
         raw_ptr_ = nullptr;
     }
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
     if (is_device_memory(memory__)) {
         unique_ptr_device_.reset(nullptr);
         raw_ptr_device_ = nullptr;
@@ -1234,7 +1280,7 @@ mdarray<T, N>::zero(memory_t mem__, size_t idx0__, size_t n__)
         // std::fill(raw_ptr_ + idx0__, raw_ptr_ + idx0__ + n__, 0);
         std::memset((void*)&raw_ptr_[idx0__], 0, n__ * sizeof(T));
     }
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
     if (n__ && on_device() && is_device_memory(mem__)) {
         mdarray_assert(raw_ptr_device_ != nullptr);
         acc::zero(&raw_ptr_device_[idx0__], n__);
@@ -1256,7 +1302,7 @@ mdarray<T, N>::copy_to(memory_t mem__, size_t idx0__, size_t n__, acc::stream_id
     if (n__ == 0) {
         return;
     }
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
     mdarray_assert(raw_ptr_ != nullptr);
     mdarray_assert(raw_ptr_device_ != nullptr);
     mdarray_assert(idx0__ + n__ <= size());
@@ -1311,7 +1357,7 @@ template <typename T, int N>
 bool
 mdarray<T, N>::on_device() const
 {
-#ifdef SIRIUS_GPU
+#if defined(SIRIUS_GPU)
     return (raw_ptr_device_ != nullptr);
 #else
     return false;

--- a/src/core/rt_graph.hpp
+++ b/src/core/rt_graph.hpp
@@ -36,6 +36,9 @@
 #include <list>
 #include <string>
 #include <vector>
+#if defined(RT_GRAPH_PRINT_ID)
+#include <iostream>
+#endif
 
 namespace rt_graph {
 
@@ -81,6 +84,9 @@ struct TimeStamp
         , identifierPtr(identifier)
         , type(stampType)
     {
+#if defined(RT_GRAPH_PRINT_ID)
+        std::cout << std::string(identifier) << std::endl;
+#endif
     }
 
     ClockType::time_point time;

--- a/src/core/splindex.hpp
+++ b/src/core/splindex.hpp
@@ -47,7 +47,7 @@ split_in_blocks(int length__, int block_size__)
     }
     /* check for correctness */
     if (std::accumulate(result.begin(), result.end(), 0) != length__) {
-        throw std::runtime_error("error in sirius::split_in_blocks()");
+        RTE_THROW("error in sirius::split_in_blocks()");
     }
 
     return result;

--- a/src/geometry/force.cpp
+++ b/src/geometry/force.cpp
@@ -807,7 +807,7 @@ Force::add_ibs_force(K_point<double>* kp__, Hamiltonian_k<double>& Hk__, mdarray
         Hk__.set_fv_h_o_apw_lo(atom, ia, 0, alm_row, alm_col, h, o);
 
         /* apply MT Hamiltonian to column coefficients */
-        Hk__.H0().apply_hmt_to_apw(ia, 0, kp__->num_gkvec_col(), alm_col, halm_col);
+        Hk__.H0().apply_hmt_to_apw(device_t::CPU, ia, 0, kp__->num_gkvec_col(), alm_col, halm_col);
 
         /* apw-apw block of the overlap matrix */
         la::wrap(la::lib_t::blas)

--- a/src/hamiltonian/diagonalize_fp.hpp
+++ b/src/hamiltonian/diagonalize_fp.hpp
@@ -570,6 +570,10 @@ diagonalize_fp(Hamiltonian_k<T> const& Hk__, K_point<T>& kp__, double itsol_tol_
         if (itso.type() == "exact") {
             diagonalize_fp_fv_exact(Hk__, kp__);
         } else if (itso.type() == "davidson") {
+            /* generate Alm coefficients once */
+            if (kp__.alm_coeffs_loc().all_atoms()) {
+                kp__.alm_coeffs_loc().generate();
+            }
             diagonalize_fp_fv_davidson(Hk__, kp__, itsol_tol__);
         }
         /* generate first-variational states */

--- a/src/hamiltonian/hamiltonian.cpp
+++ b/src/hamiltonian/hamiltonian.cpp
@@ -124,19 +124,19 @@ Hamiltonian0<T>::~Hamiltonian0()
 
 template <typename T>
 void
-Hamiltonian0<T>::apply_hmt_to_apw(device_t pu__, int ia__, int ispn__, int ngv__, mdarray<std::complex<T>, 2> const& alm__,
-                                  mdarray<std::complex<T>, 2>& halm__, int stream_id__) const
+Hamiltonian0<T>::apply_hmt_to_apw(device_t pu__, int ia__, int ispn__, int ngv__,
+                                  mdarray<std::complex<T>, 2> const& alm__, mdarray<std::complex<T>, 2>& halm__,
+                                  int stream_id__) const
 {
     auto& type = ctx_.unit_cell().atom(ia__).type();
 
     auto la  = (pu__ == device_t::CPU) ? la::lib_t::blas : la::lib_t::gpublas;
     auto mem = (pu__ == device_t::CPU) ? memory_t::host : memory_t::device;
 
-    la::wrap(la)
-            .gemm('N', 'T', ngv__, type.mt_aw_basis_size(), type.mt_aw_basis_size(),
-                  &la::constant<std::complex<T>>::one(), alm__.at(mem), alm__.ld(),
-                  hmt_[ia__].at(mem, 0, 0, ispn__), hmt_[ia__].ld(), &la::constant<std::complex<T>>::zero(),
-                  halm__.at(mem), halm__.ld(), acc::stream_id(stream_id__));
+    la::wrap(la).gemm('N', 'T', ngv__, type.mt_aw_basis_size(), type.mt_aw_basis_size(),
+                      &la::constant<std::complex<T>>::one(), alm__.at(mem), alm__.ld(),
+                      hmt_[ia__].at(mem, 0, 0, ispn__), hmt_[ia__].ld(), &la::constant<std::complex<T>>::zero(),
+                      halm__.at(mem), halm__.ld(), acc::stream_id(stream_id__));
 }
 
 template <typename T>

--- a/src/hamiltonian/hamiltonian.cpp
+++ b/src/hamiltonian/hamiltonian.cpp
@@ -124,16 +124,19 @@ Hamiltonian0<T>::~Hamiltonian0()
 
 template <typename T>
 void
-Hamiltonian0<T>::apply_hmt_to_apw(int ia__, int ispn__, int ngv__, mdarray<std::complex<T>, 2> const& alm__,
-                                  mdarray<std::complex<T>, 2>& halm__) const
+Hamiltonian0<T>::apply_hmt_to_apw(device_t pu__, int ia__, int ispn__, int ngv__, mdarray<std::complex<T>, 2> const& alm__,
+                                  mdarray<std::complex<T>, 2>& halm__, int stream_id__) const
 {
     auto& type = ctx_.unit_cell().atom(ia__).type();
 
-    la::wrap(la::lib_t::blas)
+    auto la  = (pu__ == device_t::CPU) ? la::lib_t::blas : la::lib_t::gpublas;
+    auto mem = (pu__ == device_t::CPU) ? memory_t::host : memory_t::device;
+
+    la::wrap(la)
             .gemm('N', 'T', ngv__, type.mt_aw_basis_size(), type.mt_aw_basis_size(),
-                  &la::constant<std::complex<T>>::one(), alm__.at(memory_t::host), alm__.ld(),
-                  hmt_[ia__].at(memory_t::host, 0, 0, ispn__), hmt_[ia__].ld(), &la::constant<std::complex<T>>::zero(),
-                  halm__.at(memory_t::host), halm__.ld());
+                  &la::constant<std::complex<T>>::one(), alm__.at(mem), alm__.ld(),
+                  hmt_[ia__].at(mem, 0, 0, ispn__), hmt_[ia__].ld(), &la::constant<std::complex<T>>::zero(),
+                  halm__.at(mem), halm__.ld(), acc::stream_id(stream_id__));
 }
 
 template <typename T>

--- a/src/hamiltonian/hamiltonian.hpp
+++ b/src/hamiltonian/hamiltonian.hpp
@@ -149,8 +149,8 @@ class Hamiltonian0
      *  \f]
      */
     void
-    apply_hmt_to_apw(int ia__, int j__, int ngv__, mdarray<std::complex<T>, 2> const& alm__,
-                     mdarray<std::complex<T>, 2>& halm__) const;
+    apply_hmt_to_apw(device_t pu__, int ia__, int j__, int ngv__, mdarray<std::complex<T>, 2> const& alm__,
+                     mdarray<std::complex<T>, 2>& halm__, int stream_id__ = -1) const;
 
     /// Add correction to LAPW overlap arising in the infinite-order relativistic approximation (IORA).
     void

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -230,13 +230,13 @@ Hamiltonian_k<T>::get_h_o_diag_lapw() const
         if (what & 1) {
             switch (ctx.processing_unit()) {
                 case device_t::CPU: {
-                    halm = matrix<std::complex<T>>({kp_.num_gkvec_loc(), num_mt_aw},
-                                    get_memory_pool(memory_t::host), mdarray_label("halm"));
+                    halm = matrix<std::complex<T>>({kp_.num_gkvec_loc(), num_mt_aw}, get_memory_pool(memory_t::host),
+                                                   mdarray_label("halm"));
                     break;
                 }
                 case device_t::GPU: {
                     halm = matrix<std::complex<T>>({kp_.num_gkvec_loc(), num_mt_aw},
-                                    get_memory_pool(memory_t::host_pinned), mdarray_label("halm"));
+                                                   get_memory_pool(memory_t::host_pinned), mdarray_label("halm"));
                     halm.allocate(get_memory_pool(memory_t::device));
                     break;
                 }
@@ -251,27 +251,29 @@ Hamiltonian_k<T>::get_h_o_diag_lapw() const
             PROFILE("sirius::Hamiltonian::get_h_o_diag|hmt");
             #pragma omp parallel for schedule(static, 1)
             for (int i = 0; i < na; i++) {
-                int ia        = atom_begin + i;
-                auto& type    = uc.atom(ia).type();
+                int ia     = atom_begin + i;
+                auto& type = uc.atom(ia).type();
                 matrix<std::complex<T>> alm_atom, halm_atom;
                 switch (ctx.processing_unit()) {
                     case device_t::CPU: {
-                        alm_atom = matrix<std::complex<T>>({kp_.num_gkvec_loc(), type.mt_aw_basis_size()},
-                            alm.at(memory_t::host, 0, offsets_aw[i]));
+                        alm_atom  = matrix<std::complex<T>>({kp_.num_gkvec_loc(), type.mt_aw_basis_size()},
+                                                            alm.at(memory_t::host, 0, offsets_aw[i]));
                         halm_atom = matrix<std::complex<T>>({kp_.num_gkvec_loc(), type.mt_aw_basis_size()},
-                            halm.at(memory_t::host, 0, offsets_aw[i]));
+                                                            halm.at(memory_t::host, 0, offsets_aw[i]));
                         break;
                     }
                     case device_t::GPU: {
-                        alm_atom = matrix<std::complex<T>>({kp_.num_gkvec_loc(), type.mt_aw_basis_size()},
-                            alm.at(memory_t::host, 0, offsets_aw[i]), alm.at(memory_t::device, 0, offsets_aw[i]));
+                        alm_atom  = matrix<std::complex<T>>({kp_.num_gkvec_loc(), type.mt_aw_basis_size()},
+                                                            alm.at(memory_t::host, 0, offsets_aw[i]),
+                                                            alm.at(memory_t::device, 0, offsets_aw[i]));
                         halm_atom = matrix<std::complex<T>>({kp_.num_gkvec_loc(), type.mt_aw_basis_size()},
-                            halm.at(memory_t::host, 0, offsets_aw[i]), halm.at(memory_t::device, 0, offsets_aw[i]));
+                                                            halm.at(memory_t::host, 0, offsets_aw[i]),
+                                                            halm.at(memory_t::device, 0, offsets_aw[i]));
                         break;
-
                     }
                 }
-                H0_.apply_hmt_to_apw(ctx.processing_unit(), ia, 0, kp_.num_gkvec_loc(), alm_atom, halm_atom, omp_get_thread_num());
+                H0_.apply_hmt_to_apw(ctx.processing_unit(), ia, 0, kp_.num_gkvec_loc(), alm_atom, halm_atom,
+                                     omp_get_thread_num());
             }
             if (ctx.processing_unit() == device_t::GPU) {
                 halm.copy_to(memory_t::host);
@@ -280,12 +282,13 @@ Hamiltonian_k<T>::get_h_o_diag_lapw() const
 
         /* compute APW contribution */
         for (int i = 0; i < na; i++) {
-            int ia        = atom_begin + i;
-            auto& type    = uc.atom(ia).type();
-            auto alm_atom = matrix<std::complex<T>>({kp_.num_gkvec_loc(), type.mt_aw_basis_size()},
-                    alm.at(memory_t::host, 0, offsets_aw[i]));
+            int ia         = atom_begin + i;
+            auto& type     = uc.atom(ia).type();
+            auto alm_atom  = matrix<std::complex<T>>({kp_.num_gkvec_loc(), type.mt_aw_basis_size()},
+                                                     alm.at(memory_t::host, 0, offsets_aw[i]));
             auto halm_atom = (what & 1) ? matrix<std::complex<T>>({kp_.num_gkvec_loc(), type.mt_aw_basis_size()},
-                    halm.at(memory_t::host, 0, offsets_aw[i])) : matrix<std::complex<T>>();
+                                                                  halm.at(memory_t::host, 0, offsets_aw[i]))
+                                        : matrix<std::complex<T>>();
             #pragma omp parallel
             for (int xi = 0; xi < type.mt_aw_basis_size(); xi++) {
                 #pragma omp for

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -190,7 +190,9 @@ Hamiltonian_k<T>::get_h_o_diag_lapw() const
 {
     PROFILE("sirius::Hamiltonian::get_h_o_diag");
 
-    auto const& uc = H0_.ctx().unit_cell();
+    auto const& ctx = H0_.ctx();
+
+    auto const& uc = ctx.unit_cell();
 
     splindex_block<atom_index_t> spl_num_atoms(uc.num_atoms(), n_blocks(kp_.comm().size()),
                                                block_id(kp_.comm().rank()));
@@ -207,67 +209,100 @@ Hamiltonian_k<T>::get_h_o_diag_lapw() const
         if (what & 1) {
             auto gvc      = kp_.gkvec().gkvec_cart(gvec_index_t::local(igloc));
             T ekin        = 0.5 * dot(gvc, gvc);
-            h_diag[igloc] = H0_.local_op().v0(0) + ekin * H0_.ctx().theta_pw(0).real();
+            h_diag[igloc] = H0_.local_op().v0(0) + ekin * ctx.theta_pw(0).real();
         }
         if (what & 2) {
-            o_diag[igloc] = H0_.ctx().theta_pw(0).real();
+            o_diag[igloc] = ctx.theta_pw(0).real();
         }
     }
-
-    #pragma omp parallel
-    {
-        matrix<std::complex<T>> alm({kp_.num_gkvec_loc(), uc.max_mt_aw_basis_size()});
-
-        auto halm = (what & 1) ? matrix<std::complex<T>>({kp_.num_gkvec_loc(), uc.max_mt_aw_basis_size()})
-                               : matrix<std::complex<T>>();
-
-        auto h_diag_omp = (what & 1) ? mdarray<T, 1>({kp_.num_gkvec_loc()}) : mdarray<T, 1>();
+    int atom_begin{0};
+    for (auto na : split_in_blocks(uc.num_atoms(), ctx.cfg().control().max_atom_chunk_size())) {
+        /* actual number of AW radial functions in a block of atoms */
+        int num_mt_aw{0};
+        std::vector<int> offsets_aw(na);
+        for (int i = 0; i < na; i++) {
+            int ia        = atom_begin + i;
+            auto& type    = uc.atom(ia).type();
+            offsets_aw[i] = num_mt_aw;
+            num_mt_aw += type.mt_aw_basis_size();
+        }
+        matrix<std::complex<T>> halm;
         if (what & 1) {
-            h_diag_omp.zero();
-        }
-
-        auto o_diag_omp = (what & 2) ? mdarray<T, 1>({kp_.num_gkvec_loc()}) : mdarray<T, 1>();
-        if (what & 2) {
-            o_diag_omp.zero();
-        }
-
-        #pragma omp for
-        for (int ia = 0; ia < uc.num_atoms(); ia++) {
-            auto& atom = uc.atom(ia);
-            int nmt    = atom.mt_aw_basis_size();
-
-            if (kp_.alm_coeffs_loc().all_atoms()) {
-                std::copy(kp_.alm_coeffs_loc().begin(ia), kp_.alm_coeffs_loc().end(ia), alm.at(memory_t::host));
-            } else {
-                kp_.alm_coeffs_loc().template generate<false>(atom, alm);
-            }
-            if (what & 1) {
-                H0_.apply_hmt_to_apw(ia, 0, kp_.num_gkvec_loc(), alm, halm);
-            }
-
-            for (int xi = 0; xi < nmt; xi++) {
-                for (int igloc = 0; igloc < kp_.num_gkvec_loc(); igloc++) {
-                    if (what & 1) {
-                        h_diag_omp[igloc] += std::real(std::conj(alm(igloc, xi)) * halm(igloc, xi));
-                    }
-                    if (what & 2) {
-                        o_diag_omp[igloc] += std::real(std::conj(alm(igloc, xi)) * alm(igloc, xi));
-                    }
+            switch (ctx.processing_unit()) {
+                case device_t::CPU: {
+                    halm = matrix<std::complex<T>>({kp_.num_gkvec_loc(), num_mt_aw},
+                                    get_memory_pool(memory_t::host), mdarray_label("halm"));
+                    break;
+                }
+                case device_t::GPU: {
+                    halm = matrix<std::complex<T>>({kp_.num_gkvec_loc(), num_mt_aw},
+                                    get_memory_pool(memory_t::host_pinned), mdarray_label("halm"));
+                    halm.allocate(get_memory_pool(memory_t::device));
+                    break;
                 }
             }
         }
 
-        #pragma omp critical
-        for (int igloc = 0; igloc < kp_.num_gkvec_loc(); igloc++) {
-            if (what & 1) {
-                h_diag[igloc] += h_diag_omp[igloc];
+        /* generate complex conjugated Alm coefficients for a block of atoms */
+        auto alm = generate_alm_block<true, T>(ctx, atom_begin, na, kp_.alm_coeffs_loc());
+
+        /* apply muffin-tin APW Hamiltonian to the block of Alm coefficients */
+        if (what & 1) {
+            PROFILE("sirius::Hamiltonian::get_h_o_diag|hmt");
+            #pragma omp parallel for schedule(static, 1)
+            for (int i = 0; i < na; i++) {
+                int ia        = atom_begin + i;
+                auto& type    = uc.atom(ia).type();
+                matrix<std::complex<T>> alm_atom, halm_atom;
+                switch (ctx.processing_unit()) {
+                    case device_t::CPU: {
+                        alm_atom = matrix<std::complex<T>>({kp_.num_gkvec_loc(), type.mt_aw_basis_size()},
+                            alm.at(memory_t::host, 0, offsets_aw[i]));
+                        halm_atom = matrix<std::complex<T>>({kp_.num_gkvec_loc(), type.mt_aw_basis_size()},
+                            halm.at(memory_t::host, 0, offsets_aw[i]));
+                        break;
+                    }
+                    case device_t::GPU: {
+                        alm_atom = matrix<std::complex<T>>({kp_.num_gkvec_loc(), type.mt_aw_basis_size()},
+                            alm.at(memory_t::host, 0, offsets_aw[i]), alm.at(memory_t::device, 0, offsets_aw[i]));
+                        halm_atom = matrix<std::complex<T>>({kp_.num_gkvec_loc(), type.mt_aw_basis_size()},
+                            halm.at(memory_t::host, 0, offsets_aw[i]), halm.at(memory_t::device, 0, offsets_aw[i]));
+                        break;
+
+                    }
+                }
+                H0_.apply_hmt_to_apw(ctx.processing_unit(), ia, 0, kp_.num_gkvec_loc(), alm_atom, halm_atom, omp_get_thread_num());
             }
-            if (what & 2) {
-                o_diag[igloc] += o_diag_omp[igloc];
+            if (ctx.processing_unit() == device_t::GPU) {
+                halm.copy_to(memory_t::host);
             }
         }
+
+        /* compute APW contribution */
+        for (int i = 0; i < na; i++) {
+            int ia        = atom_begin + i;
+            auto& type    = uc.atom(ia).type();
+            auto alm_atom = matrix<std::complex<T>>({kp_.num_gkvec_loc(), type.mt_aw_basis_size()},
+                    alm.at(memory_t::host, 0, offsets_aw[i]));
+            auto halm_atom = (what & 1) ? matrix<std::complex<T>>({kp_.num_gkvec_loc(), type.mt_aw_basis_size()},
+                    halm.at(memory_t::host, 0, offsets_aw[i])) : matrix<std::complex<T>>();
+            #pragma omp parallel
+            for (int xi = 0; xi < type.mt_aw_basis_size(); xi++) {
+                #pragma omp for
+                for (int igloc = 0; igloc < kp_.num_gkvec_loc(); igloc++) {
+                    if (what & 1) {
+                        h_diag[igloc] += std::real(std::conj(alm_atom(igloc, xi)) * halm_atom(igloc, xi));
+                    }
+                    if (what & 2) {
+                        o_diag[igloc] += std::real(std::conj(alm_atom(igloc, xi)) * alm_atom(igloc, xi));
+                    }
+                }
+            }
+        }
+        atom_begin += na;
     }
 
+    /* local obribal part */
     nlo = 0;
     for (auto it : spl_num_atoms) {
         auto& atom = uc.atom(it.i);
@@ -286,7 +321,7 @@ Hamiltonian_k<T>::get_h_o_diag_lapw() const
         nlo += atom.mt_lo_basis_size();
     }
 
-    if (H0_.ctx().processing_unit() == device_t::GPU) {
+    if (ctx.processing_unit() == device_t::GPU) {
         if (what & 1) {
             h_diag.allocate(memory_t::device).copy_to(memory_t::device);
         }
@@ -424,7 +459,7 @@ Hamiltonian_k<T>::set_fv_h_o(int ispn__, la::dmatrix<std::complex<T>>& h__, la::
 
                 /* can't copy alm to device now as it might be modified by the iora */
 
-                H0_.apply_hmt_to_apw(ia, ispn__, kp_.num_gkvec_col(), alm_col_atom, halm_col_atom);
+                H0_.apply_hmt_to_apw(device_t::CPU, ia, ispn__, kp_.num_gkvec_col(), alm_col_atom, halm_col_atom);
                 if (pu == device_t::GPU) {
                     halm_col_atom.copy_to(memory_t::device, acc::stream_id(tid));
                 }

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -236,7 +236,11 @@ Hamiltonian_k<T>::get_h_o_diag_lapw() const
             auto& atom = uc.atom(ia);
             int nmt    = atom.mt_aw_basis_size();
 
-            kp_.alm_coeffs_loc().template generate<false>(atom, alm);
+            if (kp_.alm_coeffs_loc().all_atoms()) {
+                std::copy(kp_.alm_coeffs_loc().begin(ia), kp_.alm_coeffs_loc().end(ia), alm.at(memory_t::host));
+            } else {
+                kp_.alm_coeffs_loc().template generate<false>(atom, alm);
+            }
             if (what & 1) {
                 H0_.apply_hmt_to_apw(ia, 0, kp_.num_gkvec_loc(), alm, halm);
             }
@@ -1062,12 +1066,12 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
     /* Prepare APW-lo contribution for the entire index of APW basis functions. Here we compute the action
      * of the APW-lo Hamiltonian and overlap on the local-orbital part of wave-functions.
      *
-     *            n
-     * +------+ +---+
-     * |      | |   |
-     * |      |x|lo |
-     * |      | |   |
-     * |      | +---+
+     *              n
+     * +------+   +---+
+     * |      |   |   |
+     * |      | x |lo |
+     * |      |   |   |
+     * |      |   +---+
      * |APW-lo|
      * |      |
      * |      |
@@ -1111,12 +1115,12 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
     /* lo-lo contribution (lo-lo Hamiltonian and overlap are block-diagonal in atom index and the whole application is
      * local to MPI rank)
      *
-     *            n
-     * +------+ +---+
-     * |      | |   |
-     * |lo-lo |x|lo |
-     * |      | |   |
-     * +------+ +---+
+     *              n
+     * +------+   +---+
+     * |      |   |   |
+     * |lo-lo | x |lo |
+     * |      |   |   |
+     * +------+   +---+
      */
     if (!apw_only__ && ctx.unit_cell().mt_lo_basis_size()) {
         PROFILE("sirius::Hamiltonian_k::apply_fv_h_o|lo-lo");

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -1149,9 +1149,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
     int offset_aw_global{0};
     int atom_begin{0};
     /* loop over blocks of atoms */
-    for (auto na : split_in_blocks(ctx.unit_cell().num_atoms(), 64)) {
-
-        //splindex_block<> spl_atoms(na, n_blocks(comm.size()), block_id(comm.rank()));
+    for (auto na : split_in_blocks(ctx.unit_cell().num_atoms(), ctx.cfg().control().max_atom_chunk_size())) {
 
         /* actual number of AW radial functions in a block of atoms */
         int num_mt_aw{0};

--- a/src/k_point/generate_lapw_wave_functions.cpp
+++ b/src/k_point/generate_lapw_wave_functions.cpp
@@ -37,6 +37,8 @@ K_point<T>::generate_lapw_wave_functions(wf::Wave_functions<T> const& evec__, wf
     int atom_begin{0};
     int mt_aw_offset{0};
 
+    auto evec_mg = evec__.memory_guard(ctx_.processing_unit_memory_t(), wf::copy_to::device);
+
     /* loop over blocks of atoms */
     for (auto na : split_in_blocks(uc.num_atoms(), ctx_.cfg().control().max_atom_chunk_size())) {
         /* actual number of AW radial functions in a block of atoms */
@@ -48,15 +50,15 @@ K_point<T>::generate_lapw_wave_functions(wf::Wave_functions<T> const& evec__, wf
         }
 
         /* generate complex conjugated Alm coefficients for a block of atoms */
-        auto alm = generate_alm_block<false, T>(ctx_, atom_begin, na, this->alm_coeffs_loc());
-        auto cs  = alm.checksum();
+        auto alm = generate_alm_block<true, T>(ctx_, atom_begin, na, this->alm_coeffs_loc());
         if (pcs) {
+            auto cs = alm.checksum();
             print_checksum("alm", cs, RTE_OUT(this->out(0)));
         }
 
         /* compute F(lm, i) = A(lm, G)^{T} * evec(G, i) for the block of atoms */
-        spla::pgemm_ssb(num_mt_aw, ctx_.num_fv_states(), this->gkvec().count(), SPLA_OP_TRANSPOSE, 1.0,
-                        alm.at(memory_t::host), alm.ld(), &evec__.pw_coeffs(0, wf::spin_index(0), wf::band_index(0)),
+        spla::pgemm_ssb(num_mt_aw, ctx_.num_fv_states(), this->gkvec().count(), SPLA_OP_CONJ_TRANSPOSE, 1.0,
+                        alm.at(ctx_.processing_unit_memory_t()), alm.ld(), evec__.pw_coeffs(wf::spin_index(0)).at(ctx_.processing_unit_memory_t()),
                         evec__.ld(), 0.0, alm_fv.at(memory_t::host), alm_fv.ld(), mt_aw_offset, 0,
                         alm_fv.spla_distribution(), ctx_.spla_context());
 

--- a/src/k_point/generate_lapw_wave_functions.cpp
+++ b/src/k_point/generate_lapw_wave_functions.cpp
@@ -38,7 +38,7 @@ K_point<T>::generate_lapw_wave_functions(wf::Wave_functions<T> const& evec__, wf
     int mt_aw_offset{0};
 
     /* loop over blocks of atoms */
-    for (auto na : split_in_blocks(uc.num_atoms(), 64)) {
+    for (auto na : split_in_blocks(uc.num_atoms(), ctx_.cfg().control().max_atom_chunk_size())) {
         /* actual number of AW radial functions in a block of atoms */
         int num_mt_aw{0};
         for (int i = 0; i < na; i++) {

--- a/src/k_point/generate_lapw_wave_functions.cpp
+++ b/src/k_point/generate_lapw_wave_functions.cpp
@@ -58,9 +58,10 @@ K_point<T>::generate_lapw_wave_functions(wf::Wave_functions<T> const& evec__, wf
 
         /* compute F(lm, i) = A(lm, G)^{T} * evec(G, i) for the block of atoms */
         spla::pgemm_ssb(num_mt_aw, ctx_.num_fv_states(), this->gkvec().count(), SPLA_OP_CONJ_TRANSPOSE, 1.0,
-                        alm.at(ctx_.processing_unit_memory_t()), alm.ld(), evec__.pw_coeffs(wf::spin_index(0)).at(ctx_.processing_unit_memory_t()),
-                        evec__.ld(), 0.0, alm_fv.at(memory_t::host), alm_fv.ld(), mt_aw_offset, 0,
-                        alm_fv.spla_distribution(), ctx_.spla_context());
+                        alm.at(ctx_.processing_unit_memory_t()), alm.ld(),
+                        evec__.pw_coeffs(wf::spin_index(0)).at(ctx_.processing_unit_memory_t()), evec__.ld(), 0.0,
+                        alm_fv.at(memory_t::host), alm_fv.ld(), mt_aw_offset, 0, alm_fv.spla_distribution(),
+                        ctx_.spla_context());
 
         atom_begin += na;
         mt_aw_offset += num_mt_aw;

--- a/src/k_point/k_point.cpp
+++ b/src/k_point/k_point.cpp
@@ -396,7 +396,7 @@ K_point<T>::update()
             alm_coeffs_row_ = std::make_unique<Matching_coefficients>(unit_cell_, *gkvec_row_);
             alm_coeffs_col_ = std::make_unique<Matching_coefficients>(unit_cell_, *gkvec_col_);
         }
-        alm_coeffs_loc_ = std::make_unique<Matching_coefficients>(unit_cell_, gkvec());
+        alm_coeffs_loc_ = std::make_unique<Matching_coefficients>(unit_cell_, gkvec(), true);
     }
 
     if (!ctx_.full_potential()) {

--- a/src/k_point/k_point.cpp
+++ b/src/k_point/k_point.cpp
@@ -392,11 +392,14 @@ K_point<T>::update()
     gkvec_partition_->update_gkvec_cart();
 
     if (ctx_.full_potential()) {
+        bool all_atoms = {false};
         if (ctx_.cfg().iterative_solver().type() == "exact") {
             alm_coeffs_row_ = std::make_unique<Matching_coefficients>(unit_cell_, *gkvec_row_);
             alm_coeffs_col_ = std::make_unique<Matching_coefficients>(unit_cell_, *gkvec_col_);
+        } else {
+            all_atoms = true;
         }
-        alm_coeffs_loc_ = std::make_unique<Matching_coefficients>(unit_cell_, gkvec(), true);
+        alm_coeffs_loc_ = std::make_unique<Matching_coefficients>(unit_cell_, gkvec(), all_atoms);
     }
 
     if (!ctx_.full_potential()) {

--- a/src/k_point/k_point.hpp
+++ b/src/k_point/k_point.hpp
@@ -718,6 +718,12 @@ class K_point
         return *alm_coeffs_loc_;
     }
 
+    inline auto&
+    alm_coeffs_loc()
+    {
+        return *alm_coeffs_loc_;
+    }
+
     inline auto const&
     comm() const
     {

--- a/src/k_point/k_point.hpp
+++ b/src/k_point/k_point.hpp
@@ -110,6 +110,18 @@ class K_point
     std::unique_ptr<Matching_coefficients> alm_coeffs_col_{nullptr};
 
     /// LAPW matching coefficients for the local set G+k vectors.
+    /** Used in operations that apply the Hamiltonian or construct LAPW wave functions
+        from the plane-wave coefficients stored locally on this MPI rank. Unlike
+        alm_coeffs_row_ and alm_coeffs_col_, which are tied to the row and column
+        distributions of the explicit LAPW Hamiltonian and overlap matrices, this
+        object follows the local G+k distribution of the k-point.
+
+        The object may cache matching coefficients for all atoms. This is used by the
+        iterative first-variation solver to generate the coefficients once and reuse
+        them during repeated Hamiltonian applications. Code paths that require atom
+        blocks can still request coefficients through the regular Matching_coefficients
+        interface; depending on the cache mode this either copies precomputed data or
+        generates the coefficients for the requested atom. */
     std::unique_ptr<Matching_coefficients> alm_coeffs_loc_{nullptr};
 
     /// Number of G+k vectors distributed along rows of MPI grid

--- a/src/lapw/generate_alm_block.hpp
+++ b/src/lapw/generate_alm_block.hpp
@@ -34,8 +34,9 @@ generate_alm_block(Simulation_context const& ctx__, int atom_begin__, int num_at
 
     /* quick exit */
     if (conjugate && alm__.all_atoms()) {
-        result = mdarray<std::complex<T>, 2>({alm__.gkvec().count(), num_mt_aw}, const_cast<std::complex<T>*>(alm__.begin(atom_begin__)),
-                                                 mdarray_label("alm_block"));
+        result = mdarray<std::complex<T>, 2>({alm__.gkvec().count(), num_mt_aw},
+                                             const_cast<std::complex<T>*>(alm__.begin(atom_begin__)),
+                                             mdarray_label("alm_block"));
         if (ctx__.processing_unit() == device_t::GPU) {
             result.allocate(get_memory_pool(memory_t::device)).copy_to(memory_t::device);
         }
@@ -87,7 +88,7 @@ generate_alm_block(Simulation_context const& ctx__, int atom_begin__, int num_at
                     auto ptr_in = alm__.begin(atom_begin__ + i);
                     for (size_t j = 0; j < alm_atom.size(); j++) {
                         ptr_out[j] = std::conj(ptr_in[j]);
-                    } 
+                    }
                 } else {
                     std::copy(alm__.begin(atom_begin__ + i), alm__.end(atom_begin__ + i), ptr_out);
                     //std::memcpy(ptr_out, alm__.begin(atom_begin__ + i), alm_atom.size() * sizeof(std::complex<T>));
@@ -105,7 +106,8 @@ generate_alm_block(Simulation_context const& ctx__, int atom_begin__, int num_at
         }
     }
     tt = (omp_get_wtime() - tt);
-    std::cout << "effective BW : " << result.size() * 2 * sizeof(std::complex<double>) / tt / (1<<30) << " GB/s" << std::endl;
+    std::cout << "effective BW : " << result.size() * 2 * sizeof(std::complex<double>) / tt / (1 << 30) << " GB/s"
+              << std::endl;
     return result;
 }
 

--- a/src/lapw/generate_alm_block.hpp
+++ b/src/lapw/generate_alm_block.hpp
@@ -29,6 +29,7 @@ generate_alm_block(Simulation_context const& ctx__, int atom_begin__, int num_at
         num_mt_aw += ctx__.unit_cell().atom(atom_begin__ + ia).mt_aw_basis_size();
     }
 
+    /* resulting block of alm coefficients */
     mdarray<std::complex<T>, 2> result;
     switch (ctx__.processing_unit()) {
         case device_t::CPU: {
@@ -68,8 +69,18 @@ generate_alm_block(Simulation_context const& ctx__, int atom_begin__, int num_at
                     break;
                 }
             }
-            /* generate LAPW matching coefficients on the CPU */
-            alm__.template generate<conjugate>(atom, alm_atom);
+            if (alm__.all_atoms()) {
+                auto ptr_out = alm_atom.at(memory_t::host);
+                std::copy(alm__.begin(atom_begin__ + i), alm__.end(atom_begin__ + i), ptr_out);
+                if (conjugate) {
+                    for (size_t i = 0; i < alm_atom.size(); i++) {
+                        alm_atom[i] = std::conj(alm_atom[i]);
+                    }
+                }
+            } else {
+                /* generate LAPW matching coefficients on the CPU */
+                alm__.template generate<conjugate>(atom, alm_atom);
+            }
             if (ctx__.processing_unit() == device_t::GPU) {
                 alm_atom.copy_to(memory_t::device, acc::stream_id(tid));
             }

--- a/src/lapw/generate_alm_block.hpp
+++ b/src/lapw/generate_alm_block.hpp
@@ -31,6 +31,17 @@ generate_alm_block(Simulation_context const& ctx__, int atom_begin__, int num_at
 
     /* resulting block of alm coefficients */
     mdarray<std::complex<T>, 2> result;
+
+    /* quick exit */
+    if (conjugate && alm__.all_atoms()) {
+        result = mdarray<std::complex<T>, 2>({alm__.gkvec().count(), num_mt_aw}, const_cast<std::complex<T>*>(alm__.begin(atom_begin__)),
+                                                 mdarray_label("alm_block"));
+        if (ctx__.processing_unit() == device_t::GPU) {
+            result.allocate(get_memory_pool(memory_t::device)).copy_to(memory_t::device);
+        }
+        return result;
+    }
+
     switch (ctx__.processing_unit()) {
         case device_t::CPU: {
             result = mdarray<std::complex<T>, 2>({alm__.gkvec().count(), num_mt_aw}, get_memory_pool(memory_t::host),
@@ -45,10 +56,11 @@ generate_alm_block(Simulation_context const& ctx__, int atom_begin__, int num_at
         }
     }
 
+    auto tt = omp_get_wtime();
     #pragma omp parallel
     {
         int tid = omp_get_thread_num();
-        #pragma omp for
+        #pragma omp for schedule(static, 1)
         for (int i = 0; i < num_atoms__; i++) {
             auto& atom = ctx__.unit_cell().atom(atom_begin__ + i);
             auto& type = atom.type();
@@ -71,11 +83,14 @@ generate_alm_block(Simulation_context const& ctx__, int atom_begin__, int num_at
             }
             if (alm__.all_atoms()) {
                 auto ptr_out = alm_atom.at(memory_t::host);
-                std::copy(alm__.begin(atom_begin__ + i), alm__.end(atom_begin__ + i), ptr_out);
-                if (conjugate) {
-                    for (size_t i = 0; i < alm_atom.size(); i++) {
-                        alm_atom[i] = std::conj(alm_atom[i]);
-                    }
+                if constexpr (!conjugate) {
+                    auto ptr_in = alm__.begin(atom_begin__ + i);
+                    for (size_t j = 0; j < alm_atom.size(); j++) {
+                        ptr_out[j] = std::conj(ptr_in[j]);
+                    } 
+                } else {
+                    std::copy(alm__.begin(atom_begin__ + i), alm__.end(atom_begin__ + i), ptr_out);
+                    //std::memcpy(ptr_out, alm__.begin(atom_begin__ + i), alm_atom.size() * sizeof(std::complex<T>));
                 }
             } else {
                 /* generate LAPW matching coefficients on the CPU */
@@ -89,6 +104,8 @@ generate_alm_block(Simulation_context const& ctx__, int atom_begin__, int num_at
             acc::sync_stream(acc::stream_id(tid));
         }
     }
+    tt = (omp_get_wtime() - tt);
+    std::cout << "effective BW : " << result.size() * 2 * sizeof(std::complex<double>) / tt / (1<<30) << " GB/s" << std::endl;
     return result;
 }
 

--- a/src/lapw/generate_alm_block.hpp
+++ b/src/lapw/generate_alm_block.hpp
@@ -57,7 +57,6 @@ generate_alm_block(Simulation_context const& ctx__, int atom_begin__, int num_at
         }
     }
 
-    auto tt = omp_get_wtime();
     #pragma omp parallel
     {
         int tid = omp_get_thread_num();
@@ -91,7 +90,6 @@ generate_alm_block(Simulation_context const& ctx__, int atom_begin__, int num_at
                     }
                 } else {
                     std::copy(alm__.begin(atom_begin__ + i), alm__.end(atom_begin__ + i), ptr_out);
-                    //std::memcpy(ptr_out, alm__.begin(atom_begin__ + i), alm_atom.size() * sizeof(std::complex<T>));
                 }
             } else {
                 /* generate LAPW matching coefficients on the CPU */
@@ -105,9 +103,6 @@ generate_alm_block(Simulation_context const& ctx__, int atom_begin__, int num_at
             acc::sync_stream(acc::stream_id(tid));
         }
     }
-    tt = (omp_get_wtime() - tt);
-    std::cout << "effective BW : " << result.size() * 2 * sizeof(std::complex<double>) / tt / (1 << 30) << " GB/s"
-              << std::endl;
     return result;
 }
 

--- a/src/lapw/matching_coefficients.hpp
+++ b/src/lapw/matching_coefficients.hpp
@@ -48,6 +48,7 @@ class Matching_coefficients // TODO: compute on GPU
     /// Description of the G+k vectors.
     fft::Gvec const& gkvec_;
 
+    /// Length of G+k vectors.
     std::vector<double> gkvec_len_;
 
     /// Spherical harmonics Ylm(theta, phi) of the G+k vectors.
@@ -55,6 +56,12 @@ class Matching_coefficients // TODO: compute on GPU
 
     /// Precomputed values for the linear equations for matching coefficients.
     mdarray<std::complex<double>, 4> alm_b_;
+
+    /// Matching coefficients for all atoms.
+    mdarray<std::complex<double>, 2> alm_all_atoms_;
+
+    /// True if matching coefficients for all atoms are computed.
+    bool all_atoms_{false};
 
     /// Generate matching coefficients for a specific \f$ \ell \f$ and order.
     /** \param [in] ngk           Number of G+k vectors.
@@ -99,14 +106,15 @@ class Matching_coefficients // TODO: compute on GPU
 
   public:
     /// Constructor
-    Matching_coefficients(Unit_cell const& unit_cell__, fft::Gvec const& gkvec__)
+    Matching_coefficients(Unit_cell const& unit_cell__, fft::Gvec const& gkvec__, bool all_atoms__ = false)
         : unit_cell_(unit_cell__)
         , gkvec_(gkvec__)
+        , all_atoms_(all_atoms__)
     {
         int lmax_apw  = unit_cell__.lmax_apw();
         int lmmax_apw = sf::lmmax(lmax_apw);
 
-        gkvec_ylm_ = mdarray<std::complex<double>, 2>({gkvec_.count(), lmmax_apw});
+        gkvec_ylm_ = mdarray<std::complex<double>, 2>({gkvec_.count(), lmmax_apw}, mdarray_label("gkvec_ylm"));
         gkvec_len_.resize(gkvec_.count());
 
         /* get length and Ylm harmonics of G+k vectors */
@@ -173,6 +181,23 @@ class Matching_coefficients // TODO: compute on GPU
                 }
             }
         }
+
+        if (all_atoms_) {
+            alm_all_atoms_ = mdarray<std::complex<double>, 2>({gkvec_.count(), unit_cell_.mt_aw_basis_size()},
+                    mdarray_label("alm_all_atoms"));
+        }
+    }
+
+    inline auto const&
+    gkvec() const
+    {
+        return gkvec_;
+    }
+
+    inline auto
+    all_atoms() const
+    {
+        return all_atoms_;
     }
 
     /// Generate plane-wave matching coefficients for the radial solutions of a given atom.
@@ -284,10 +309,28 @@ class Matching_coefficients // TODO: compute on GPU
         }
     }
 
-    auto const&
-    gkvec() const
+    /// Generate matching coefficients for all atoms.
+    inline void
+    generate()
     {
-        return gkvec_;
+        int num_mt_aw{0};
+        std::vector<int> mt_aw_offset(unit_cell_.num_atoms());
+        for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
+            mt_aw_offset[ia] = num_mt_aw;
+            num_mt_aw += unit_cell_.atom(ia).mt_aw_basis_size();
+        }
+
+        #pragma omp parallel for
+        for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
+            auto& atom = unit_cell_.atom(ia);
+            auto& type = atom.type();
+            /* wrap matching coefficients of a single atom */
+            mdarray<std::complex<double>, 2> alm_atom({this->gkvec().count(), type.mt_aw_basis_size()},
+                                                       alm_all_atoms_.at(memory_t::host, 0, mt_aw_offset[ia]),
+                                                       mdarray_label("alm_atom"));
+            /* generate LAPW matching coefficients on the CPU */
+            this->generate<false>(atom, alm_atom);
+        }
     }
 };
 

--- a/src/lapw/matching_coefficients.hpp
+++ b/src/lapw/matching_coefficients.hpp
@@ -60,6 +60,9 @@ class Matching_coefficients // TODO: compute on GPU
     /// Matching coefficients for all atoms.
     mdarray<std::complex<double>, 2> alm_all_atoms_;
 
+    /// Offset in the alm_all_atoms array.
+    std::vector<int> mt_aw_offset_;
+
     /// True if matching coefficients for all atoms are computed.
     bool all_atoms_{false};
 
@@ -200,6 +203,18 @@ class Matching_coefficients // TODO: compute on GPU
         return all_atoms_;
     }
 
+    inline auto
+    begin(int ia) const
+    {
+        return alm_all_atoms_.at(memory_t::host, 0, mt_aw_offset_[ia]);
+    }
+
+    inline auto
+    end(int ia) const
+    {
+        return this->begin(ia) + this->gkvec().count() * unit_cell_.atom(ia).type().mt_aw_basis_size();
+    }
+
     /// Generate plane-wave matching coefficients for the radial solutions of a given atom.
     /** \param [in]  atom      Atom, for which matching coefficients are generated.
         \param [out] alm       Array of matching coefficients with dimension indices \f$ ({\bf G+k}, \xi) \f$.
@@ -313,10 +328,12 @@ class Matching_coefficients // TODO: compute on GPU
     inline void
     generate()
     {
+        PROFILE("sirius::Matching_coefficients::generate");
+
         int num_mt_aw{0};
-        std::vector<int> mt_aw_offset(unit_cell_.num_atoms());
+        mt_aw_offset_ = std::vector<int>(unit_cell_.num_atoms());
         for (int ia = 0; ia < unit_cell_.num_atoms(); ia++) {
-            mt_aw_offset[ia] = num_mt_aw;
+            mt_aw_offset_[ia] = num_mt_aw;
             num_mt_aw += unit_cell_.atom(ia).mt_aw_basis_size();
         }
 
@@ -326,7 +343,7 @@ class Matching_coefficients // TODO: compute on GPU
             auto& type = atom.type();
             /* wrap matching coefficients of a single atom */
             mdarray<std::complex<double>, 2> alm_atom({this->gkvec().count(), type.mt_aw_basis_size()},
-                                                       alm_all_atoms_.at(memory_t::host, 0, mt_aw_offset[ia]),
+                                                       alm_all_atoms_.at(memory_t::host, 0, mt_aw_offset_[ia]),
                                                        mdarray_label("alm_atom"));
             /* generate LAPW matching coefficients on the CPU */
             this->generate<false>(atom, alm_atom);

--- a/src/lapw/matching_coefficients.hpp
+++ b/src/lapw/matching_coefficients.hpp
@@ -188,7 +188,7 @@ class Matching_coefficients // TODO: compute on GPU
 
         if (all_atoms_) {
             alm_all_atoms_ = mdarray<std::complex<double>, 2>({gkvec_.count(), unit_cell_.mt_aw_basis_size()},
-                    mdarray_label("alm_all_atoms"));
+                                                              mdarray_label("alm_all_atoms"));
         }
     }
 
@@ -352,8 +352,8 @@ class Matching_coefficients // TODO: compute on GPU
             auto& type = atom.type();
             /* wrap matching coefficients of a single atom */
             mdarray<std::complex<double>, 2> alm_atom({this->gkvec().count(), type.mt_aw_basis_size()},
-                                                       alm_all_atoms_.at(memory_t::host, 0, mt_aw_offset_[ia]),
-                                                       mdarray_label("alm_atom"));
+                                                      alm_all_atoms_.at(memory_t::host, 0, mt_aw_offset_[ia]),
+                                                      mdarray_label("alm_atom"));
             /* generate conjugated LAPW matching coefficients on the CPU */
             this->generate<true>(atom, alm_atom);
         }

--- a/src/lapw/matching_coefficients.hpp
+++ b/src/lapw/matching_coefficients.hpp
@@ -58,6 +58,7 @@ class Matching_coefficients // TODO: compute on GPU
     mdarray<std::complex<double>, 4> alm_b_;
 
     /// Matching coefficients for all atoms.
+    /** For convenience, conjugated coefficients are stored */
     mdarray<std::complex<double>, 2> alm_all_atoms_;
 
     /// Offset in the alm_all_atoms array.
@@ -203,15 +204,23 @@ class Matching_coefficients // TODO: compute on GPU
         return all_atoms_;
     }
 
+    /// Return pointer to the beginning of Alm array for a given atom.
     inline auto
     begin(int ia) const
     {
+        if (!all_atoms_) {
+            RTE_THROW("Matching coefficients for all atoms were not allocated");
+        }
         return alm_all_atoms_.at(memory_t::host, 0, mt_aw_offset_[ia]);
     }
 
+    /// Return pointer to the end of Alm array for a given atom.
     inline auto
     end(int ia) const
     {
+        if (!all_atoms_) {
+            RTE_THROW("Matching coefficients for all atoms were not allocated");
+        }
         return this->begin(ia) + this->gkvec().count() * unit_cell_.atom(ia).type().mt_aw_basis_size();
     }
 
@@ -345,8 +354,8 @@ class Matching_coefficients // TODO: compute on GPU
             mdarray<std::complex<double>, 2> alm_atom({this->gkvec().count(), type.mt_aw_basis_size()},
                                                        alm_all_atoms_.at(memory_t::host, 0, mt_aw_offset_[ia]),
                                                        mdarray_label("alm_atom"));
-            /* generate LAPW matching coefficients on the CPU */
-            this->generate<false>(atom, alm_atom);
+            /* generate conjugated LAPW matching coefficients on the CPU */
+            this->generate<true>(atom, alm_atom);
         }
     }
 };

--- a/src/symmetry/symmetrize_pw_function.hpp
+++ b/src/symmetry/symmetrize_pw_function.hpp
@@ -359,8 +359,6 @@ symmetrize_pw_function_impl_v2(Crystal_symmetry const& sym__, fft::Gvec_sym cons
                sym_phase_factors__(2, G[2], isym);
     };
 
-    double const eps{1e-9};
-
     PROFILE_START("sirius::symmetrize|fpw|local");
 
     #pragma omp parallel for schedule(static, 1)


### PR DESCRIPTION
Major updates:
- cache Alm coefficients for all atoms. This is an important performance fix for LAPW Davidson solver.
- name change control->beta_chunk_size to control->max_atom_chunk_size to cover both pp-pw and lapw cases
- add a possibility to print mdarray allocation
- refactor get_h_o_diag_lapw()
- generate lapw wave-functions on GPUs 