### PR TITLE
CMake: Preserve ScaLAPACK link interfaces for static builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,6 @@ endif()
 find_package(MPI REQUIRED)
 #set(GSL_CBLAS_LIBRARY ${BLAS_LIBRARIES} CACHE STRING "" FORCE)
 find_package(GSL REQUIRED)
-set_target_properties(GSL::gsl PROPERTIES INTERFACE_LINK_LIBRARIES "")
 find_package(LibXC 4.0.0 REQUIRED)
 find_package(LibSPG REQUIRED)
 find_package(HDF5 REQUIRED C)
@@ -174,43 +173,56 @@ endif()
 
 set(SIRIUS_LINALG_LIB "")
 if(SIRIUS_USE_MKL)
-  set(MKL_INTERFACE "lp64" CACHE STRING "")
-  set(MKL_THREADING "sequential" CACHE STRING "")
-  execute_process(COMMAND ${MPI_CXX_COMPILER} --showme:version
-                  OUTPUT_VARIABLE MPI_VER_OUT
-                  ERROR_VARIABLE MPI_VER_ERR)
-  if(MPI_VER_OUT MATCHES "Open MPI" OR MPI_VER_ERR MATCHES "Open MPI")
-    set(MKL_MPI "openmpi")
-  else()
-    set(MKL_MPI "intelmpi")
-  endif()
-  find_package(MKL CONFIG REQUIRED)
-  set(SIRIUS_LINALG_LIB "MKL::MKL")
+  set(MKL_INTERFACE "lp64" CACHE STRING "oneMKL interface: lp64 or ilp64")
+  set(MKL_THREADING "sequential" CACHE STRING "oneMKL threading layer")
+  set(MKL_LINK "dynamic" CACHE STRING "oneMKL linkage: static, dynamic, or sdl")
+  set_property(CACHE MKL_LINK PROPERTY STRINGS static dynamic sdl)
+
   if(SIRIUS_USE_SCALAPACK)
-    if(TARGET MKL::mkl_scalapack_lp64)
-      list(APPEND SIRIUS_LINALG_LIB MKL::mkl_scalapack_lp64)
-    else()
-      find_library(_MKL_SCALAPACK mkl_scalapack_lp64
-        HINTS $ENV{MKLROOT}/lib $ENV{MKLROOT}/lib/intel64)
-      list(APPEND SIRIUS_LINALG_LIB ${_MKL_SCALAPACK})
+    # Request the complete cluster target from MKLConfig.cmake.  It owns the
+    # ScaLAPACK -> BLACS -> MKL link order and the --start/--end-group pair
+    # needed for static oneMKL on ELF platforms.
+    set(ENABLE_SCALAPACK ON)
+
+    # Do not silently map every non-Open-MPI implementation to Intel MPI.
+    # MKLConfig.cmake accepts intelmpi, openmpi, mpich, and mpich2.
+    if(NOT DEFINED MKL_MPI)
+      if(MPI_CXX_LIBRARY_VERSION_STRING MATCHES "Open MPI")
+        set(MKL_MPI "openmpi")
+      elseif(MPI_CXX_LIBRARY_VERSION_STRING MATCHES "MPICH")
+        set(MKL_MPI "mpich")
+      elseif(MPI_CXX_LIBRARY_VERSION_STRING MATCHES "Intel.*MPI")
+        set(MKL_MPI "intelmpi")
+      else()
+        message(FATAL_ERROR
+          "Cannot infer MKL_MPI from MPI_CXX_LIBRARY_VERSION_STRING='${MPI_CXX_LIBRARY_VERSION_STRING}'. "
+          "Set -DMKL_MPI={intelmpi,openmpi,mpich,mpich2} explicitly.")
+      endif()
     endif()
-    if(TARGET MKL::mkl_blacs_${MKL_MPI}_lp64)
-      list(APPEND SIRIUS_LINALG_LIB MKL::mkl_blacs_${MKL_MPI}_lp64)
-    else()
-      find_library(_MKL_BLACS mkl_blacs_${MKL_MPI}_lp64
-        HINTS $ENV{MKLROOT}/lib $ENV{MKLROOT}/lib/intel64)
-      list(APPEND SIRIUS_LINALG_LIB ${_MKL_BLACS})
+  endif()
+
+  find_package(MKL CONFIG REQUIRED)
+
+  if(SIRIUS_USE_SCALAPACK)
+    if(NOT TARGET MKL::MKL_SCALAPACK)
+      message(FATAL_ERROR
+        "oneMKL did not provide MKL::MKL_SCALAPACK.  Ensure ENABLE_SCALAPACK=ON, "
+        "MKL_LINK is not 'sdl', and MKL_MPI names a supported MPI family.")
     endif()
