### PR TITLE
CMake: Remove duplicate ScaLAPACK linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,8 +209,8 @@ else()
   find_package(LAPACK REQUIRED)
   set(SIRIUS_LINALG_LIB "${LAPACK_LIBRARIES}")
   if(SIRIUS_USE_SCALAPACK)
-    find_package(SCALAPACK REQUIRED) # just sets scalapack_DIR
-    set(SIRIUS_LINALG_LIB "${SIRIUS_LINALG_LIB};${SIRIUS_SCALAPACK_LIBRARIES}")
+    find_package(SCALAPACK REQUIRED)
+    list(APPEND SIRIUS_LINALG_LIB sirius::scalapack)
   endif()
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -114,7 +114,6 @@ target_link_libraries(sirius_cxx PUBLIC ${GSL_LIBRARY}
   sirius::hdf5
   costa::costa
   $<TARGET_NAME_IF_EXISTS:sirius::elpa>
-  $<TARGET_NAME_IF_EXISTS:sirius::scalapack>
   $<$<BOOL:${SIRIUS_USE_DLAF}>:DLAF::DLAF>
   $<TARGET_NAME_IF_EXISTS:sirius::magma>
   $<TARGET_NAME_IF_EXISTS:sirius::libvdwxc>


### PR DESCRIPTION
Follow up to #1148.