### PR TITLE
CMake: Remove cmake_minimum_required from Config

### DIFF
--- a/cmake/siriusConfig.cmake.in
+++ b/cmake/siriusConfig.cmake.in
@@ -1,5 +1,9 @@
 @PACKAGE_INIT@
 
+if(CMAKE_VERSION VERSION_LESS "3.25")
+  message(FATAL_ERROR "SIRIUS requires CMake 3.25 or newer.")
+endif()
+
 include(CMakeFindDependencyMacro)
 
 set(SIRIUS_USE_DFTD3 @SIRIUS_USE_DFTD3@)

--- a/cmake/sirius_cxxConfig.cmake.in
+++ b/cmake/sirius_cxxConfig.cmake.in
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.23)
-
 include(CMakeFindDependencyMacro)
 
 if(NOT TARGET sirius::sirius_cxx)

--- a/cmake/sirius_cxxConfig.cmake.in
+++ b/cmake/sirius_cxxConfig.cmake.in
@@ -1,3 +1,7 @@
+if(CMAKE_VERSION VERSION_LESS "3.25")
+  message(FATAL_ERROR "SIRIUS requires CMake 3.25 or newer.")
+endif()
+
 include(CMakeFindDependencyMacro)
 
 if(NOT TARGET sirius::sirius_cxx)


### PR DESCRIPTION
Setting `cmake_minimum_required()` in `sirius_cxxConfig.cmake.in` will override the policy settings inherited from downstream projects, such as `CMP0144`.