+    set(SIRIUS_LINALG_LIB MKL::MKL_SCALAPACK)
+  else()
+    set(SIRIUS_LINALG_LIB MKL::MKL)
   endif()
 elseif(SIRIUS_USE_CRAY_LIBSCI)
   find_package(CRAY_LIBSCI REQUIRED)
   set(SIRIUS_LINALG_LIB "${SIRIUS_CRAY_LIBSCI_LIBRARIES}")
 else()
   find_package(LAPACK REQUIRED)
-  set(SIRIUS_LINALG_LIB "${LAPACK_LIBRARIES}")
   if(SIRIUS_USE_SCALAPACK)
     find_package(SCALAPACK REQUIRED)
-    list(APPEND SIRIUS_LINALG_LIB sirius::scalapack)
+    set(SIRIUS_LINALG_LIB sirius::scalapack)
+  else()
+    set(SIRIUS_LINALG_LIB LAPACK::LAPACK)
   endif()
 endif()
 

--- a/cmake/modules/FindSCALAPACK.cmake
+++ b/cmake/modules/FindSCALAPACK.cmake
@@ -1,32 +1,78 @@
 include(FindPackageHandleStandardArgs)
-find_package(PkgConfig REQUIRED)
 
-pkg_search_module(_SCALAPACK scalapack)
-find_library(SIRIUS_SCALAPACK_LIBRARIES
-  NAMES scalapack scalapack-openmpi scalapack-mpich
-  HINTS
-  ${_SCALAPACK_LIBRARY_DIRS}
-  ENV SCALAPACKROOT
-  /usr /usr/local
-  PATH_SUFFIXES lib lib64
-  DOC "scalapack library path")
+# Prefer a package-provided target: it is the only route that can faithfully
+# carry a vendor's complete BLACS / BLAS / LAPACK closure without guessing.
+find_package(scalapack CONFIG QUIET)
 
-if(NOT TARGET sirius::scalapack)
-  add_library(sirius::scalapack INTERFACE IMPORTED)
-  set_target_properties(sirius::scalapack PROPERTIES
-    INTERFACE_LINK_LIBRARIES "${SIRIUS_SCALAPACK_LIBRARIES}"
-  )
-  if(_SCALAPACK_INCLUDE_DIRS)
-    set_target_properties(sirius::scalapack PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${_SCALAPACK_INCLUDE_DIRS}"
-    )
+set(_scalapack_provider_target "")
+foreach(_target IN ITEMS scalapack::scalapack ScaLAPACK::ScaLAPACK scalapack)
+  if(TARGET ${_target})
+    set(_scalapack_provider_target ${_target})
+    break()
+  endif()
+endforeach()
+
+# Most distribution packages provide a .pc file.  Query its static closure so
+# the imported target also works when libscalapack itself is an archive.
+if(NOT _scalapack_provider_target)
+  find_package(PkgConfig QUIET)
+  if(PkgConfig_FOUND)
+    set(_scalapack_pkg_config_argn "${PKG_CONFIG_ARGN}")
+    list(PREPEND PKG_CONFIG_ARGN --static)
+    pkg_search_module(_SCALAPACK QUIET IMPORTED_TARGET
+      scalapack scalapack-openmpi scalapack-mpich)
+    set(PKG_CONFIG_ARGN "${_scalapack_pkg_config_argn}")
+
+    if(_SCALAPACK_FOUND)
+      set(_scalapack_provider_target PkgConfig::_SCALAPACK)
+    endif()
   endif()
 endif()
 
-if(CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES)
-  set_property(TARGET sirius::scalapack APPEND PROPERTY
-    INTERFACE_LINK_LIBRARIES ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES})
+# Last resort for installations with neither a Config package nor pkg-config.
+# SIRIUS_SCALAPACK_LIBRARIES is deliberately a *list*: a caller can supply the
+# full ordered static closure (ScaLAPACK, BLACS and any init archives) instead
+# of losing it through a one-library find_library() result.
+set(SIRIUS_SCALAPACK_LIBRARIES "" CACHE STRING
+  "Ordered ScaLAPACK link items for the raw fallback")
+if(NOT _scalapack_provider_target)
+  if(NOT SIRIUS_SCALAPACK_LIBRARIES)
+    find_library(SIRIUS_SCALAPACK_LIBRARY
+      NAMES scalapack scalapack-openmpi scalapack-mpich
+      HINTS ENV SCALAPACKROOT
+      PATH_SUFFIXES lib lib64
+      DOC "ScaLAPACK library path")
+    set(SIRIUS_SCALAPACK_LIBRARIES "${SIRIUS_SCALAPACK_LIBRARY}")
+  endif()
+  set(_scalapack_provider_target "${SIRIUS_SCALAPACK_LIBRARIES}")
+  set(_scalapack_raw_fallback TRUE)
 endif()
 
