### PR TITLE
fix nvhpc compilation

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,6 +90,15 @@ set(_SOURCES
 
   # create library with .cpp, .cu and .f90 sources
 add_library(sirius_cxx "${_SOURCES};${_CUSOURCES};")
+
+# sirius+cuda is crashing nvcpfe (segfault) in hamiltonian_k.cpp
+# when processing openmp directives
+if(CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
+  set_source_files_properties(hamiltonian/hamiltonian_k.cpp PROPERTIES
+      COMPILE_OPTIONS "-Mnoopenmp")
+endif()
+
+
 target_compile_features(sirius_cxx PUBLIC cxx_std_17)
 target_compile_features(sirius_cxx PUBLIC c_std_99)
 target_compile_features(sirius_cxx PUBLIC cuda_std_17)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,8 +90,6 @@ set(_SOURCES
 
   # create library with .cpp, .cu and .f90 sources
 add_library(sirius_cxx "${_SOURCES};${_CUSOURCES};")
-
-
 target_compile_features(sirius_cxx PUBLIC cxx_std_17)
 target_compile_features(sirius_cxx PUBLIC c_std_99)
 target_compile_features(sirius_cxx PUBLIC cuda_std_17)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,13 +91,6 @@ set(_SOURCES
   # create library with .cpp, .cu and .f90 sources
 add_library(sirius_cxx "${_SOURCES};${_CUSOURCES};")
 
-# sirius+cuda is crashing nvcpfe (segfault) in hamiltonian_k.cpp
-# when processing openmp directives
-if(CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC")
-  set_source_files_properties(hamiltonian/hamiltonian_k.cpp PROPERTIES
-      COMPILE_OPTIONS "-Mnoopenmp")
-endif()
-
 
 target_compile_features(sirius_cxx PUBLIC cxx_std_17)
 target_compile_features(sirius_cxx PUBLIC c_std_99)

--- a/src/core/omp.hpp
+++ b/src/core/omp.hpp
@@ -20,9 +20,13 @@
 
 #include <omp.h>
 
+/* NVC++ does not support user-defined OpenMP reductions ("declare reduction for user defined
+ * reductions" is not part of the "NVIDIA subset" of OpenMP); guard it out for that compiler. */
+#if !defined(__NVCOMPILER)
 #pragma omp declare reduction( \
     complex_double_plus : std::complex<double> : omp_out += omp_in \
 ) initializer(omp_priv = std::complex<double>{0.0, 0.0})
+#endif
 
 #else
 inline int

--- a/src/density/density.cpp
+++ b/src/density/density.cpp
@@ -898,8 +898,8 @@ add_k_point_contribution_dm_fplapw(Simulation_context const& ctx__, K_point<T> c
             for (int ispn = 0; ispn < ctx__.num_spins(); ispn++) {
                 for (int j = 0; j < kp__.num_occupied_bands(ispn); j++) {
                     for (int xi = 0; xi < mt_basis_size; xi++) {
-                        auto z           = kp__.spinor_wave_functions().mt_coeffs(xi, li, wf::spin_index(ispn),
-                                                                                  wf::band_index(j));
+                        auto z =
+                                kp__.spinor_wave_functions().mt_coeffs(xi, li, wf::spin_index(ispn), wf::band_index(j));
                         wf1(xi, j, ispn) = std::conj(z);
                         wf2(xi, j, ispn) =
                                 static_cast<std::complex<double>>(z) * kp__.band_occupancy(j, ispn) * kp__.weight();

--- a/src/density/density.cpp
+++ b/src/density/density.cpp
@@ -661,9 +661,10 @@ Density::generate_paw_density()
 
     PROFILE("sirius::Density::generate_paw_density");
 
+    int n = unit_cell_.spl_num_paw_atoms().local_size();
     #pragma omp parallel for
-    for (auto it : unit_cell_.spl_num_paw_atoms()) {
-        generate_paw_density(it.li);
+    for (int i = 0; i < n; i++) {
+        generate_paw_density(paw_atom_index_t::local(i));
     }
 }
 
@@ -883,19 +884,21 @@ add_k_point_contribution_dm_fplapw(Simulation_context const& ctx__, K_point<T> c
     auto one = la::constant<std::complex<double>>::one();
 
     /* add |psi_j> n_j <psi_j| to density matrix */
+    int nat_loc = kp__.spinor_wave_functions().spl_num_atoms().local_size();
     #pragma omp parallel
     {
         mdarray<std::complex<double>, 3> wf1({uc.max_mt_basis_size(), ctx__.num_bands(), ctx__.num_spins()});
         mdarray<std::complex<double>, 3> wf2({uc.max_mt_basis_size(), ctx__.num_bands(), ctx__.num_spins()});
         #pragma omp for
-        for (auto it : kp__.spinor_wave_functions().spl_num_atoms()) {
-            int ia            = it.i;
+        for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
+            auto li           = atom_index_t::local(ialoc);
+            int ia            = kp__.spinor_wave_functions().spl_num_atoms().global_index(li);
             int mt_basis_size = uc.atom(ia).type().mt_basis_size();
 
             for (int ispn = 0; ispn < ctx__.num_spins(); ispn++) {
                 for (int j = 0; j < kp__.num_occupied_bands(ispn); j++) {
                     for (int xi = 0; xi < mt_basis_size; xi++) {
-                        auto z           = kp__.spinor_wave_functions().mt_coeffs(xi, it.li, wf::spin_index(ispn),
+                        auto z           = kp__.spinor_wave_functions().mt_coeffs(xi, li, wf::spin_index(ispn),
                                                                                   wf::band_index(j));
                         wf1(xi, j, ispn) = std::conj(z);
                         wf2(xi, j, ispn) =

--- a/src/geometry/force.cpp
+++ b/src/geometry/force.cpp
@@ -355,28 +355,34 @@ Force::calc_forces_ewald()
 
     mdarray<std::complex<double>, 1> rho_tmp({ctx_.gvec().count()});
     rho_tmp.zero();
+    int igloc0 = ctx_.gvec().skip_g0();
+    int ngv    = ctx_.gvec().count();
     #pragma omp parallel for schedule(static)
-    for (auto it : skip_g0(ctx_.gvec())) {
+    for (int igloc = igloc0; igloc < ngv; igloc++) {
 
-        double g2 = std::pow(ctx_.gvec().gvec_len(it.igloc), 2);
+        auto ig = ctx_.gvec().global_index(gvec_index_t::local(igloc));
+
+        double g2 = std::pow(ctx_.gvec().gvec_len(gvec_index_t::local(igloc)), 2);
 
         std::complex<double> rho(0, 0);
 
         for (int ja = 0; ja < unit_cell.num_atoms(); ja++) {
-            rho += ctx_.gvec_phase_factor(it.ig, ja) * static_cast<double>(unit_cell.atom(ja).zn());
+            rho += ctx_.gvec_phase_factor(ig, ja) * static_cast<double>(unit_cell.atom(ja).zn());
         }
 
-        rho_tmp[it.igloc] = prefac * std::conj(rho) * std::exp(-g2 / (4 * alpha)) / g2;
+        rho_tmp[igloc] = prefac * std::conj(rho) * std::exp(-g2 / (4 * alpha)) / g2;
     }
 
     #pragma omp parallel for
     for (int ja = 0; ja < unit_cell.num_atoms(); ja++) {
-        for (auto it : skip_g0(ctx_.gvec())) {
+        for (int igloc = igloc0; igloc < ngv; igloc++) {
+
+            auto ig = ctx_.gvec().global_index(gvec_index_t::local(igloc));
 
             /* cartesian coordinates for getting cartesian force components */
-            auto gvec_cart = ctx_.gvec().gvec_cart(it.igloc);
+            auto gvec_cart = ctx_.gvec().gvec_cart(gvec_index_t::local(igloc));
 
-            double scalar_part = (rho_tmp[it.igloc] * ctx_.gvec_phase_factor(it.ig, ja)).imag() *
+            double scalar_part = (rho_tmp[igloc] * ctx_.gvec_phase_factor(ig, ja)).imag() *
                                  static_cast<double>(unit_cell.atom(ja).zn());
 
             for (int x : {0, 1, 2}) {

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -887,6 +887,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
     int ngv = kp_.num_gkvec_loc();
 
     auto& spl_atoms = phi__.spl_num_atoms();
+    int nat_loc     = spl_atoms.local_size();
 
     /* block size of scalapack distribution */
     int bs = ctx.cyclic_block_size();
@@ -895,18 +896,18 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
     auto& zero = la::constant<Tc>::zero();
 
     /* apply APW-lo muffin-tin part of Hamiltonian to lo- part of wave-functions */
-    auto apply_hmt_apw_lo = [this, &ctx, &phi__, la, mem, &b__, &spl_atoms](wf::Wave_functions_mt<T>& h_apw_lo__) {
+    auto apply_hmt_apw_lo = [this, &ctx, &phi__, la, mem, &b__, &spl_atoms,
+                             nat_loc](wf::Wave_functions_mt<T>& h_apw_lo__) {
         #pragma omp parallel for
-        for (auto it : spl_atoms) {
+        for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
             int tid    = omp_get_thread_num();
-            int ia     = it.i;
+            /* local atom index */
+            auto aidx  = atom_index_t::local(ialoc);
+            int ia     = spl_atoms.global_index(aidx);
             auto& atom = ctx.unit_cell().atom(ia);
             auto& type = atom.type();
             int naw    = type.mt_aw_basis_size();
             int nlo    = type.mt_lo_basis_size();
-
-            /* local atom index */
-            auto aidx = it.li;
 
             auto& hmt = this->H0_.hmt(ia);
 
@@ -922,18 +923,17 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
     };
 
     /* apply APW-lo part of overlap matrix to lo- part of wave-functions */
-    auto apply_omt_apw_lo = [this, &ctx, &phi__, &b__, &spl_atoms](wf::Wave_functions_mt<T>& o_apw_lo__) {
+    auto apply_omt_apw_lo = [this, &ctx, &phi__, &b__, &spl_atoms, nat_loc](wf::Wave_functions_mt<T>& o_apw_lo__) {
         o_apw_lo__.zero(memory_t::host, wf::spin_index(0), wf::band_range(0, b__.size()));
 
         #pragma omp parallel for
-        for (auto it : spl_atoms) {
-            int ia     = it.i;
+        for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
+            auto aidx  = atom_index_t::local(ialoc);
+            int ia     = spl_atoms.global_index(aidx);
             auto& atom = ctx.unit_cell().atom(ia);
             auto& type = atom.type();
             int naw    = type.mt_aw_basis_size();
             int nlo    = type.mt_lo_basis_size();
-
-            auto aidx = it.li;
 
             for (int j = 0; j < b__.size(); j++) {
                 for (int ilo = 0; ilo < nlo; ilo++) {
@@ -953,18 +953,17 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
         }
     };
 
-    auto appy_hmt_lo_lo = [this, &ctx, &phi__, la, mem, &b__, &spl_atoms](wf::Wave_functions<T>& hphi__) {
+    auto appy_hmt_lo_lo = [this, &ctx, &phi__, la, mem, &b__, &spl_atoms, nat_loc](wf::Wave_functions<T>& hphi__) {
         /* lo-lo contribution */
         #pragma omp parallel for
-        for (auto it : spl_atoms) {
+        for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
             int tid    = omp_get_thread_num();
-            auto ia    = it.i;
+            auto aidx  = atom_index_t::local(ialoc);
+            auto ia    = spl_atoms.global_index(aidx);
             auto& atom = ctx.unit_cell().atom(ia);
             auto& type = atom.type();
             int naw    = type.mt_aw_basis_size();
             int nlo    = type.mt_lo_basis_size();
-
-            auto aidx = it.li;
 
             auto& hmt = H0_.hmt(ia);
 
@@ -976,15 +975,14 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
         }
     };
 
-    auto appy_omt_lo_lo = [this, &ctx, &phi__, &b__, &spl_atoms](wf::Wave_functions<T>& ophi__) {
+    auto appy_omt_lo_lo = [this, &ctx, &phi__, &b__, &spl_atoms, nat_loc](wf::Wave_functions<T>& ophi__) {
         /* lo-lo contribution */
         #pragma omp parallel for
-        for (auto it : spl_atoms) {
-            auto ia    = it.i;
+        for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
+            auto aidx  = atom_index_t::local(ialoc);
+            auto ia    = spl_atoms.global_index(aidx);
             auto& atom = ctx.unit_cell().atom(ia);
             auto& type = atom.type();
-
-            auto aidx = it.li;
 
             for (int ilo = 0; ilo < type.mt_lo_basis_size(); ilo++) {
                 int xi_lo = type.mt_aw_basis_size() + ilo;
@@ -1013,15 +1011,15 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
     auto appy_hmt_apw_apw = [this, &ctx, la, mem, &b__](int atom_begin__, wf::Wave_functions_mt<T> const& alm_phi__,
                                                         wf::Wave_functions_mt<T>& halm_phi__) {
         size_t nops{0};
+        int nat_loc_alm = alm_phi__.spl_num_atoms().local_size();
         #pragma omp parallel for reduction(+:nops)
-        for (auto it : alm_phi__.spl_num_atoms()) {
+        for (int ialoc = 0; ialoc < nat_loc_alm; ialoc++) {
             int tid    = omp_get_thread_num();
-            int ia     = atom_begin__ + it.i;
+            auto aidx  = atom_index_t::local(ialoc);
+            int ia     = atom_begin__ + alm_phi__.spl_num_atoms().global_index(aidx);
             auto& atom = ctx.unit_cell().atom(ia);
             auto& type = atom.type();
             int naw    = type.mt_aw_basis_size();
-
-            auto aidx = it.li;
 
             auto& hmt = H0_.hmt(ia);
 
@@ -1036,18 +1034,17 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
         return nops;
     };
 
-    auto apply_hmt_lo_apw = [this, &ctx, la, mem, &b__, &spl_atoms](wf::Wave_functions_mt<T> const& alm_phi__,
-                                                                    wf::Wave_functions<T>& hphi__) {
+    auto apply_hmt_lo_apw = [this, &ctx, la, mem, &b__, &spl_atoms,
+                             nat_loc](wf::Wave_functions_mt<T> const& alm_phi__, wf::Wave_functions<T>& hphi__) {
         #pragma omp parallel for
-        for (auto it : spl_atoms) {
+        for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
             int tid    = omp_get_thread_num();
-            int ia     = it.i;
+            auto aidx  = atom_index_t::local(ialoc);
+            int ia     = spl_atoms.global_index(aidx);
             auto& atom = ctx.unit_cell().atom(ia);
             auto& type = atom.type();
             int naw    = type.mt_aw_basis_size();
             int nlo    = type.mt_lo_basis_size();
-
-            auto aidx = it.li;
 
             auto& hmt = H0_.hmt(ia);
 
@@ -1059,17 +1056,16 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
         }
     };
 
-    auto apply_omt_lo_apw = [this, &ctx, mem, &b__, &spl_atoms](wf::Wave_functions_mt<T> const& alm_phi__,
-                                                                wf::Wave_functions<T>& ophi__) {
+    auto apply_omt_lo_apw = [this, &ctx, mem, &b__, &spl_atoms,
+                             nat_loc](wf::Wave_functions_mt<T> const& alm_phi__, wf::Wave_functions<T>& ophi__) {
         #pragma omp parallel for
-        for (auto it : spl_atoms) {
-            int ia     = it.i;
+        for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
+            auto aidx  = atom_index_t::local(ialoc);
+            int ia     = spl_atoms.global_index(aidx);
             auto& atom = ctx.unit_cell().atom(ia);
             auto& type = atom.type();
             int naw    = type.mt_aw_basis_size();
             int nlo    = type.mt_lo_basis_size();
-
-            auto aidx = it.li;
 
             for (int ilo = 0; ilo < nlo; ilo++) {
                 int xi_lo = naw + ilo;

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -33,8 +33,7 @@ namespace {
 template <typename T>
 void
 accumulate_pw_diag(mdarray<T, 2>& diag__, matrix<std::complex<T>> const& beta_gk_tmp__,
-                    matrix<std::complex<T>> const& beta_gk_t__, int offs__, int nbf__, int ispn__,
-                    int num_gkvec_loc__)
+                   matrix<std::complex<T>> const& beta_gk_t__, int offs__, int nbf__, int ispn__, int num_gkvec_loc__)
 {
     #pragma omp parallel for schedule(static)
     for (int ig_loc = 0; ig_loc < num_gkvec_loc__; ig_loc++) {
@@ -909,7 +908,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
         /* dispatch one async gemm per atom, round-robin over the available GPU streams;
          * gemm calls are non-blocking, so a plain serial loop still saturates the GPU */
         for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
-            int sid    = ialoc % acc::num_streams();
+            int sid = ialoc % acc::num_streams();
             /* local atom index */
             auto aidx  = atom_index_t::local(ialoc);
             int ia     = spl_atoms.global_index(aidx);
@@ -1042,8 +1041,8 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
         return nops;
     };
 
-    auto apply_hmt_lo_apw = [this, &ctx, la, mem, &b__, &spl_atoms,
-                             nat_loc](wf::Wave_functions_mt<T> const& alm_phi__, wf::Wave_functions<T>& hphi__) {
+    auto apply_hmt_lo_apw = [this, &ctx, la, mem, &b__, &spl_atoms, nat_loc](wf::Wave_functions_mt<T> const& alm_phi__,
+                                                                             wf::Wave_functions<T>& hphi__) {
         /* dispatch one async gemm per atom, round-robin over GPU streams */
         for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
             int sid    = ialoc % acc::num_streams();
@@ -1064,8 +1063,8 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
         }
     };
 
-    auto apply_omt_lo_apw = [this, &ctx, mem, &b__, &spl_atoms,
-                             nat_loc](wf::Wave_functions_mt<T> const& alm_phi__, wf::Wave_functions<T>& ophi__) {
+    auto apply_omt_lo_apw = [this, &ctx, mem, &b__, &spl_atoms, nat_loc](wf::Wave_functions_mt<T> const& alm_phi__,
+                                                                         wf::Wave_functions<T>& ophi__) {
         #pragma omp parallel for
         for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
             auto aidx  = atom_index_t::local(ialoc);

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -898,9 +898,10 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
     /* apply APW-lo muffin-tin part of Hamiltonian to lo- part of wave-functions */
     auto apply_hmt_apw_lo = [this, &ctx, &phi__, la, mem, &b__, &spl_atoms,
                              nat_loc](wf::Wave_functions_mt<T>& h_apw_lo__) {
-        #pragma omp parallel for
+        /* dispatch one async gemm per atom, round-robin over the available GPU streams;
+         * gemm calls are non-blocking, so a plain serial loop still saturates the GPU */
         for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
-            int tid    = omp_get_thread_num();
+            int sid    = ialoc % acc::num_streams();
             /* local atom index */
             auto aidx  = atom_index_t::local(ialoc);
             int ia     = spl_atoms.global_index(aidx);
@@ -915,7 +916,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
                               hmt.ld(), phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())),
                               phi__.ld(), &la::constant<Tc>::zero(),
                               h_apw_lo__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(0)), h_apw_lo__.ld(),
-                              acc::stream_id(tid));
+                              acc::stream_id(sid));
         }
         if (is_device_memory(mem)) {
             h_apw_lo__.copy_to(memory_t::host);
@@ -954,10 +955,9 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
     };
 
     auto appy_hmt_lo_lo = [this, &ctx, &phi__, la, mem, &b__, &spl_atoms, nat_loc](wf::Wave_functions<T>& hphi__) {
-        /* lo-lo contribution */
-        #pragma omp parallel for
+        /* lo-lo contribution; dispatch one async gemm per atom, round-robin over GPU streams */
         for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
-            int tid    = omp_get_thread_num();
+            int sid    = ialoc % acc::num_streams();
             auto aidx  = atom_index_t::local(ialoc);
             auto ia    = spl_atoms.global_index(aidx);
             auto& atom = ctx.unit_cell().atom(ia);
@@ -971,7 +971,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
                               hmt.ld(), phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())),
                               phi__.ld(), &la::constant<Tc>::one(),
                               hphi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())), hphi__.ld(),
-                              acc::stream_id(tid));
+                              acc::stream_id(sid));
         }
     };
 
@@ -1012,9 +1012,9 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
                                                         wf::Wave_functions_mt<T>& halm_phi__) {
         size_t nops{0};
         int nat_loc_alm = alm_phi__.spl_num_atoms().local_size();
-        #pragma omp parallel for reduction(+:nops)
+        /* dispatch one async gemm per atom, round-robin over GPU streams */
         for (int ialoc = 0; ialoc < nat_loc_alm; ialoc++) {
-            int tid    = omp_get_thread_num();
+            int sid    = ialoc % acc::num_streams();
             auto aidx  = atom_index_t::local(ialoc);
             int ia     = atom_begin__ + alm_phi__.spl_num_atoms().global_index(aidx);
             auto& atom = ctx.unit_cell().atom(ia);
@@ -1028,7 +1028,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
                               alm_phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(0)), alm_phi__.ld(),
                               &la::constant<Tc>::zero(),
                               halm_phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(0)), halm_phi__.ld(),
-                              acc::stream_id(tid));
+                              acc::stream_id(sid));
             nops += 8L * naw * b__.size() * naw;
         }
         return nops;
@@ -1036,9 +1036,9 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
 
     auto apply_hmt_lo_apw = [this, &ctx, la, mem, &b__, &spl_atoms,
                              nat_loc](wf::Wave_functions_mt<T> const& alm_phi__, wf::Wave_functions<T>& hphi__) {
-        #pragma omp parallel for
+        /* dispatch one async gemm per atom, round-robin over GPU streams */
         for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
-            int tid    = omp_get_thread_num();
+            int sid    = ialoc % acc::num_streams();
             auto aidx  = atom_index_t::local(ialoc);
             int ia     = spl_atoms.global_index(aidx);
             auto& atom = ctx.unit_cell().atom(ia);
@@ -1052,7 +1052,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
                               hmt.ld(), alm_phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(0)),
                               alm_phi__.ld(), &la::constant<Tc>::one(),
                               hphi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())), hphi__.ld(),
-                              acc::stream_id(tid));
+                              acc::stream_id(sid));
         }
     };
 

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -24,6 +24,30 @@
 
 namespace sirius {
 
+namespace {
+
+/* accumulate <G+k|beta_xi1> X_{xi1, xi2} <beta_xi2|G+k> into diag(ig_loc, ispn); factored out of
+ * Hamiltonian_k<T>::get_h_o_diag_pw() and templated on T only (rather than inline in a function
+ * also templated on <F, what>) to keep the number of TU-level instantiations carrying this
+ * OpenMP loop small. */
+template <typename T>
+void
+accumulate_pw_diag(mdarray<T, 2>& diag__, matrix<std::complex<T>> const& beta_gk_tmp__,
+                    matrix<std::complex<T>> const& beta_gk_t__, int offs__, int nbf__, int ispn__,
+                    int num_gkvec_loc__)
+{
+    #pragma omp parallel for schedule(static)
+    for (int ig_loc = 0; ig_loc < num_gkvec_loc__; ig_loc++) {
+        T sum{0};
+        for (int xi = 0; xi < nbf__; xi++) {
+            sum += std::real(beta_gk_tmp__(ig_loc, xi) * std::conj(beta_gk_t__(ig_loc, offs__ + xi)));
+        }
+        diag__(ig_loc, ispn__) += sum;
+    }
+}
+
+} // namespace
+
 template <typename T>
 Hamiltonian_k<T>::Hamiltonian_k(Hamiltonian0<T> const& H0__, K_point<T>& kp__)
     : H0_(H0__)
@@ -144,15 +168,7 @@ Hamiltonian_k<T>::get_h_o_diag_pw() const
                         .gemm('N', 'N', kp_.num_gkvec_loc(), nbf, nbf, &la::constant<std::complex<T>>::one(),
                               &beta_gk_t(0, offs), beta_gk_t.ld(), &d_sum(0, 0), d_sum.ld(),
                               &la::constant<std::complex<T>>::zero(), &beta_gk_tmp(0, 0), beta_gk_tmp.ld());
-                #pragma omp parallel
-                for (int xi = 0; xi < nbf; xi++) {
-                    #pragma omp for schedule(static) nowait
-                    for (int ig_loc = 0; ig_loc < kp_.num_gkvec_loc(); ig_loc++) {
-                        /* compute <G+k|beta_xi1> D_{xi1, xi2} <beta_xi2|G+k> contribution from all atoms */
-                        h_diag(ig_loc, ispn) +=
-                                std::real(beta_gk_tmp(ig_loc, xi) * std::conj(beta_gk_t(ig_loc, offs + xi)));
-                    }
-                }
+                accumulate_pw_diag(h_diag, beta_gk_tmp, beta_gk_t, offs, nbf, ispn, kp_.num_gkvec_loc());
             }
 
             if (what & 2) {
@@ -160,15 +176,7 @@ Hamiltonian_k<T>::get_h_o_diag_pw() const
                         .gemm('N', 'N', kp_.num_gkvec_loc(), nbf, nbf, &la::constant<std::complex<T>>::one(),
                               &beta_gk_t(0, offs), beta_gk_t.ld(), &q_sum(0, 0), q_sum.ld(),
                               &la::constant<std::complex<T>>::zero(), &beta_gk_tmp(0, 0), beta_gk_tmp.ld());
-                #pragma omp parallel
-                for (int xi = 0; xi < nbf; xi++) {
-                    #pragma omp for schedule(static) nowait
-                    for (int ig_loc = 0; ig_loc < kp_.num_gkvec_loc(); ig_loc++) {
-                        /* compute <G+k|beta_xi1> Q_{xi1, xi2} <beta_xi2|G+k> contribution from all atoms */
-                        o_diag(ig_loc, ispn) +=
-                                std::real(beta_gk_tmp(ig_loc, xi) * std::conj(beta_gk_t(ig_loc, offs + xi)));
-                    }
-                }
+                accumulate_pw_diag(o_diag, beta_gk_tmp, beta_gk_t, offs, nbf, ispn, kp_.num_gkvec_loc());
             }
         }
     }

--- a/src/hamiltonian/hamiltonian_k.cpp
+++ b/src/hamiltonian/hamiltonian_k.cpp
@@ -907,8 +907,9 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
                              nat_loc](wf::Wave_functions_mt<T>& h_apw_lo__) {
         /* dispatch one async gemm per atom, round-robin over the available GPU streams;
          * gemm calls are non-blocking, so a plain serial loop still saturates the GPU */
+        #pragma omp parallel for
         for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
-            int sid = ialoc % acc::num_streams();
+            int tid = omp_get_thread_num();
             /* local atom index */
             auto aidx  = atom_index_t::local(ialoc);
             int ia     = spl_atoms.global_index(aidx);
@@ -923,7 +924,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
                               hmt.ld(), phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())),
                               phi__.ld(), &la::constant<Tc>::zero(),
                               h_apw_lo__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(0)), h_apw_lo__.ld(),
-                              acc::stream_id(sid));
+                              acc::stream_id(tid));
         }
         if (is_device_memory(mem)) {
             h_apw_lo__.copy_to(memory_t::host);
@@ -963,8 +964,9 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
 
     auto appy_hmt_lo_lo = [this, &ctx, &phi__, la, mem, &b__, &spl_atoms, nat_loc](wf::Wave_functions<T>& hphi__) {
         /* lo-lo contribution; dispatch one async gemm per atom, round-robin over GPU streams */
+        #pragma omp parallel for
         for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
-            int sid    = ialoc % acc::num_streams();
+            int tid    = omp_get_thread_num();
             auto aidx  = atom_index_t::local(ialoc);
             auto ia    = spl_atoms.global_index(aidx);
             auto& atom = ctx.unit_cell().atom(ia);
@@ -978,7 +980,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
                               hmt.ld(), phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())),
                               phi__.ld(), &la::constant<Tc>::one(),
                               hphi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())), hphi__.ld(),
-                              acc::stream_id(sid));
+                              acc::stream_id(tid));
         }
     };
 
@@ -1020,8 +1022,9 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
         size_t nops{0};
         int nat_loc_alm = alm_phi__.spl_num_atoms().local_size();
         /* dispatch one async gemm per atom, round-robin over GPU streams */
+        #pragma omp parallel for
         for (int ialoc = 0; ialoc < nat_loc_alm; ialoc++) {
-            int sid    = ialoc % acc::num_streams();
+            int tid    = omp_get_thread_num();
             auto aidx  = atom_index_t::local(ialoc);
             int ia     = atom_begin__ + alm_phi__.spl_num_atoms().global_index(aidx);
             auto& atom = ctx.unit_cell().atom(ia);
@@ -1035,7 +1038,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
                               alm_phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(0)), alm_phi__.ld(),
                               &la::constant<Tc>::zero(),
                               halm_phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(0)), halm_phi__.ld(),
-                              acc::stream_id(sid));
+                              acc::stream_id(tid));
             nops += 8L * naw * b__.size() * naw;
         }
         return nops;
