### PR TITLE
CI: fix github workflows (bullseye EOL)

### DIFF
--- a/.github/workflows/check-format.yml
+++ b/.github/workflows/check-format.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    container: zhongruoyu/llvm-ports:18.1.8-slim-bullseye
+    container: zhongruoyu/llvm-ports:18.1.8-slim-bookworm
     steps:
       - uses: actions/checkout@v4
       - name: Check .cpp and .hpp files

--- a/.github/workflows/generate-api.yml
+++ b/.github/workflows/generate-api.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    container: zhongruoyu/llvm-ports:18.1.8-slim-bullseye
+    container: zhongruoyu/llvm-ports:18.1.8-slim-bookworm
     steps:
       - uses: actions/checkout@v4
       - name: Check API generation

--- a/.github/workflows/generate-api.yml
+++ b/.github/workflows/generate-api.yml
@@ -17,7 +17,7 @@ jobs:
           cd ./src/api
           apt update
           apt install -y python3-pip
-          python3 -m pip install PyYAML
+          python3 -m pip install --break-system-packages PyYAML
           python3 generate_api.py sirius_api.cpp
 
 


### PR DESCRIPTION
## Summary
- Debian bullseye reached end-of-life a couple of days ago, so the `zhongruoyu/llvm-ports:18.1.8-slim-bullseye` container used by `check-format.yml` is no longer maintained/available.
- Switch to `zhongruoyu/llvm-ports:18.1.8-slim-bookworm`, which provides the same clang-format/LLVM 18.1.8 toolchain on the still-supported Debian bookworm base.

