### PR TITLE
Fix GPU leading dimension in generate_d_mtrx

### DIFF
--- a/src/potential/generate_d_mtrx.cpp
+++ b/src/potential/generate_d_mtrx.cpp
@@ -129,7 +129,7 @@ Potential::generate_d_mtrx()
                                                         ctx_.gvec_coord().at(memory_t::device, g_begin, 1),
                                                         ctx_.gvec_coord().at(memory_t::device, g_begin, 2),
                                                         ctx_.unit_cell().atom_coord(iat).at(memory_t::device),
-                                                        veff_a.at(memory_t::device, 0, 0, iv), ng, 1 + iv);
+                                                        veff_a.at(memory_t::device, 0, 0, iv), veff_a.ld() / 2, 1 + iv);
 
                         la::wrap(la::lib_t::gpublas)
                                 .gemm('N', 'N', nqlm, atom_type.num_atoms(), 2 * ng, &la::constant<double>::one(),


### PR DESCRIPTION
## Summary

Fix an incorrect leading dimension passed to `mul_veff_with_phase_factors_gpu()` in `Potential::generate_d_mtrx()`.

`veff_a` is allocated using the maximum G-vector block size and stored as `double`, while the GPU kernel accesses the buffer as complex elements. The leading dimension passed to the kernel should therefore correspond to the allocated complex-element stride, `veff_a.ld() / 2`, rather than the current block length `ng`.

## Observed issue

We reproduced a CPU/GPU correctness divergence on SIRIUS 7.11.1 using a Si128 workload on a ROCm gfx936/BW100 system.

With the default unequal G-vector block partition:

`389162 / 389162 / 389160`

we observed approximately:

* D-matrix max CPU/GPU difference: `3.70e-6`
* converged total-energy difference: `1.61e-5 Ha`

Both CPU and GPU results were independently reproducible.

As a same-binary control, changing only the chunk size to produce equal blocks:

`583742 / 583742`

reduced the D-matrix difference to approximately `2.66e-14` and the first-SCF total-energy difference to approximately `1.82e-12 Ha`.

## Validation

With this patch, a full Si128 SCF calculation recovered CPU/GPU agreement:

* total-energy absolute difference: `2.16e-12 Ha`
* free-energy absolute difference: `1.59e-12 Ha`
* Fermi-energy absolute difference: `2.43e-14`
* band-gap absolute difference: `1.25e-13`

Both CPU and patched GPU calculations converged in 30 iterations.

A targeted performance regression showed no material performance change; the patched/default SCF-time ratio was approximately `1.00018`.

The issue has been experimentally validated on ROCm/BW100. CUDA has not yet been tested.