@@ -1044,8 +1047,9 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
     auto apply_hmt_lo_apw = [this, &ctx, la, mem, &b__, &spl_atoms, nat_loc](wf::Wave_functions_mt<T> const& alm_phi__,
                                                                              wf::Wave_functions<T>& hphi__) {
         /* dispatch one async gemm per atom, round-robin over GPU streams */
+        #pragma omp parallel for
         for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
-            int sid    = ialoc % acc::num_streams();
+            int tid    = omp_get_thread_num();
             auto aidx  = atom_index_t::local(ialoc);
             int ia     = spl_atoms.global_index(aidx);
             auto& atom = ctx.unit_cell().atom(ia);
@@ -1059,7 +1063,7 @@ Hamiltonian_k<T>::apply_fv_h_o(bool apw_only__, bool phi_is_lo__, wf::band_range
                               hmt.ld(), alm_phi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(0)),
                               alm_phi__.ld(), &la::constant<Tc>::one(),
                               hphi__.at(mem, 0, aidx, wf::spin_index(0), wf::band_index(b__.begin())), hphi__.ld(),
-                              acc::stream_id(sid));
+                              acc::stream_id(tid));
         }
     };
 

--- a/src/hamiltonian/non_local_operator.cpp
+++ b/src/hamiltonian/non_local_operator.cpp
@@ -484,8 +484,9 @@ apply_U_operator(Simulation_context& ctx__, wf::spin_range spins__, wf::band_ran
 
     if (ctx__.num_mag_dims() == 3) {
         Up.zero();
+        int n_at_lvl__ = u_op__.u_matrix().num_atomic_levels();
         #pragma omp parallel for schedule(static)
-        for (int at_lvl = 0; at_lvl < u_op__.u_matrix().num_atomic_levels(); at_lvl++) {
+        for (int at_lvl = 0; at_lvl < n_at_lvl__; at_lvl++) {
             const int ia     = u_op__.atomic_orbital(at_lvl).first;
             auto const& atom = ctx__.unit_cell().atom(ia);
             if (atom.type().lo_descriptor_hub(u_op__.atomic_orbital(at_lvl).second).use_for_calculation()) {

--- a/src/k_point/get_wave_function_value.hpp
+++ b/src/k_point/get_wave_function_value.hpp
@@ -48,7 +48,8 @@ get_wave_function_value(K_point<double> const& kp__, wf::Wave_functions<double> 
             sf::spherical_harmonics(atom.type().lmax_apw(), tp[0], tp[1], &ylm[0]);
 
             // iterate over all atomic basis functions (apw and lo)
-            #pragma omp parallel for reduction(complex_double_plus:val)
+            double re{0}, im{0};
+            #pragma omp parallel for reduction(+:re, im)
             for (int xi = 0; xi < atom.mt_basis_size(); xi++) {
                 // expansion coefficient
                 auto c = wf__.mt_coeffs(xi, loc.index_local, spin_idx__, band_idx__);
@@ -61,21 +62,29 @@ get_wave_function_value(K_point<double> const& kp__, wf::Wave_functions<double> 
                            atom.symmetry_class().radial_function(jr, idxrf)) /
                           atom.type().radial_grid().dx(jr);
 
-                val += c * ylm[lm] * (atom.symmetry_class().radial_function(jr, idxrf) + f1 * dr);
+                auto v = c * ylm[lm] * (atom.symmetry_class().radial_function(jr, idxrf) + f1 * dr);
+                re += v.real();
+                im += v.imag();
             }
+            val += std::complex<double>(re, im);
         }
         // broadcast from the rank which computed the sum
         wf__.comm().bcast(&val, 1, loc.ib);
 
     } else {
         // sum over local set of G+k-vectors
-        #pragma omp parallel for reduction(complex_double_plus:val)
-        for (int igloc = 0; igloc < kp__.gkvec().count(); igloc++) {
+        double re{0}, im{0};
+        int ngkloc = kp__.gkvec().count();
+        #pragma omp parallel for reduction(+:re, im)
+        for (int igloc = 0; igloc < ngkloc; igloc++) {
             // G+k vector in Cartesian coordinates
             auto vgc = kp__.gkvec().gvec_cart(gvec_index_t::local(igloc));
             // plane-wave expansion
-            val += wf__.pw_coeffs(igloc, spin_idx__, band_idx__) * std::exp(std::complex<double>(0.0, dot(r__, vgc)));
+            auto v = wf__.pw_coeffs(igloc, spin_idx__, band_idx__) * std::exp(std::complex<double>(0.0, dot(r__, vgc)));
+            re += v.real();
+            im += v.imag();
         }
+        val += std::complex<double>(re, im);
         kp__.gkvec().comm().allreduce(&val, 1);
         val /= std::sqrt(uc.omega());
     }

--- a/src/k_point/k_point_set.cpp
+++ b/src/k_point/k_point_set.cpp
@@ -451,11 +451,13 @@ K_point_set::find_band_occupancies()
     auto emin = std::numeric_limits<double>::max();
     auto emax = std::numeric_limits<double>::lowest();
 
+    int nkp_loc = spl_num_kpoints_.local_size();
     #pragma omp parallel for reduction(min : emin) reduction(max : emax)
-    for (auto it : spl_num_kpoints_) {
+    for (int ikloc = 0; ikloc < nkp_loc; ikloc++) {
+        int ik = spl_num_kpoints_.global_index(kp_index_t::local(ikloc));
         for (int ispn = 0; ispn < ctx_.num_spinors(); ispn++) {
-            emin = std::min(emin, this->get<T>(it.i)->band_energy(0, ispn));
-            emax = std::max(emax, this->get<T>(it.i)->band_energy(ctx_.num_bands() - 1, ispn));
+            emin = std::min(emin, this->get<T>(ik)->band_energy(0, ispn));
+            emax = std::max(emax, this->get<T>(ik)->band_energy(ctx_.num_bands() - 1, ispn));
         }
     }
     this->comm().allreduce<double, mpi::op_t::min>(&emin, 1);

--- a/src/lapw/generate_gvec_ylm.hpp
+++ b/src/lapw/generate_gvec_ylm.hpp
@@ -23,10 +23,11 @@ generate_gvec_ylm(Simulation_context const& ctx__, int lmax__)
     PROFILE("sirius::generate_gvec_ylm");
 
     mdarray<std::complex<double>, 2> gvec_ylm({sf::lmmax(lmax__), ctx__.gvec().count()}, mdarray_label("gvec_ylm"));
+    int ngv = ctx__.gvec().count();
     #pragma omp parallel for schedule(static)
-    for (auto it : ctx__.gvec()) {
-        auto rtp = r3::spherical_coordinates(ctx__.gvec().gvec_cart(it.igloc));
-        sf::spherical_harmonics(lmax__, rtp[1], rtp[2], &gvec_ylm(0, it.igloc));
+    for (int igloc = 0; igloc < ngv; igloc++) {
+        auto rtp = r3::spherical_coordinates(ctx__.gvec().gvec_cart(gvec_index_t::local(igloc)));
+        sf::spherical_harmonics(lmax__, rtp[1], rtp[2], &gvec_ylm(0, igloc));
     }
     return gvec_ylm;
 }

--- a/src/lapw/generate_sbessel_mt.hpp
+++ b/src/lapw/generate_sbessel_mt.hpp
@@ -23,12 +23,13 @@ generate_sbessel_mt(Simulation_context const& ctx__, int lmax__)
     PROFILE("sirius::generate_sbessel_mt");
 
     mdarray<double, 3> sbessel_mt({lmax__ + 1, ctx__.gvec().count(), ctx__.unit_cell().num_atom_types()});
+    int ngv = ctx__.gvec().count();
     for (int iat = 0; iat < ctx__.unit_cell().num_atom_types(); iat++) {
         #pragma omp parallel for schedule(static)
-        for (auto it : ctx__.gvec()) {
-            auto gv = ctx__.gvec().gvec_cart(it.igloc);
+        for (int igloc = 0; igloc < ngv; igloc++) {
+            auto gv = ctx__.gvec().gvec_cart(gvec_index_t::local(igloc));
             gsl_sf_bessel_jl_array(lmax__, gv.length() * ctx__.unit_cell().atom_type(iat).mt_radius(),
-                                   &sbessel_mt(0, it.igloc, iat));
+                                   &sbessel_mt(0, igloc, iat));
         }
     }
     return sbessel_mt;

--- a/src/lapw/matching_coefficients.hpp
+++ b/src/lapw/matching_coefficients.hpp
@@ -126,18 +126,19 @@ class Matching_coefficients // TODO: compute on GPU
         {
             std::vector<std::complex<double>> ylm(lmmax_apw);
 
+            int ngk = gkvec_.count();
             #pragma omp for
-            for (auto it : gkvec_) {
-                auto gkvec_cart = gkvec_.gkvec_cart(it.igloc);
+            for (int igloc = 0; igloc < ngk; igloc++) {
+                auto gkvec_cart = gkvec_.gkvec_cart(gvec_index_t::local(igloc));
                 /* get r, theta, phi */
                 auto vs = r3::spherical_coordinates(gkvec_cart);
 
-                gkvec_len_[it.igloc] = vs[0];
+                gkvec_len_[igloc] = vs[0];
                 /* get spherical harmonics */
                 sf::spherical_harmonics(lmax_apw, vs[1], vs[2], &ylm[0]);
 
                 for (int lm = 0; lm < lmmax_apw; lm++) {
-                    gkvec_ylm_(it.igloc, lm) = ylm[lm];
+                    gkvec_ylm_(igloc, lm) = ylm[lm];
                 }
             }
         }

--- a/src/potential/paw_potential.cpp
+++ b/src/potential/paw_potential.cpp
@@ -88,10 +88,12 @@ Potential::generate_PAW_effective_potential(Density const& density)
     sirius::symmetrize_mt_function(unit_cell_, ctx_.rotm_rlm(), ctx_.mpi_grid_mt_sym(), 0, ps_comp);
 
     /* calculate PAW Dij matrix */
+    int n_paw_atoms_loc = unit_cell_.spl_num_paw_atoms().local_size();
     #pragma omp parallel for
-    for (auto it : unit_cell_.spl_num_paw_atoms()) {
-        auto ia = unit_cell_.paw_atom_index(it.i);
-        calc_PAW_local_Dij(ia, d_mtrx_paw_[it.i]);
+    for (int ialoc = 0; ialoc < n_paw_atoms_loc; ialoc++) {
+        auto i  = unit_cell_.spl_num_paw_atoms().global_index(paw_atom_index_t::local(ialoc));
+        auto ia = unit_cell_.paw_atom_index(i);
+        calc_PAW_local_Dij(ia, d_mtrx_paw_[i]);
     }
     for (int i = 0; i < unit_cell_.num_paw_atoms(); i++) {
         auto location = unit_cell_.spl_num_paw_atoms().location(typename paw_atom_index_t::global(i));
@@ -327,9 +329,11 @@ Potential::PAW_xc_total_energy(Density const& density__) const
     }
     /* compute contribution from the core */
     double ecore{0};
+    int n_paw_atoms_loc = unit_cell_.spl_num_paw_atoms().local_size();
     #pragma omp parallel for reduction(+:ecore)
-    for (auto it : unit_cell_.spl_num_paw_atoms()) {
-        auto ia = unit_cell_.paw_atom_index(it.i);
+    for (int ialoc = 0; ialoc < n_paw_atoms_loc; ialoc++) {
+        auto i  = unit_cell_.spl_num_paw_atoms().global_index(paw_atom_index_t::local(ialoc));
+        auto ia = unit_cell_.paw_atom_index(i);
 
         auto& atom = unit_cell_.atom(ia);
 
@@ -356,11 +360,13 @@ double
 Potential::PAW_one_elec_energy(Density const& density__) const
 {
     double e{0};
+    int n_paw_atoms_loc = unit_cell_.spl_num_paw_atoms().local_size();
     #pragma omp parallel for reduction(+:e)
-    for (auto it : unit_cell_.spl_num_paw_atoms()) {
-        auto ia = unit_cell_.paw_atom_index(it.i);
+    for (int ialoc = 0; ialoc < n_paw_atoms_loc; ialoc++) {
+        auto i  = unit_cell_.spl_num_paw_atoms().global_index(paw_atom_index_t::local(ialoc));
+        auto ia = unit_cell_.paw_atom_index(i);
         auto dm = density__.density_matrix_aux(atom_index_t::global(ia));
-        e += calc_PAW_one_elec_energy(unit_cell_.atom(ia), dm, d_mtrx_paw_[it.i]);
+        e += calc_PAW_one_elec_energy(unit_cell_.atom(ia), dm, d_mtrx_paw_[i]);
     }
     comm_.allreduce(&e, 1);
     return e;

--- a/src/potential/xc_mt.cpp
+++ b/src/potential/xc_mt.cpp
@@ -352,23 +352,25 @@ Potential::xc_mt(Density const& density__, bool use_lapl__)
 {
     PROFILE("sirius::Potential::xc_mt");
 
+    int nat_loc = unit_cell_.spl_num_atoms().local_size();
     #pragma omp parallel for
-    for (auto it : unit_cell_.spl_num_atoms()) {
-        auto& rgrid = unit_cell_.atom(it.i).radial_grid();
+    for (int ialoc = 0; ialoc < nat_loc; ialoc++) {
+        int ia      = unit_cell_.spl_num_atoms().global_index(atom_index_t::local(ialoc));
+        auto& rgrid = unit_cell_.atom(ia).radial_grid();
         std::vector<Flm const*> rho(ctx_.num_mag_dims() + 1);
         std::vector<Flm*> vxc(ctx_.num_mag_dims() + 1);
-        rho[0] = &density__.rho().mt()[it.i];
-        vxc[0] = &xc_potential_->mt()[it.i];
+        rho[0] = &density__.rho().mt()[ia];
+        vxc[0] = &xc_potential_->mt()[ia];
         for (int j = 0; j < ctx_.num_mag_dims(); j++) {
-            rho[j + 1] = &density__.mag(j).mt()[it.i];
-            vxc[j + 1] = &effective_magnetic_field(j).mt()[it.i];
+            rho[j + 1] = &density__.mag(j).mt()[ia];
+            vxc[j + 1] = &effective_magnetic_field(j).mt()[ia];
         }
 
         auto rhomin = sirius::xc_mt(rgrid, *sht_, xc_func_, ctx_.num_mag_dims(), rho, vxc,
-                                    &xc_energy_density_->mt()[it.i], use_lapl__);
+                                    &xc_energy_density_->mt()[ia], use_lapl__);
         if (rhomin < 0.0) {
             std::stringstream s;
-            s << "[xc_mt] negative charge density " << rhomin << " for atom " << it.i << std::endl
+            s << "[xc_mt] negative charge density " << rhomin << " for atom " << ia << std::endl
               << "  current Rlm expansion of the charge density may be not sufficient, try to increase lmax"
               << std::endl
               << "  sht.lmax       : " << sht_->lmax() << std::endl
@@ -381,8 +383,8 @@ Potential::xc_mt(Density const& density__, bool use_lapl__)
         /* add auxiliary magnetic field antiparallel to starting magnetization */
         for (int j = 0; j < ctx_.num_mag_dims(); j++) {
             for (int ir = 0; ir < rgrid.num_points(); ir++) {
-                effective_magnetic_field(j).mt()[it.i](0, ir) -=
-                        aux_bf_(j, it.i) * ctx_.unit_cell().atom(it.i).vector_field()[comp_map[j]];
+                effective_magnetic_field(j).mt()[ia](0, ir) -=
+                        aux_bf_(j, ia) * ctx_.unit_cell().atom(ia).vector_field()[comp_map[j]];
             }
         }
     } // ialoc

--- a/src/radial/radial_integrals.cpp
+++ b/src/radial/radial_integrals.cpp
@@ -86,9 +86,10 @@ Radial_integrals_aug<jl_deriv>::generate()
             }
         }
 
+        int nq = spl_q_.local_size();
         #pragma omp parallel for
-        for (auto it : spl_q_) {
-            int iq = it.i;
+        for (int iqloc = 0; iqloc < nq; iqloc++) {
+            int iq = spl_q_.global_index(iqloc);
 
             sf::Spherical_Bessel_functions jl(2 * lmax_beta, atom_type.radial_grid(), grid_q_[iq]);
 
@@ -145,9 +146,10 @@ Radial_integrals_rho_pseudo::generate()
 
         Spline<double> rho(atom_type.radial_grid(), atom_type.ps_total_charge_density());
 
+        int nq = spl_q_.local_size();
         #pragma omp parallel for
-        for (auto it : spl_q_) {
-            int iq = it.i;
+        for (int iqloc = 0; iqloc < nq; iqloc++) {
+            int iq = spl_q_.global_index(iqloc);
             sf::Spherical_Bessel_functions jl(0, atom_type.radial_grid(), grid_q_[iq]);
 
             values_(iat)(iq) = sirius::inner(jl[0], rho, 0, atom_type.num_mt_points()) / fourpi;
@@ -174,9 +176,10 @@ Radial_integrals_rho_core_pseudo<jl_deriv>::generate()
 
         Spline<double> ps_core(atom_type.radial_grid(), atom_type.ps_core_charge_density());
 
+        int nq = spl_q_.local_size();
         #pragma omp parallel for
-        for (auto it : spl_q_) {
-            int iq = it.i;
+        for (int iqloc = 0; iqloc < nq; iqloc++) {
+            int iq = spl_q_.global_index(iqloc);
             sf::Spherical_Bessel_functions jl(0, atom_type.radial_grid(), grid_q_[iq]);
 
             if (jl_deriv) {
@@ -209,9 +212,10 @@ Radial_integrals_beta<jl_deriv>::generate()
             values_(idxrf, iat) = Spline<double>(grid_q_);
         }
 
+        int nq = spl_q_.local_size();
         #pragma omp parallel for
-        for (auto it : spl_q_) {
-            int iq = it.i;
+        for (int iqloc = 0; iqloc < nq; iqloc++) {
+            int iq = spl_q_.global_index(iqloc);
             sf::Spherical_Bessel_functions jl(unit_cell_.lmax(), atom_type.radial_grid(), grid_q_[iq]);
             for (int idxrf = 0; idxrf < nrb; idxrf++) {
                 int l = atom_type.indexr(idxrf).am.l();
@@ -269,9 +273,10 @@ Radial_integrals_vloc<jl_deriv>::generate()
 
         auto rg = atom_type.radial_grid().segment(np);
 
+        int nq = spl_q_.local_size();
         #pragma omp parallel for
-        for (auto it : spl_q_) {
-            int iq = it.i;
+        for (int iqloc = 0; iqloc < nq; iqloc++) {
+            int iq = spl_q_.global_index(iqloc);
             Spline<double> s(rg);
             double g = grid_q_[iq];
 

--- a/src/symmetry/symmetrize_pw_function.hpp
+++ b/src/symmetry/symmetrize_pw_function.hpp
@@ -361,8 +361,11 @@ symmetrize_pw_function_impl_v2(Crystal_symmetry const& sym__, fft::Gvec_sym cons
 
     PROFILE_START("sirius::symmetrize|fpw|local");
 
+    auto const& gvec_shells = gvec_sym__.gvec_shells();
+    int n_gvec_shells       = static_cast<int>(gvec_shells.size());
     #pragma omp parallel for schedule(static, 1)
-    for (auto& e : gvec_sym__.gvec_shells()) {
+    for (int ishell = 0; ishell < n_gvec_shells; ishell++) {
+        auto const& e = gvec_shells[ishell];
 
         std::unordered_map<r3::vector<int>, char, fft::r3_int_hash> is_done;
         for (auto igloc : e) {


### PR DESCRIPTION
`nvhpc` crashed with a segfault on `hamiltonian_k.cpp` when using `sirius+cuda`. Most likely cause is the number of template instantiations/TU complexity.

- remove the declaration for omp reduction for `std::complex` when nvhpc is used (this gave a compilation error)
- rewrite (reorder) omp for loops in `hamiltonian_k.cpp` to avoid the segfault
- rewrite range-based for loops (nvhpc seems to require the canonical form)

The error for range-based for loops with nvhpc are the following:
```
NVC++-S-0155-Unsupported initialization in OMP for loop  (rangefor_omp_test.cpp: 24)
NVC++-S-0155-#pragma pfor does not match canonical form  (rangefor_omp_test.cpp: 24)
NVC++/arm Linux 26.5-0: compilation completed with severe errors
```