### PR TITLE
Describe sirius_cxx as a dependent library for shared builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,7 +318,8 @@ if(SIRIUS_CREATE_FORTRAN_BINDINGS)
   # write siriusConfig.cmake for F90 API
   configure_package_config_file("${PROJECT_SOURCE_DIR}/cmake/siriusConfig.cmake.in"
     "${PROJECT_BINARY_DIR}/siriusConfig.cmake"
-    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/sirius)
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/sirius"
+    PATH_VARS CMAKE_INSTALL_LIBDIR)
   install(FILES "${PROJECT_BINARY_DIR}/siriusConfig.cmake"
                 "${PROJECT_BINARY_DIR}/siriusConfigVersion.cmake"
                 DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/sirius")

--- a/cmake/siriusConfig.cmake.in
+++ b/cmake/siriusConfig.cmake.in
@@ -12,10 +12,31 @@ set(SIRIUS_USE_NLCGLIB @SIRIUS_USE_NLCGLIB@)
 set(SIRIUS_USE_VCSQNM @SIRIUS_USE_VCSQNM@)
 
 set(SIRIUS_BUILD_SHARED_LIBS @BUILD_SHARED_LIBS@)
+
 if(NOT SIRIUS_BUILD_SHARED_LIBS)
+  # Static archives need the complete transitive link closure.
   find_dependency(sirius_cxx CONFIG)
 endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/siriusTargets.cmake")
+
+if(SIRIUS_BUILD_SHARED_LIBS)
+  # libsirius_cxx is an implementation dependency of libsirius,
+  # not part of the public Fortran usage requirements.
+  find_library(
+    _SIRIUS_CXX_LIBRARY
+    NAMES sirius_cxx
+    PATHS @PACKAGE_CMAKE_INSTALL_LIBDIR@
+    NO_DEFAULT_PATH
+    NO_CACHE
+    REQUIRED
+  )
+  set_property(
+    TARGET sirius::sirius
+    APPEND PROPERTY IMPORTED_LINK_DEPENDENT_LIBRARIES
+    "${_SIRIUS_CXX_LIBRARY}"
+  )
+  unset(_SIRIUS_CXX_LIBRARY)
+endif()
 
 check_required_components(sirius)


### PR DESCRIPTION
Describe `libsirius_cxx` as an implementation dependency of the imported `sirius::sirius` target when SIRIUS is built with shared libraries.

This allows consumers to link only against `sirius::sirius` without loading the full `sirius_cxx` dependency interface, which can otherwise rediscover conflicting ELPA or DFT-D3 providers and leak C++ usage requirements into Fortran consumers.

Static builds retain the existing `find_dependency(sirius_cxx CONFIG)` behavior because they require the complete transitive link closure.