-find_package_handle_standard_args(SCALAPACK DEFAULT_MSG SIRIUS_SCALAPACK_LIBRARIES)
-mark_as_advanced(SIRIUS_SCALAPACK_LIBRARIES)
+find_package_handle_standard_args(SCALAPACK
+  REQUIRED_VARS _scalapack_provider_target)
+
+if(SCALAPACK_FOUND AND NOT TARGET sirius::scalapack)
+  add_library(sirius::scalapack INTERFACE IMPORTED)
+  target_link_libraries(sirius::scalapack INTERFACE
+    "${_scalapack_provider_target}")
+
+  # A raw shared library records its own dependencies, but a raw static archive
+  # does not.  Append the universal part of the dependency graph in the only
+  # safe direction: ScaLAPACK first, then MPI and LAPACK.  For a split static
+  # BLACS installation users must set SIRIUS_SCALAPACK_LIBRARIES to its complete
+  # ordered archive list; Config and pkg-config providers need no guessing here.
+  if(_scalapack_raw_fallback)
+    find_package(MPI REQUIRED COMPONENTS CXX)
+    find_package(LAPACK REQUIRED)
+    target_link_libraries(sirius::scalapack INTERFACE
+      MPI::MPI_CXX
+      LAPACK::LAPACK)
+  endif()
+
+  if(CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES)
+    target_link_libraries(sirius::scalapack INTERFACE
+      ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES})
+  endif()
+endif()
+
+mark_as_advanced(SIRIUS_SCALAPACK_LIBRARY)

--- a/cmake/sirius_cxxConfig.cmake.in
+++ b/cmake/sirius_cxxConfig.cmake.in
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.23)
 
+include(CMakeFindDependencyMacro)
+
 if(NOT TARGET sirius::sirius_cxx)
   # Find bundled modules first
   set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules"
@@ -33,9 +35,6 @@ if(NOT TARGET sirius::sirius_cxx)
 
   find_dependency(MPI ${mode} COMPONENTS CXX)
   find_dependency(GSL ${mode})
-  if(TARGET GSL::gsl)
-    set_target_properties(GSL::gsl PROPERTIES INTERFACE_LINK_LIBRARIES "")
-  endif()
   find_dependency(fmt ${mode})
   find_dependency(LibXC 3.0.0 ${mode})
   find_dependency(LibSPG ${mode})
@@ -66,14 +65,18 @@ if(NOT TARGET sirius::sirius_cxx)
   if(SIRIUS_USE_MKL)
     set(MKL_INTERFACE "@MKL_INTERFACE@")
     set(MKL_THREADING "@MKL_THREADING@")
+    set(MKL_LINK "@MKL_LINK@")
     set(MKL_MPI "@MKL_MPI@")
-    find_dependency(MKL CONFIG)
+    if(SIRIUS_USE_SCALAPACK)
+      set(ENABLE_SCALAPACK ON)
+    endif()
+    find_dependency(MKL CONFIG ${mode})
   elseif(SIRIUS_USE_CRAY_LIBSCI)
     find_dependency(CRAY_LIBSCI ${mode})
   else()
     find_dependency(LAPACK ${mode})
     if(SIRIUS_USE_SCALAPACK)
-      find_dependency(SCALAPACK ${mode}) # just sets scalapack_DIR
+      find_dependency(SCALAPACK ${mode})
     endif()
   endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,7 +107,7 @@ if(SIRIUS_USE_CUDA)
    set_target_properties(sirius_cxx PROPERTIES CUDA_ARCHITECTURES ${CMAKE_CUDA_ARCHITECTURES})
 endif()
 
-target_link_libraries(sirius_cxx PUBLIC ${GSL_LIBRARY}
+target_link_libraries(sirius_cxx PUBLIC
   MPI::MPI_CXX
   sirius::libxc
   sirius::libspg


### PR DESCRIPTION
This reworks the linear-algebra dependency setup so that ScaLAPACK keeps its complete transitive link interface instead of being flattened into a manually ordered library list.

* Prefer a package-provided ScaLAPACK target, then a `pkg-config --static` target, before falling back to a user-provided ordered library list.
* Link `sirius::scalapack` before its MPI and LAPACK dependencies, which is required when ScaLAPACK and/or LAPACK are static archives.
* Use oneMKL's `MKL::MKL_SCALAPACK` target when ScaLAPACK support is enabled, allowing `MKLConfig.cmake` to provide the matching BLACS libraries and required static-link group options.
* Detect Open MPI, MPICH, and Intel MPI explicitly rather than treating every non-Open-MPI implementation as Intel MPI. (MPICH is compatible with Intel MPI wrappers)
* Preserve the imported `GSL::gsl` usage requirements instead of clearing its CBLAS dependency.
* Make the installed `sirius_cxx` package self-contained by including `CMakeFindDependencyMacro` and restoring the oneMKL configuration needed by downstream consumers.